### PR TITLE
Rename 'test static' to 'validate' and refine

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,13 +171,13 @@ Usage:
 pick validate --list
 ```
 
-#### `--list`
-
-Displays a list of available validations and their descriptions. Using this option lists the tests without running them.
-
 ```
 pick validate [--format=format[:target]] [validations] [targets*]
 ```
+
+#### `--list`
+
+Displays a list of available validations and their descriptions. Using this option lists the tests without running them.
 
 #### `--format=format[:target]`
 
@@ -189,7 +189,7 @@ Multiple `--format` options can be specified as long as they all have distinct o
 
 #### `validations`
 
-Specifies a comma separated list of validations to run (or `all`). See the `--help` output for a list of available validations. Defaults to `all` if not supplied.
+Specifies a comma separated list of validations to run (or `all`). See the `--list` output for a list of available validations. Defaults to `all` if not supplied.
 
 #### `targets`
 


### PR DESCRIPTION
This PR proposes moving the `test static` actions to a new subcommand called `validate` and streamlining the options and syntax.

The functionality managed by the "static analysis" tasks (hereafter referred to as "validations") are conceptually distinct from unit tests and acceptance tests. The "validations" are about ensuring your content conforms to syntax rules and externally supplied style guides, whereas "tests" are things that you create to ensure your content behaves as you expect it to.

I suspect these were grouped under the `test` subcommand so that a single `pick test` invocation could logically be expected to run everything and I do see the value of that, but I would be interested in exploring other ways to accomplish that.

I'm also not sure how much resonance the term "static analysis" (and hence the subcommand action`static`) will have with users. Is that concept and what it implies in a Puppet context widely known among module developers? This is another area I'd love to see the external UX research drill into.