### PR TITLE
Remove 'Code Management' section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,28 +72,6 @@ The default template sets up [rspec](http://rspec.info/) for Ruby-level unit tes
 pick test unit
 ```
 
-### Manage code with version control
-
-Version control is critical when infrastructure is described in code. If you don't have an established version control routine, `pick` provides a set of commands to get you started.
-
-1. From your module's directory, download and apply changes from your upstream repository:
-
-```
-pick update [--source=git_url] # download and apply changes from upstream
-````
-
-2. After you make changes, add all of your changes and commit to Git with:
-
-```
-pick commit
-```
-
-3. Push your commit to Git with:
-
-```
-pick upload [--destination=git_url] [--environment=environment]
-```
-
 <!-- // TODO: git hosting services (integration); code manager workflow integration; CI/CD Integration -->
 
 


### PR DESCRIPTION
This PR proposes removing the VCS command wrappers from `pick`.

None of the proposed commands seem like meaningful improvements or simplifications of the native `git` commands and as soon as something goes wrong with a pull or push it now looks like our tool is broken.

- `pick update [--source=git_url]` vs `git pull <git_url>`
- `pick commit` vs `git commit -a -m 'my message'` (or a bit of config to allow for no commit message if we really want to enable that)
- `pick upload [--destination=git_url] [--environment=environment]` vs `git push <git_url> <branch>`

If we're going to encourage people to use VCS (and specifically `git`) we shouldn't obfuscate it from them.