### PR TITLE
(SDK-244) Add rubocop validator

### DIFF
--- a/lib/pdk/validators/base_validator.rb
+++ b/lib/pdk/validators/base_validator.rb
@@ -4,10 +4,27 @@ require 'pdk/cli/exec'
 module PDK
   module Validate
     class BaseValidator
+      def self.parse_targets(options)
+        # If no targets are specified, then we will run validations from the
+        # base module directory.
+        if options[:targets].nil? || options[:targets].empty?
+          [PDK::Util.module_root]
+        else
+          options[:targets]
+        end
+      end
+
+      def self.parse_options(options, targets)
+        targets
+      end
+
       def self.invoke(options = {})
-        PDK.logger.info(_("Running %{cmd} with options: %{options}") % {cmd: cmd, options: options})
-        # result = PDK::CLI::Exec.execute(cmd, options)
-        # result
+        targets = parse_targets(options)
+        cmd_options = parse_options(options, targets)
+
+        PDK.logger.debug(_("Running %{cmd} with options: %{options}") % {cmd: cmd, options: cmd_options})
+        result = PDK::CLI::Exec.execute(cmd, *cmd_options)
+        result
       end
     end
   end

--- a/lib/pdk/validators/metadata.rb
+++ b/lib/pdk/validators/metadata.rb
@@ -12,11 +12,6 @@ module PDK
       def self.cmd
         'metadata-json-lint'
       end
-
-      def self.invoke(options = {})
-        PDK.logger.info(_("Running %{cmd} with options: %{options}") % {cmd: cmd, options: options})
-        result = { "#{name}" => PDK::CLI::Exec.execute(cmd) }
-      end
     end
   end
 end

--- a/lib/pdk/validators/puppet/puppet_lint.rb
+++ b/lib/pdk/validators/puppet/puppet_lint.rb
@@ -14,39 +14,14 @@ module PDK
         "puppet-lint"
       end
 
-      def self.parse_targets(options = {})
-        targets = []
+      def self.parse_options(options, targets)
+        cmd_options = []
 
-        # If no targets are passed, then we will run puppet-lint on the base
-        # module directory by default and lint everything.
-        if options[:targets].nil? or options[:targets].empty?
-          module_root = PDK::Util.module_root
-          targets << module_root unless module_root.nil?
-        else
-          targets.concat(options[:targets])
-        end
-        targets
-      end
-
-      def self.parse_format(options = {})
-        if options[:format].nil? or options[:format].empty?
-          format = ""
-        elsif options[:format] == "junit"
-          format = "--json"
+        if options[:format] && options[:format] == 'junit'
+          cmd_options << '--json'
         end
 
-        format
-      end
-
-      def self.invoke(options = {})
-        targets = parse_targets(options)
-        format = parse_format(options)
-
-        PDK.logger.info(_("Running %{cmd} on targets:\n  -%{targets}") % {cmd: cmd, targets: targets.join("\n  -")})
-        opts = targets
-        opts << format
-
-        PDK::CLI::Exec.execute(cmd, *opts)
+        cmd_options.concat(targets)
       end
     end
   end

--- a/lib/pdk/validators/puppet/puppet_parser.rb
+++ b/lib/pdk/validators/puppet/puppet_parser.rb
@@ -12,11 +12,6 @@ module PDK
       def self.cmd
         'pwd'
       end
-
-      def self.invoke(options = {})
-        PDK.logger.info(_("Running %{cmd} with options: %{options}") % {cmd: cmd, options: options})
-        result = PDK::CLI::Exec.execute(cmd)
-      end
     end
   end
 end

--- a/lib/pdk/validators/ruby/rubocop.rb
+++ b/lib/pdk/validators/ruby/rubocop.rb
@@ -11,13 +11,18 @@ module PDK
       end
 
       def self.cmd
-        'pwd'
+        'rubocop'
       end
 
-      def self.invoke(options = {})
-        PDK.logger.info(_("Running %{cmd} with options: %{options}") % {cmd: cmd, options: options})
-        result = PDK::CLI::Exec.execute(cmd)
-      end 
+      def self.parse_options(options, targets)
+        cmd_options = if options[:format] && options[:format] == 'junit'
+          ['--format', 'json']
+        else
+          ['--format', 'clang']
+        end
+
+        cmd_options.concat(targets)
+      end
     end
   end
 end


### PR DESCRIPTION
Refactors the validators further so that parsing targets from the CLI and invoking the command are part of the base class. This way, the only thing each validator needs to do is implement a method to build an array of arguments to pass to the command