### PR TITLE
(MAINT) Replace --report-* options with --format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Runs unit tests. Any errors are displayed to the console and reported in the rep
 Usage:
 
 ```
-pdk test unit [--list] [--tests=test_list] [--report-file=file_name] [--report-format=format] [runner_options]
+pdk test unit [--list] [--tests=test_list] [--format=format[:target]] [runner_options]
 ```
 
 #### `--list`
@@ -194,13 +194,13 @@ Displays a list of unit tests and their descriptions. Using this option lists th
 
 A comma-separated list of tests to run. Use this during development to pinpoint a single failing test. See the `--list` output for allowed values.
 
-#### `--report-file=file_name`
+#### `--format=format[:target]`
 
-Specifies a filename to which to write the test results. If no filename is specified, no report is created.
+Specifies the format of the output. Valid values: `junit`, `text`. Default: `text`.
 
-#### `--report-format=format`
+Optionally, you can specify a target file for the given output format with the syntax: `--format=junit:report.xml`
 
-Specifies the format of the report. Valid values: `junit`, `text`. Default: `junit`.
+Multiple `--format` options can be specified as long as they all have distinct output targets.
 
 #### `runner_options`
 

--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -22,9 +22,22 @@ module PDK
             exit 0
           end
 
-          option nil, :'report-file', 'report-file', argument: :required
-          option nil, :'report-format', 'report-format', argument: :required do |value|
-            PDK::CLI::Util::OptionValidator.enum(value, PDK::Report.formats)
+          format_desc = <<~EOS
+            Specify desired output format. Valid formats are '#{PDK::Report.formats.join("', '")}'.
+            You may also specify a file to which the formatted output will be directed, for example: '--format=junit:report.xml'.
+            This option may be specified multiple times as long as each option specifies a distinct target file.
+          EOS
+
+          option :f, :format, format_desc, { argument: :required, multiple: true } do |values|
+            values.compact.each do |v|
+              if v.include?(':')
+                format = v.split(':', 2).first
+
+                PDK::CLI::Util::OptionValidator.enum(format, PDK::Report.formats)
+              else
+                PDK::CLI::Util::OptionValidator.enum(v, PDK::Report.formats)
+              end
+            end
           end
         end
 


### PR DESCRIPTION
This adds --format as a global option even though initially it may only
be relevant to the `validate` and `test` subcommands.