### PR TITLE
(SDK-200) Add user interview for `new module` info gathering

### DIFF
--- a/lib/pdk/cli/input.rb
+++ b/lib/pdk/cli/input.rb
@@ -1,0 +1,12 @@
+module PDK
+  module CLI
+    module Input
+      def self.get(default=nil)
+        print '--> '
+        input = STDIN.gets.chomp.strip
+        input = default if input == ''
+        input
+      end
+    end
+  end
+end

--- a/lib/pdk/cli/new/module.rb
+++ b/lib/pdk/cli/new/module.rb
@@ -23,7 +23,7 @@ module PDK
 
             run do |opts, args, cmd|
               puts "Creating new module: #{args[0]}"
-              PDK::Generate::Module.invoke
+              PDK::Generate::Module.invoke(args[0])
             end
           end
         end

--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -1,5 +1,8 @@
 require 'pdk'
+require 'pdk/logger'
+require 'pdk/module/metadata'
 require 'pdk/cli/exec'
+require 'pdk/cli/input'
 
 module PDK
   module Generate
@@ -10,8 +13,66 @@ module PDK
         cmd
       end
 
-      def self.invoke(opts={})
+      def self.invoke(name, opts={})
+        metadata = PDK::Module::Metadata.new(
+          {
+            'name' => name,
+            'version' => '0.1.0',
+            'dependencies' => [
+              { 'name' => 'puppetlabs-stdlib', 'version_requirement' => '>= 1.0.0' }
+            ]
+          }
+        )
+
+        module_interview(metadata) unless opts[:skip_interview] # TODO: Build way to get info by answers file
+
+        # TODO: write metadata.json, build module directory structure, and write out templates.
         PDK::CLI::Exec.execute(cmd(opts))
+      end
+
+      def self.module_interview(metadata)
+        puts "We need to create a metadata.json file for this module.  Please answer the"
+        puts "following questions; if the question is not applicable to this module, feel free"
+        puts "to leave it blank."
+
+        begin
+          puts "\nPuppet uses Semantic Versioning (semver.org) to version modules."
+          puts "What version is this module?  [#{metadata.data['version']}]"
+          metadata.update('version' => PDK::CLI::Input.get(metadata.data['version']))
+        rescue
+          PDK.logger.error("We're sorry, we could not parse that as a Semantic Version.")
+          retry
+        end
+
+        puts "\nWho wrote this module?  [#{metadata.data['author']}]"
+        metadata.data.update('author' => PDK::CLI::Input.get(metadata.data['author']))
+
+        puts "\nWhat license does this module code fall under?  [#{metadata.data['license']}]"
+        metadata.data.update('license' => PDK::CLI::Input.get(metadata.data['license']))
+
+        puts "\nHow would you describe this module in a single sentence?"
+        metadata.data.update('summary' => PDK::CLI::Input.get(metadata.data['summary']))
+
+        puts "\nWhere is this module's source code repository?"
+        metadata.data.update('source' => PDK::CLI::Input.get(metadata.data['source']))
+
+        puts "\nWhere can others go to learn more about this module?  [#{metadata.data['project_page'] || '(none)'}]"
+        metadata.data.update('project_page' => PDK::CLI::Input.get(metadata.data['project_page']))
+
+        puts "\nWhere can others go to file issues about this module? [#{metadata.data['issues_url'] || '(none)'}]"
+        metadata.data.update('issues_url' => PDK::CLI::Input.get(metadata.data['issues_url']))
+
+        puts
+        puts '-' * 40
+        puts metadata.to_json
+        puts '-' * 40
+        puts
+        puts "About to generate this metadata; continue? [n/Y]"
+
+        if PDK::CLI::Input.get('Y') !~ /^y(es)?$/i
+          puts "Aborting..."
+          exit 0
+        end
       end
     end
   end

--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -1,0 +1,70 @@
+require 'json'
+
+module PDK
+  module Module
+    class Metadata
+
+      attr_accessor :data
+
+      DEFAULTS = {
+        'name'          => nil,
+        'version'       => nil,
+        'author'        => nil,
+        'summary'       => nil,
+        'license'       => 'Apache-2.0',
+        'source'        => '',
+        'project_page'  => nil,
+        'issues_url'    => nil,
+        'dependencies'  => Set.new.freeze,
+        'data_provider' => nil,
+      }
+
+      def initialize(params = {})
+        @data = DEFAULTS.dup
+        update(params) if params
+      end
+
+      def update(data)
+        # TODO: validate all data
+        process_name(data) if data['name']
+        @data.merge!(data)
+        self
+      end
+
+      def to_json
+        JSON.pretty_generate(@data)
+      end
+
+      private
+
+      # Do basic validation and parsing of the name parameter.
+      def process_name(data)
+        validate_name(data['name'])
+        author, module_name = data['name'].split(/[-\/]/, 2)
+
+        data['author'] ||= author if @data['author'] == DEFAULTS['author']
+      end
+
+      # Validates that the given module name is both namespaced and well-formed.
+      def validate_name(name)
+        return if name =~ /\A[a-z0-9]+[-\/][a-z][a-z0-9_]*\Z/i
+
+        namespace, modname = name.split(/[-\/]/, 2)
+        modname = :namespace_missing if namespace == ''
+
+        err = case modname
+        when nil, '', :namespace_missing
+          "the field must be a dash-separated username and module name"
+        when /[^a-z0-9_]/i
+          "the module name contains non-alphanumeric (or underscore) characters"
+        when /^[^a-z]/i
+          "the module name must begin with a letter"
+        else
+          "the namespace contains non-alphanumeric characters"
+        end
+
+        raise ArgumentError, "Invalid 'name' field in metadata.json: #{err}"
+      end
+    end
+  end
+end

--- a/spec/generators/module_spec.rb
+++ b/spec/generators/module_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe PDK::Generate::Module do
+  context 'when gathering module information via the user interview' do
+    let (:metadata) { PDK::Module::Metadata.new.update(
+                        'name' => 'foo-bar',
+                        'version' => '0.1.0',
+                        'dependencies' => [
+                          { 'name' => 'puppetlabs-stdlib', 'version_requirement' => '>= 1.0.0' }
+                        ]
+                      )
+                    }
+
+    it 'should populate the Metadata object based on user input' do
+      allow(STDOUT).to receive(:puts)
+      expect(PDK::CLI::Input).to receive(:get) { '2.2.0' }
+      expect(PDK::CLI::Input).to receive(:get) { 'William Hopper' }
+      expect(PDK::CLI::Input).to receive(:get) { 'Apache-2.0' }
+      expect(PDK::CLI::Input).to receive(:get) { 'A simple module to do some stuff.' }
+      expect(PDK::CLI::Input).to receive(:get) { 'github.com/whopper/bar' }
+      expect(PDK::CLI::Input).to receive(:get) { 'forge.puppet.com/whopper/bar' }
+      expect(PDK::CLI::Input).to receive(:get) { 'tickets.foo.com/whopper/bar' }
+      expect(PDK::CLI::Input).to receive(:get) { 'yes' }
+
+      described_class.module_interview(metadata)
+
+      expect(metadata.data).to eq(
+        {
+          'name'          => 'foo-bar',
+          'version'       => '2.2.0',
+          'author'        => 'William Hopper',
+          'license'       => 'Apache-2.0',
+          'summary'       => 'A simple module to do some stuff.',
+          'source'        => 'github.com/whopper/bar',
+          'project_page'  => 'forge.puppet.com/whopper/bar',
+          'issues_url'    => 'tickets.foo.com/whopper/bar',
+          'dependencies'  => [{'name' => 'puppetlabs-stdlib', 'version_requirement' => '>= 1.0.0'}],
+          'data_provider' => nil,
+        }
+      )
+    end
+  end
+end

--- a/spec/module/metadata_spec.rb
+++ b/spec/module/metadata_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe PDK::Module::Metadata do
+  context 'when processing and validating metadata' do
+    let (:metadata) { PDK::Module::Metadata.new.update(
+                        'name' => 'foo-bar',
+                        'version' => '0.1.0',
+                        'dependencies' => [
+                          { 'name' => 'puppetlabs-stdlib', 'version_requirement' => '>= 1.0.0' }
+                        ]
+                      )
+                    }
+
+    it 'should error when the provided name is not namespaced' do
+      expect { metadata.update({'name' => 'foo'}) }.to raise_error(ArgumentError, "Invalid 'name' field in metadata.json: the field must be a dash-separated username and module name")
+    end
+
+    it 'should error when the provided name contains non-alphanumeric characters' do
+      expect { metadata.update({'name' => 'foo-@bar'}) }.to raise_error(ArgumentError, "Invalid 'name' field in metadata.json: the module name contains non-alphanumeric (or underscore) characters")
+    end
+
+    it 'should error when the provided name starts with a non-letter character' do
+      expect { metadata.update({'name' => 'foo-1bar'}) }.to raise_error(ArgumentError, "Invalid 'name' field in metadata.json: the module name must begin with a letter")
+    end
+  end
+end


### PR DESCRIPTION
This commit adds an interactive interview to gather module information
when generating a new module. Included is a new `Metadata` class which
models the eventual metadata.json file.