### PR TITLE
(maint) Windows cache folder should not be roaming

### DIFF
--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -36,7 +36,7 @@ module PDK
     # @return [String] Fully qualified path to per-user PDK cachedir.
     def cachedir
       if Gem.win_platform?
-        basedir = ENV['APPDATA']
+        basedir = ENV['LOCALAPPDATA']
       else
         basedir = Dir.home
       end


### PR DESCRIPTION
Change cache location from APPDATA to LOCALAPPDATA
This makes it local data and not roaming.