### PR TITLE
(maint) make debug output optional

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -41,6 +41,10 @@ module PDK
               end
             end
           end
+
+          flag :d, :debug, _("Enable debug output.") do |_, _|
+            PDK.logger.enable_debug_output
+          end
         end
 
         cmd.add_command(Cri::Command.new_basic_help)

--- a/lib/pdk/logger.rb
+++ b/lib/pdk/logger.rb
@@ -14,6 +14,12 @@ module PDK
       self.formatter = proc do |severity,datetime,progname,msg|
         "pdk (#{severity}): #{msg}\n"
       end
+
+      self.level = ::Logger::INFO
+    end
+
+    def enable_debug_output
+      self.level = ::Logger::DEBUG
     end
   end
 end

--- a/locales/pdk.pot
+++ b/locales/pdk.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: puppet development kit \n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
-"POT-Creation-Date: 2017-04-21 12:09-0700\n"
-"PO-Revision-Date: 2017-04-21 12:09-0700\n"
+"POT-Creation-Date: 2017-05-02 14:07+1000\n"
+"PO-Revision-Date: 2017-05-02 14:07+1000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -36,6 +36,10 @@ msgstr ""
 
 #: ../lib/pdk/cli.rb:26
 msgid "Specify desired output format. Valid formats are '%{available_formats}'. You may also specify a file to which the formatted output will be directed, for example: '--format=junit:report.xml'. This option may be specified multiple times as long as each option specifies a distinct target file."
+msgstr ""
+
+#: ../lib/pdk/cli.rb:45
+msgid "Enable debug output."
 msgstr ""
 
 #: ../lib/pdk/cli/new.rb:11

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe PDK::Logger do
+  context 'by default' do
+    it 'should print info messages to stdout' do
+      expect(STDOUT).to receive(:write).with(a_string_matching(/test message/))
+
+      subject.info('test message')
+    end
+
+    it 'should not print debug messages to stdout' do
+      expect(STDOUT).to_not receive(:write).with(anything)
+
+      subject.debug('test message')
+    end
+  end
+
+  context 'with debug output enabled' do
+    it 'should print debug messages to stdout' do
+      expect(STDOUT).to receive(:write).with(a_string_matching(/test debug message/))
+
+      subject.enable_debug_output
+      subject.debug('test debug message')
+    end
+  end
+end


### PR DESCRIPTION
Defaults the level/threshold for the logger to INFO, so that DEBUG level
messages aren't logged by default (the standard log levels for Ruby's
logger are DEBUG < INFO < WARN < ERROR < FATAL < UNKNOWN).

An instance method has been added to the PDK::Logger class that sets the
level to DEBUG (to maintain the existing abstraction) and a -d/--debug
flag has been added to the root CLI command (making it available to all
the subcommands) which call this method to enable debug logging from the
CLI.