### PR TITLE
(SDK-262) Populate default metadata to match interview defaults

### DIFF
--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -17,10 +17,11 @@ module PDK
 
       def self.invoke(opts={})
         defaults = {
+          'name'         => "#{Etc.getlogin}-#{opts[:name]}",
           'version'      => '0.1.0',
           'dependencies' => [
             { 'name' => 'puppetlabs-stdlib', 'version_requirement' => '>= 1.0.0' }
-          ]
+          ],
         }
 
         defaults['license'] = opts[:license] if opts.has_key? :license
@@ -81,7 +82,7 @@ module PDK
 
         begin
           puts ""
-          forge_user = PDK::CLI::Input.get(_("What is your Puppet Forge username?"), Etc.getlogin)
+          forge_user = PDK::CLI::Input.get(_("What is your Puppet Forge username?"), metadata.data['author'])
           metadata.update!('name' => "#{forge_user}-#{opts[:name]}")
         rescue StandardError => e
           PDK.logger.error(_("We're sorry, we could not parse your module name: %{message}") % {:message => e.message})

--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -10,7 +10,7 @@ module PDK
         'name'          => nil,
         'version'       => nil,
         'author'        => nil,
-        'summary'       => nil,
+        'summary'       => '',
         'license'       => 'Apache-2.0',
         'source'        => '',
         'project_page'  => nil,


### PR DESCRIPTION
Populates the `name` (and by extension `author`) metadata defaults before optionally invoking the interview, this way the metadata without interview will match the metadata if you just hit enter to all the questions in the interview.

Also, the default value for the summary field has been changed from `nil` to an empty string (same as `source`) because it is listed in [the documentation](https://docs.puppet.com/puppet/4.10/modules_metadata.html) as a required value.

This should clear up the pending acceptance test in #58 