### PR TITLE
(MAINT) Make version in gemspec unfrozen for mystical Trusty reasons

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -5,7 +5,7 @@ require 'pdk/version'
 
 Gem::Specification.new do |spec|
   spec.name    = 'pdk'
-  spec.version = PDK::VERSION
+  spec.version = PDK::VERSION.dup
   spec.authors = ['David Schmitt']
   spec.email   = ['david.schmitt@puppet.com']
 


### PR DESCRIPTION
For some reason, `gem build` fails on Trusty when the gemspec version is frozen:

```
15:51:32 cd pdk && \
15:51:32 	gem build pdk.gemspec && \
15:51:32 	/opt/puppetlabs/sdk/bin/gem install --no-rdoc --no-ri --local pdk-0.1.0.gem && \
15:51:32 	install -d '/opt/puppetlabs/bin' && \
15:51:32 	([[ '/opt/puppetlabs/bin/pdk' -ef '/opt/puppetlabs/sdk/bin/pdk' ]] || ln -s '/opt/puppetlabs/sdk/bin/pdk' '/opt/puppetlabs/bin/pdk')
15:51:32 Invalid gemspec in [pdk.gemspec]: can't modify frozen String
15:51:32 ERROR:  Error loading gemspec. Aborting.
15:51:32 make: *** [rubygem-pdk-install] Error 1
```