### PR TITLE
(SDK-218) Update acceptance testing to use ENV['SHA']

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ build-iPhoneSimulator/
 /log/
 /repo-config/
 /acceptance_hosts.yml
+
+# Puppet packaging files
+/ext/packaging/

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,38 @@ gettext_spec = Gem::Specification.find_by_name 'gettext-setup'
 load "#{gettext_spec.gem_dir}/lib/tasks/gettext.rake"
 GettextSetup.initialize(File.absolute_path('locales', File.dirname(__FILE__)))
 
+build_defs_file = 'ext/build_defaults.yaml'
+if File.exist?(build_defs_file)
+  begin
+    require 'yaml'
+    @build_defaults ||= YAML.load_file(build_defs_file)
+  rescue Exception => e
+    STDERR.puts "Unable to load yaml from #{build_defs_file}:"
+    STDERR.puts e
+  end
+  @packaging_url  = @build_defaults['packaging_url']
+  @packaging_repo = @build_defaults['packaging_repo']
+  raise "Could not find packaging url in #{build_defs_file}" if @packaging_url.nil?
+  raise "Could not find packaging repo in #{build_defs_file}" if @packaging_repo.nil?
+
+  namespace :package do
+    desc "Bootstrap packaging automation (clone packaging repo)"
+    task :bootstrap do
+      if File.exist?("ext/#{@packaging_repo}")
+        puts "It looks like you already have ext/#{@packaging_repo}. If you don't like it, blow it away with package:implode."
+      else
+        cd 'ext' do
+          %x{git clone #{@packaging_url}}
+        end
+      end
+    end
+    desc "Remove all cloned packaging automation"
+    task :implode do
+      rm_rf "ext/#{@packaging_repo}"
+    end
+  end
+end
+
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.exclude_pattern = 'spec/spec_helper_acceptance.rb,spec/acceptance/**'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -13,8 +13,8 @@ desc 'Run acceptance tests'
 RSpec::Core::RakeTask.new(:acceptance) do |t|
   require 'beaker-hostgenerator'
 
-  unless ENV['PACKAGE_BUILD_VERSION'] then
-    abort 'Environment variable PACKAGE_BUILD_VERSION must be set to the SHA of a puppet-sdk build'
+  unless ENV['SHA'] then
+    abort 'Environment variable SHA must be set to the SHA of a puppet-sdk build'
   end
 
   test_target = ENV['TEST_TARGET']

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,0 +1,5 @@
+---
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_repo: 'packaging'
+packager: 'puppetlabs'
+gpg_key: '7F438280EF8D349F'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -10,10 +10,10 @@ RSpec.configure do |c|
     # Install pdk on workstation host
     if workstation['platform'] =~ /windows/
       # BKR-1109 requests a neater way to install an MSI
-      msi_url = "http://#{ENV['BUILD_SERVER']}/puppet-sdk/#{ENV['PACKAGE_BUILD_VERSION']}/repos/windows/puppet-sdk-x64.msi"
+      msi_url = "http://#{ENV['BUILD_SERVER']}/puppet-sdk/#{ENV['SHA']}/repos/windows/puppet-sdk-x64.msi"
       generic_install_msi_on(workstation, msi_url)
     else
-      install_puppetlabs_dev_repo(workstation, 'puppet-sdk', ENV['PACKAGE_BUILD_VERSION'], 'repo-config')
+      install_puppetlabs_dev_repo(workstation, 'puppet-sdk', ENV['SHA'], 'repo-config')
 
       # Install pdk package
       workstation.install_package('puppet-sdk')


### PR DESCRIPTION
The actual environment variable that CI uses to store the puppet-sdk package reference is SHA