### PR TITLE
(SDK-195) Initial commit of acceptance spec tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ build-iPhoneSimulator/
 /pkg/
 /spec/reports/
 /tmp/
+
+# beaker output directories
+/log/
+/repo-config/

--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,7 @@ group(:development, :test) do
   gem 'pry-byebug', '~> 3.4'
 end
 
+group :acceptance do
+  gem 'beaker-rspec'
+end
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,13 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.exclude_pattern = 'spec/spec_helper_acceptance.rb,spec/acceptance/**' 
+end
+
+desc 'Run acceptance tests'
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/spec_helper_acceptance.rb,spec/acceptance/**.rb'
+end
 
 task :default => :spec

--- a/spec/acceptance/cli_spec.rb
+++ b/spec/acceptance/cli_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper_acceptance'
+
+describe 'Basic usage of the CLI' do
+  it 'should display help text' do
+    on(workstation, '/opt/puppetlabs/sdk/bin/pdk --help') do |outcome|
+      expect(outcome.stdout).to match /NAME.*USAGE.*DESCRIPTION.*COMMANDS.*OPTIONS/m
+    end
+  end
+end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,8 @@
+HOSTS:
+  centos-7-x64:
+    roles:
+      - workstation
+    platform: el-7-x86_64
+    box: puppetlabs/centos-7.0-64-nocm
+    hypervisor: vagrant
+    type: foss

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,17 @@
+require 'beaker-rspec'
+
+def workstation
+  find_at_most_one('workstation')
+end
+
+RSpec.configure do |c|
+  c.before(:suite) do
+    
+    # Install pdk on workstation host
+    install_puppetlabs_dev_repo(workstation, 'puppet-sdk', ENV['PACKAGE_BUILD_VERSION'], 'repo-config')
+
+    # Install pdk package
+    workstation.install_package('puppet-sdk')
+
+  end
+end


### PR DESCRIPTION
Initial commit of acceptance testing using beaker-rspec and a vagrant host.

Requires PACKAGE_BUILD_VERSION to be set to a SHA of a packaged build of puppet-sdk on a build server. This _should_ be enforced/self-documented using rototiller, but that requires a fix in the next rototiller release (QA-2887)