### PR TITLE
(SDK-261) Manage basic bundler operations for module dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 before_install: gem install bundler -v 1.14.6
 bundler_args: "--without development"
 script:
+  - "bundle binstubs pdk"
   - "cat Gemfile"
   - "cat Gemfile.lock"
   - "bundle exec rake $CHECK"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ test_script:
   - SET PATH=C:\%PLATFORM%\bin;%PATH%
   - SET LOG_SPEC_ORDER=true
   - bundle install --jobs 4 --retry 2 --without development
+  - bundle binstubs pdk
   - type Gemfile.lock
   - ruby -v
   - bundle exec rake spec acceptance:local

--- a/lib/pdk/cli/tests/unit.rb
+++ b/lib/pdk/cli/tests/unit.rb
@@ -41,7 +41,6 @@ module PDK
                 report = Report.new(opts.fetch(:'report-file'), format)
               end
 
-              puts _("Running unit tests: %{tests}") % {tests: tests}
               PDK::Test::Unit.invoke(tests, report)
             end
           end

--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -1,5 +1,6 @@
 require 'pdk'
 require 'pdk/cli/exec'
+require 'pdk/util/bundler'
 
 module PDK
   module Test
@@ -13,6 +14,10 @@ module PDK
       end
 
       def self.invoke(tests, report = nil)
+        PDK::Util::Bundler.ensure_bundle!
+
+        puts _("Running unit tests: %{tests}") % {tests: tests}
+
         output = PDK::CLI::Exec.execute(cmd(tests))
         report.write(output) if report
       end

--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -12,5 +12,19 @@ module PDK
       Dir::Tmpname.make_tmpname(File.join(Dir.tmpdir, base), nil)
     end
     module_function :make_tmpdir_name
+
+    # Returns the fully qualified path to a per-user PDK cachedir.
+    #
+    # @return [String] Fully qualified path to per-user PDK cachedir.
+    def cachedir
+      if Gem.win_platform?
+        basedir = ENV['APPDATA']
+      else
+        basedir = Dir.home
+      end
+
+      return File.join(basedir, '.pdk', 'cache')
+    end
+    module_function :cachedir
   end
 end

--- a/lib/pdk/util/bundler.rb
+++ b/lib/pdk/util/bundler.rb
@@ -1,0 +1,139 @@
+require 'bundler'
+require 'tty-spinner'
+require 'pdk/util'
+require 'pdk/cli/exec'
+
+module PDK
+  module Util
+    module Bundler
+      class BundleHelper; end
+
+      def self.ensure_bundle!
+        bundle = BundleHelper.new
+
+        if bundle.has_gemfile?
+          if !bundle.locked?
+            unless bundle.lock!
+              raise PDK::CLI::FatalError, _("Unable to resolve Gemfile dependencies.")
+            end
+          end
+
+          if !bundle.installed?
+            unless bundle.install!
+              raise PDK::CLI::FatalError, _("Unable to install missing Gemfile dependencies.")
+            end
+          end
+        end
+      end
+
+      class BundleHelper
+        def has_gemfile?
+          # return a pure boolean
+          !!gemfile
+        end
+
+        def locked?
+          # return a pure boolean
+          !!gemfile_lock
+        end
+
+        def installed?
+          output_start(_("Checking for missing Gemfile dependencies"))
+
+          result = invoke('check', "--gemfile=#{gemfile}", "--path=#{bundle_cachedir}")
+
+          output_end(:success)
+
+          return result[:exit_code] == 0
+        end
+
+        def lock!
+          output_start(_("Resolving Gemfile dependencies"))
+
+          result = invoke('lock')
+
+          if result[:exit_code] == 0
+            output_end(:success)
+          else
+            output_end(:failure)
+            $stderr.puts result[:stdout]
+            $stderr.puts result[:stderr]
+          end
+
+          return result[:exit_code] == 0
+        end
+
+        def install!
+          output_start(_("Installing missing Gemfile dependencies"))
+
+          result = invoke('install', "--gemfile=#{gemfile}", "--path=#{bundle_cachedir}")
+
+          if result[:exit_code] == 0
+            output_end(:success)
+          else
+            output_end(:failure)
+            $stderr.puts result[:stdout]
+            $stderr.puts result[:stderr]
+          end
+
+          return result[:exit_code] == 0
+        end
+
+        private
+
+        def invoke(*args)
+          ::Bundler.with_clean_env do
+            PDK::CLI::Exec.bundle(*args)
+          end
+        end
+
+        def find_upwards(target)
+          previous = nil
+          current  = File.expand_path(Dir.pwd)
+
+          until !File.directory?(current) || current == previous
+            filename = File.join(current, target)
+            return filename if File.file?(filename)
+            current, previous = File.expand_path("..", current), current
+          end
+        end
+
+        def gemfile
+          @gemfile ||= find_upwards('Gemfile')
+        end
+
+        def gemfile_lock
+          @gemfile_lock ||= find_upwards('Gemfile.lock')
+        end
+
+        def bundle_cachedir
+          @bundle_cachedir ||= File.join(PDK::Util.cachedir, 'bundler')
+        end
+
+        # These two output_* methods are just a way to not try to do the spinner stuff on Windows for now.
+        def output_start(message)
+          if Gem.win_platform?
+            $stderr.print "#{message}... "
+          else
+            @spinner = TTY::Spinner.new("[:spinner] #{message}")
+            @spinner.auto_spin
+          end
+        end
+
+        def output_end(state)
+          if Gem.win_platform?
+            $stderr.print (state == :success) ? _("done.\n") : _("FAILURE!\n")
+          else
+            if state == :success
+              @spinner.success
+            else
+              @spinner.error
+            end
+
+            remove_instance_variable(:@spinner)
+          end
+        end
+      end
+    end
+  end
+end

--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'cri', '~> 2.7.1'
   spec.add_runtime_dependency 'childprocess', '~> 0.6.2'
   spec.add_runtime_dependency 'gettext-setup', '~> 0.24'
+  spec.add_runtime_dependency 'tty-spinner', '~> 0.4'
 end

--- a/spec/acceptance/cli_spec.rb
+++ b/spec/acceptance/cli_spec.rb
@@ -1,15 +1,8 @@
 require 'spec_helper_acceptance'
 
 describe 'Basic usage of the CLI' do
-  context 'when the --help options is used' do
-    let(:help_output) { shell_ex("#{path_to_pdk} --help") }
-
-    it 'displays help text on stdout' do
-      expect(help_output.stdout).to match(/NAME.*USAGE.*DESCRIPTION.*COMMANDS.*OPTIONS/m)
-    end
-
-    it 'has an empty stderr' do
-      expect(help_output.stderr).to eq('')
-    end
+  describe command("#{path_to_pdk} --help") do
+    its(:stdout) { is_expected.to match(/NAME.*USAGE.*DESCRIPTION.*COMMANDS.*OPTIONS/m) }
+    its(:stderr) { is_expected.to match(/\A\Z/) }
   end
 end

--- a/spec/util/bundler_spec.rb
+++ b/spec/util/bundler_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+RSpec.describe PDK::Util::Bundler do
+  describe '.ensure_bundle!' do
+    context 'when there is no Gemfile' do
+      before(:each) do
+        allow(File).to receive(:file?).with(/Gemfile$/).and_return(false)
+      end
+
+      it 'does nothing' do
+        expect(PDK::CLI::Exec).to_not receive(:bundle)
+
+        PDK::Util::Bundler.ensure_bundle!
+      end
+    end
+
+    context 'when there is no Gemfile.lock' do
+      before(:each) do
+        allow(File).to receive(:file?).with(/Gemfile$/).and_return(true)
+        allow(File).to receive(:file?).with(/Gemfile\.lock$/).and_return(false)
+        allow(PDK::CLI::Exec).to receive(:bundle).with('check', any_args).and_return({exit_code: 1})
+        allow(PDK::CLI::Exec).to receive(:bundle).with('install', any_args).and_return({exit_code: 0})
+      end
+
+      it 'generates Gemfile.lock' do
+        expect(PDK::CLI::Exec).to receive(:bundle).with('lock', any_args).and_return({exit_code: 0})
+
+        expect { PDK::Util::Bundler.ensure_bundle! }.to output(/resolving gemfile/i).to_stderr
+      end
+    end
+
+    context 'when there are missing gems' do
+      before(:each) do
+        allow(File).to receive(:file?).with(/Gemfile$/).and_return(true)
+        allow(File).to receive(:file?).with(/Gemfile\.lock$/).and_return(true)
+        allow(PDK::CLI::Exec).to receive(:bundle).with('check', any_args).and_return({exit_code: 1})
+      end
+
+      it 'installs missing gems' do
+        expect(PDK::CLI::Exec).to receive(:bundle).with('install', any_args).and_return({exit_code: 0})
+
+        expect { PDK::Util::Bundler.ensure_bundle! }.to output(/installing missing gemfile/i).to_stderr
+      end
+    end
+
+    context 'when there are no missing gems' do
+      before(:each) do
+        allow(File).to receive(:file?).with(/Gemfile$/).and_return(true)
+        allow(File).to receive(:file?).with(/Gemfile\.lock$/).and_return(true)
+      end
+
+      it 'checks for missing but does not install anything' do
+        expect(PDK::CLI::Exec).to receive(:bundle).with('check', any_args).and_return({exit_code: 0})
+        expect(PDK::CLI::Exec).to_not receive(:bundle).with('install', any_args)
+
+        expect { PDK::Util::Bundler.ensure_bundle! }.to output(/checking for missing/i).to_stderr
+      end
+    end
+  end
+end


### PR DESCRIPTION
This seems to be working pretty well at this point.

I added a conditional to disable the spinner stuff on Windows for now because there are some special considerations for making control sequences work under cmd/ps. Definitely solvable but probably more appropriate for a subsequent release.

There are a couple PRs backed up in the packaging repo to make this all work with packaged builds, but the paths etc. are all up to date with where things will eventually be.