### PR TITLE
(SDK-191) Allow validators and targets as arguments rather than options

### DIFF
--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -26,12 +26,11 @@ module PDK
           process.io.stderr.close
         end
 
-        Struct.new("CommandResult", :exit_code, :stdout, :stderr)
-        Struct::CommandResult.new(
-          process.exit_code,
-          stdout,
-          stderr
-        )
+        {
+          :exit_code => process.exit_code,
+          :stdout => stdout,
+          :stderr => stderr
+        }
       end
     end
   end

--- a/lib/pdk/cli/util/option_normalizer.rb
+++ b/lib/pdk/cli/util/option_normalizer.rb
@@ -2,6 +2,11 @@ module PDK
   module CLI
     module Util
       class OptionNormalizer
+        def self.comma_separated_list_to_array(list, options = {})
+          raise 'Error: expected comma separated list' unless OptionValidator.is_comma_separated_list?(list)
+          list.split(',').compact
+        end
+
         # Parse one or more format:target pairs.
         # @return [Array<Report>] An array of one or more Reports.
         def self.report_formats(formats, options = {})

--- a/lib/pdk/cli/util/option_validator.rb
+++ b/lib/pdk/cli/util/option_validator.rb
@@ -3,12 +3,7 @@ module PDK
     module Util
       class OptionValidator
         def self.is_comma_separated_list?(list, options = {})
-          list =~ /^[\w+\-,]+,([\w+\-,])+$/ ? true : false
-        end
-
-        def self.comma_separated_list_to_array(list, options = {})
-          raise 'Error: expected comma separated list' unless is_comma_separated_list?(list)
-          list.split(',').compact
+          list =~ /^[\w\-]+(?:,[\w\-]+)+$/ ? true : false
         end
 
         def self.enum(val, valid_entries, options = {})

--- a/lib/pdk/validators/base_validator.rb
+++ b/lib/pdk/validators/base_validator.rb
@@ -4,10 +4,10 @@ require 'pdk/cli/exec'
 module PDK
   module Validate
     class BaseValidator
-      def self.invoke(report = nil, options = {})
+      def self.invoke(options = {})
         PDK.logger.info("Running #{cmd} with options: #{options}")
-        output = PDK::CLI::Exec.execute(cmd, options)
-        report.write(output) if report
+        result = PDK::CLI::Exec.execute(cmd, options)
+        result
       end
     end
   end

--- a/lib/pdk/validators/metadata.rb
+++ b/lib/pdk/validators/metadata.rb
@@ -5,6 +5,10 @@ require 'pdk/validators/base_validator'
 module PDK
   module Validate
     class Metadata < BaseValidator
+      def self.name
+        'metadata'
+      end
+
       def self.cmd
         'metadata-json-lint'
       end

--- a/lib/pdk/validators/puppet_lint.rb
+++ b/lib/pdk/validators/puppet_lint.rb
@@ -5,6 +5,10 @@ require 'pdk/validators/base_validator'
 module PDK
   module Validate
     class PuppetLint < BaseValidator
+      def self.name
+        'puppet-lint'
+      end
+
       def self.cmd
         'puppet-lint'
       end

--- a/lib/pdk/validators/puppet_parser.rb
+++ b/lib/pdk/validators/puppet_parser.rb
@@ -5,6 +5,10 @@ require 'pdk/validators/base_validator'
 module PDK
   module Validate
     class PuppetParser < BaseValidator
+      def self.name
+        'puppet-parser'
+      end
+
       def self.cmd
         'puppet-parser-validate'
       end

--- a/lib/pdk/validators/ruby_lint.rb
+++ b/lib/pdk/validators/ruby_lint.rb
@@ -5,6 +5,10 @@ require 'pdk/validators/base_validator'
 module PDK
   module Validate
     class RubyLint < BaseValidator
+      def self.name
+        'ruby-lint'
+      end
+
       def self.cmd
         'rubocop'
       end

--- a/spec/cli/option_normalizer_spec.rb
+++ b/spec/cli/option_normalizer_spec.rb
@@ -2,6 +2,16 @@ require 'spec_helper'
 require 'pdk/cli/util/option_normalizer'
 
 describe PDK::CLI::Util::OptionNormalizer do
+  context 'when normalizing lists' do
+    it 'should normalize and return an array of strings when the list is comma separated' do
+      expect(described_class.comma_separated_list_to_array('a,b,c')).to eq(%w(a b c))
+    end
+
+    it 'should raise an error when the list is invalid' do
+      expect { described_class.comma_separated_list_to_array('a,b c,d') }.to raise_error('Error: expected comma separated list')
+    end
+  end
+
   context 'when parsing report formats and targets' do
 
     context 'when a single format is specified' do

--- a/spec/cli/option_validator_spec.rb
+++ b/spec/cli/option_validator_spec.rb
@@ -10,14 +10,6 @@ describe PDK::CLI::Util::OptionValidator do
     it 'should return false if the list is not comma separated' do
       expect(described_class.is_comma_separated_list?('a,b c,d')).to eq(false)
     end
-
-    it 'should normalize and return an array of strings when the list is comma separated' do
-      expect(described_class.comma_separated_list_to_array('a,b,c')).to eq(%w(a b c))
-    end
-
-    it 'should raise an error when the list is invalid' do
-      expect { described_class.comma_separated_list_to_array('a,b c,d') }.to raise_error('Error: expected comma separated list')
-    end
   end
 
   context 'when verifying a value exists in an enum' do

--- a/spec/cli/validate_spec.rb
+++ b/spec/cli/validate_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+describe PDK::CLI::Validate do
+  context 'when no arguments or options are provided' do
+    it 'should invoke each validator with no report and no options' do
+      [PDK::Validate::Metadata,
+       PDK::Validate::PuppetLint,
+       PDK::Validate::PuppetParser,
+       PDK::Validate::RubyLint].each do |validator|
+        expect(validator).to receive(:invoke).with({})
+      end
+      expect_any_instance_of(Logger).to receive(:info).with('Running all available validators...')
+      PDK::CLI.run(['validate'])
+    end
+  end
+
+  context 'when the --list option is provided' do
+    it 'should list all of the available validators and exit' do
+      # TODO: replace this with a real output mechanism
+      expect(STDOUT).to receive(:puts).with('Available validators: metadata, puppet-lint, puppet-parser, ruby-lint')
+
+      begin
+        PDK::CLI.run(['validate', '--list'])
+      rescue SystemExit => e
+        expect(e.status).to eq(0)
+      end
+    end
+  end
+
+  context 'when validators are provided as arguments' do
+    it 'should only invoke a single validator when only one is provided' do
+      expect(PDK::Validate::Metadata).to receive(:invoke).with({})
+
+      [PDK::Validate::PuppetLint,
+       PDK::Validate::PuppetParser,
+       PDK::Validate::RubyLint].each do |validator|
+        expect(validator).not_to receive(:invoke)
+      end
+
+      PDK::CLI.run(['validate', 'metadata'])
+    end
+
+    it 'should invoke each provided validator when multiple are provided' do
+      [PDK::Validate::PuppetLint, PDK::Validate::PuppetParser].each do |validator|
+        expect(validator).to receive(:invoke).with({})
+      end
+
+      [PDK::Validate::Metadata, PDK::Validate::RubyLint].each do |validator|
+        expect(validator).not_to receive(:invoke)
+      end
+
+      PDK::CLI.run(['validate', 'puppet-lint,puppet-parser'])
+    end
+
+    it 'should warn about unknown validators' do
+      expect_any_instance_of(Logger).to receive(:warn).with('Unknown validator \'bad-val\'. Available validators: metadata, puppet-lint, puppet-parser, ruby-lint')
+      expect(PDK::Validate::PuppetLint).to receive(:invoke).with({})
+
+      PDK::CLI.run(['validate', 'puppet-lint,bad-val'])
+    end
+
+    context 'when targets are provided as arguments' do
+      it 'should invoke the specified validator with the target as an option' do
+        expect(PDK::Validate::Metadata).to receive(:invoke).with({:targets => ['lib/', 'manifests/']})
+
+        PDK::CLI.run(['validate', 'metadata', 'lib/', 'manifests/'])
+      end
+    end
+  end
+
+  context 'when targets are provided as arguments and no validators are specified' do
+    it 'should invoke all validators with the target as an option' do
+      [PDK::Validate::Metadata,
+       PDK::Validate::PuppetLint,
+       PDK::Validate::PuppetParser,
+       PDK::Validate::RubyLint].each do |validator|
+        expect(validator).to receive(:invoke).with({:targets => ['lib/', 'manifests/']})
+      end
+      expect_any_instance_of(Logger).to receive(:info).with('Running all available validators...')
+      PDK::CLI.run(['validate', 'lib/', 'manifests/'])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'pdk'
+require 'pdk/cli'


### PR DESCRIPTION
This commit updates the `validate` subcommand to take validations
and targets as arguments rather than options.

If a user wishes to specify which validations to run, they must
supply a comma separated list of validators as the first argument,
before any targets are specified.

* If a comma separated list if provided as the first argument, we
assume it is a list of validators.
* If a single item is provided as the first argument, we check if
It is a known validator. If so, we treat it as such. Otherwise, we
treat it as a target.
* All subsequent arguments are treated as targets.

In addition, new spec tests have been added to verify the behavior of the `validate` subcommand.