### PR TITLE
Relax data type validation to warn when non-standard types used

### DIFF
--- a/lib/pdk/cli/util/option_validator.rb
+++ b/lib/pdk/cli/util/option_validator.rb
@@ -60,10 +60,14 @@ module PDK
             Tuple Struct Optional Catalogentry Type Any Callable NotUndef
           }.freeze
 
-          string.scan(/\b(([a-zA-Z]+)(,|\[|\]|\Z))/) do |result|
+          string.scan(/\b(([a-zA-Z0-9_]+)(,|\[|\]|\Z))/) do |result|
             type = result[1]
 
-            return false unless valid_types.include?(type)
+            return false unless string =~ /\A[A-Z]/
+
+            unless valid_types.include?(type)
+              PDK.logger.warn(_("Non-standard data type '%{type}', check the generated files for mistakes") % {type: type})
+            end
           end
 
           true

--- a/spec/cli/option_validator_spec.rb
+++ b/spec/cli/option_validator_spec.rb
@@ -157,8 +157,14 @@ describe PDK::CLI::Util::OptionValidator do
       expect(subject.is_valid_data_type?('string')).to be false
     end
 
+    it 'warns the user about non-standard data types' do
+      expect(logger).to receive(:warn).with(a_string_matching(/Non-standard data type 'Test123'/))
+      expect(subject.is_valid_data_type?('Test123')).to be true
+    end
+
     it 'checks all the data types in an abstract data type' do
-      expect(subject.is_valid_data_type?('Variant[Integer, boolean, String]')).to be false
+      expect(logger).to receive(:warn).with(a_string_matching(/Non-standard data type 'Test123'/))
+      expect(subject.is_valid_data_type?('Variant[Integer, Test123, String]')).to be true
     end
   end
 end


### PR DESCRIPTION
Following up on #48, this PR relaxes the data type validation to allow non-standard data types to be used.