### PR TITLE
(MAINT) Minor adjustments to CLI setup.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,6 @@ group(:development, :test) do
   gem 'bundler', '~> 1.13'
   gem 'rake', '~> 10.0'
   gem 'rspec', '~> 3.0'
+  gem 'pry-byebug', '~> 3.4'
 end
 

--- a/exe/pick
+++ b/exe/pick
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
 
 require 'pick/cli'
-Pick::CLI.run(ARGV)
+
+Pick::CLI.run(ARGV.dup)

--- a/lib/pick/cli/validate.rb
+++ b/lib/pick/cli/validate.rb
@@ -1,11 +1,14 @@
 require 'cri'
 require 'pick/cli/util/option_validator'
+require 'pick/report'
 
-include Pick::CLI::Util
+require 'pick/validate'
 
 module Pick
   module CLI
     class Validate
+      include Pick::CLI::Util
+
       def self.command
         @validate ||= Cri::Command.define do
           name 'validate'
@@ -13,12 +16,8 @@ module Pick
           summary 'Run static analysis tests.'
           description 'Run metadata-json-lint, puppet parser validate, puppet-lint, or rubocop.'
 
-          flag :h, :help, 'validate help' do |value, cmd|
-            puts cmd.help
-            exit 0
-          end
-
           flag nil, :list, 'list all available validators'
+
           option nil, :validators, "Available validators: #{Pick::Validate.validators.map(&:cmd).join(', ')}", argument: :required do |values|
             # Ensure the argument is a comma separated list and that each validator exists
             OptionValidator.enum(OptionValidator.list(values), Pick::Validate.validators.map(&:cmd))


### PR DESCRIPTION
* Change the way the CLI base command is constructed
  to ensure subcommands aren't added multiple times.
* Make pick executable pass a copy of ARGV to the CLI.
* Remove unnecessary splat from parameter to Pick::CLI.run
* Add a "help" subcommand using the build in Cri helper.
* Clean up "require" statements.
* Remove redundant "--help" flag from "validate" subcommand
* Add pry-byebug to Gemfile.