### PR TITLE
(MAINT) Update Pick::Report specs to use and clean up a tmpdir.

### DIFF
--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -1,6 +1,15 @@
 require 'spec_helper'
+require 'tmpdir'
 
 describe Pick::Report do
+  def tmpdir
+    @tmpdir ||= Dir.mktmpdir
+  end
+
+  after(:each) do
+    FileUtils.remove_entry_secure(@tmpdir) if @tmpdir
+  end
+
   it 'should include formats junit and text' do
     expect(Pick::Report.formats).to eq(%w(junit text))
   end
@@ -10,7 +19,7 @@ describe Pick::Report do
   end
 
   context 'when no format is specified' do
-    let(:report) { Pick::Report.new('foo') }
+    let(:report) { Pick::Report.new(File.join(tmpdir, 'report')) }
 
     it 'should instantiate its format to junit' do
       expect(report).to receive(:prepare_junit).with('cmd output')
@@ -19,7 +28,7 @@ describe Pick::Report do
   end
 
   context 'when a format is specified' do
-    let(:report) { Pick::Report.new('foo', 'text') }
+    let(:report) { Pick::Report.new(File.join(tmpdir, 'report.txt'), 'text') }
 
     it 'should instantiate its format to text' do
       expect(report).to receive(:prepare_text).with('cmd output')


### PR DESCRIPTION
Old specs were leaving a "foo" file behind after specs finished.