### PR TITLE
Refine unit testing section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,16 @@ Runs unit tests. Any errors are displayed to the console and reported in the rep
 Usage:
 
 ```
-pick test unit [--format=format] [runner_options] [targets*]
+pick test unit [--format=format[:target]] [runner_options] [targets*]
 ```
 
-#### `--format=format`
+#### `--format=format[:target]`
 
-Specifies the format of the report. Valid values: `junit`, `text`. Default: `text`.
+Specifies the format of the output. Valid values: `junit`, `text`. Default: `text`.
+
+Optionally, you can specify a target file for the given output format with the syntax: `--format=junit:report.xml`
+
+Multiple `--format` options can be specified as long as they all have distinct output targets.
 
 #### `runner_options`
 

--- a/README.md
+++ b/README.md
@@ -194,30 +194,22 @@ Runs unit tests. Any errors are displayed to the console and reported in the rep
 Usage:
 
 ```
-pick test unit [--list] [--tests=test_list] [--report-file=file_name] [--report-format=format] [runner_options]
+pick test unit [--format=format] [runner_options] [targets*]
 ```
 
-#### `--list`
+#### `--format=format`
 
-Displays a list of unit tests and their descriptions. Using this option lists the tests without running them.
-
-#### `--tests=test_list`
-
-A comma-separated list of tests to run. Use this during development to pinpoint a single failing test. See the `--list` output for allowed values.
-
-#### `--report-file=file_name`
-
-Specifies a filename to which to write the test results. If no filename is specified, no report is created.
-
-#### `--report-format=format`
-
-Specifies the format of the report. Valid values: `junit`, `text`. Default: `junit`.
+Specifies the format of the report. Valid values: `junit`, `text`. Default: `text`.
 
 #### `runner_options`
 
 <!-- this is a cop-out; alternatives are surfacing the real runner to advanced users, or completely wrapping the runner's interface -->
 
 Specifies options to pass through to the actual test-runner. In the default template (and most commonly across modules), this is [rspec](https://relishapp.com/rspec/rspec-core/docs/command-line).
+
+#### `targets`
+
+Specifies a list of directories or individual test files to run. Defaults to running everything in `spec/unit` and `spec/puppet`.
 
 ## Contributing
 


### PR DESCRIPTION
This PR proposes a couple of minor changes to the syntax for running unit tests with pick.

Most notably, it does away with the concept of available test runners (`--list` and `--tests=` options) since it seems like we are only really shipping one test runner for unit tests (rspec) and the actual selection of tests seems better suited to a `targets` argument.

Ruby and Puppet unit tests are both invoked using `rspec` with the difference being where in the "spec" directory the tests are located. If we refactored the layout of the spec directory a bit so that we had `spec/unit/ruby` and `spec/unit/puppet` then we could just make the default directory context for `test unit` be the `spec/unit` directory, resulting in the following usages:

- `pick test unit`: runs both rspec and rspec-puppet tests
- `pick test unit ruby`: runs rspec (ruby) tests
- `pick test unit puppet`: runs rspec-puppet tests