### PR TITLE
(SDK-190) Acceptance tests for using commands outside module folder

### DIFF
--- a/spec/acceptance/new_class_spec.rb
+++ b/spec/acceptance/new_class_spec.rb
@@ -1,33 +1,42 @@
 require 'spec_helper_acceptance'
 
 describe 'Creating a new class' do
-  include_context 'in a new module', 'foo'
+  context 'in a new module' do
+    include_context 'in a new module', 'foo'
 
-  context 'when creating the main class' do
-    describe command('pdk new class foo') do
-      its(:exit_status) { is_expected.to eq 0 }
-      its(:stdout) { is_expected.to match(%r{Creating .* from template}) }
-      its(:stdout) { is_expected.not_to match(%r{WARN|ERR}) }
-      # use this weird regex to match for empty string to get proper diff output on failure
-      its(:stderr) { is_expected.to match(%r{\A\Z}) }
-    end
+    context 'when creating the main class' do
+      describe command('pdk new class foo') do
+        its(:exit_status) { is_expected.to eq 0 }
+        its(:stdout) { is_expected.to match(%r{Creating .* from template}) }
+        its(:stdout) { is_expected.not_to match(%r{WARN|ERR}) }
+        # use this weird regex to match for empty string to get proper diff output on failure
+        its(:stderr) { is_expected.to match(%r{\A\Z}) }
+      end
 
-    describe file('manifests') do
-      it { is_expected.to be_directory }
-    end
+      describe file('manifests') do
+        it { is_expected.to be_directory }
+      end
 
-    describe file('manifests/init.pp') do
-      it { is_expected.to be_file }
-      its(:content) do
-        is_expected.to match(%r{class foo})
+      describe file('manifests/init.pp') do
+        it { is_expected.to be_file }
+        its(:content) do
+          is_expected.to match(%r{class foo})
+        end
+      end
+
+      describe file('spec/classes/foo_spec.rb') do
+        it { is_expected.to be_file }
+        its(:content) do
+          is_expected.to match(%r{foo})
+        end
       end
     end
+  end
 
-    describe file('spec/classes/foo_spec.rb') do
-      it { is_expected.to be_file }
-      its(:content) do
-        is_expected.to match(%r{foo})
-      end
+  context 'outside a module folder' do
+    describe command('pdk new class bar') do
+      its(:exit_status) { is_expected.not_to eq 0 }
+      its(:stdout) { is_expected.to match(%r{metadata.json.*does not exist}) }
     end
   end
 end

--- a/spec/acceptance/new_class_spec.rb
+++ b/spec/acceptance/new_class_spec.rb
@@ -20,7 +20,7 @@ describe 'Creating a new class' do
       describe file('manifests/init.pp') do
         it { is_expected.to be_file }
         its(:content) do
-          is_expected.to match(%r{class foo})
+          is_expected.to match(%r{class foo })
         end
       end
 
@@ -28,6 +28,62 @@ describe 'Creating a new class' do
         it { is_expected.to be_file }
         its(:content) do
           is_expected.to match(%r{foo})
+        end
+      end
+    end
+
+    context 'when creating an ancillary class' do
+      describe command('pdk new class foo::bar') do
+        its(:exit_status) { is_expected.to eq 0 }
+        its(:stdout) { is_expected.to match(%r{Creating .* from template}) }
+        its(:stdout) { is_expected.not_to match(%r{WARN|ERR}) }
+        # use this weird regex to match for empty string to get proper diff output on failure
+        its(:stderr) { is_expected.to match(%r{\A\Z}) }
+      end
+
+      describe file('manifests') do
+        it { is_expected.to be_directory }
+      end
+
+      describe file('manifests/bar.pp') do
+        it { is_expected.to be_file }
+        its(:content) do
+          is_expected.to match(%r{class foo::bar})
+        end
+      end
+
+      describe file('spec/classes/bar_spec.rb') do
+        it { is_expected.to be_file }
+        its(:content) do
+          is_expected.to match(%r{foo::bar})
+        end
+      end
+    end
+
+    context 'when creating a deeply nested class' do
+      describe command('pdk new class foo::bar::baz') do
+        its(:exit_status) { is_expected.to eq 0 }
+        its(:stdout) { is_expected.to match(%r{Creating .* from template}) }
+        its(:stdout) { is_expected.not_to match(%r{WARN|ERR}) }
+        # use this weird regex to match for empty string to get proper diff output on failure
+        its(:stderr) { is_expected.to match(%r{\A\Z}) }
+      end
+
+      describe file('manifests') do
+        it { is_expected.to be_directory }
+      end
+
+      describe file('manifests/bar/baz.pp') do
+        it { is_expected.to be_file }
+        its(:content) do
+          is_expected.to match(%r{class foo::bar::baz})
+        end
+      end
+
+      describe file('spec/classes/bar/baz_spec.rb') do
+        it { is_expected.to be_file }
+        its(:content) do
+          is_expected.to match(%r{foo::bar::baz})
         end
       end
     end

--- a/spec/acceptance/test_spec.rb
+++ b/spec/acceptance/test_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper_acceptance'
+
+describe 'Using the test command' do
+  context 'within a module directory' do
+    before(:all) do
+      system('pdk new module foo --skip-interview') || raise
+      Dir.chdir('foo')
+    end
+
+    after(:all) do
+      Dir.chdir('..')
+      FileUtils.rm_rf('foo')
+    end
+
+    describe command('pdk test unit') do
+      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to match(%r{Running unit tests}) }
+      its(:stderr) { is_expected.not_to match(%r{WARN|ERROR|FAIL}i) }
+    end
+  end
+
+  context 'not within a module directory' do
+    before(:all) do
+      Dir.mkdir('not_a_module') || raise
+      Dir.chdir('not_a_module')
+    end
+
+    after(:all) do
+      Dir.chdir('..')
+      FileUtils.rm_rf('not_a_module')
+    end
+
+    describe command('pdk test unit') do
+      its(:exit_status) do
+        pending 'Test command is currently a stub'
+        is_expected.not_to eq 0
+      end
+      its(:stderr) { is_expected.not_to match(%r{WARN|ERROR|FAIL}i) }
+    end
+  end
+end


### PR DESCRIPTION
Adds an acceptance spec for using pdk new class when not inside a module folder.
Adds a pending acceptance spec for using pdk test unit when not inside a module folder.
Does not address pdk validate when not inside a module folder - SDK-277 is an existing bug for this.