### PR TITLE
(FIXUP) Add a GEM_PATH for bundler when running acceptance tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'rubocop'
 gem 'nokogiri', '1.7.2'
 
 group(:development, :test) do
-  gem 'bundler', '~> 1.13'
   gem 'pry-byebug', '~> 3.4'
   gem 'rake', '~> 10.0'
   gem 'rspec', '~> 3.0'

--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_runtime_dependency 'bundler', '~> 1.15'
   spec.add_runtime_dependency 'cri', '~> 2.9.1'
   spec.add_runtime_dependency 'childprocess', '~> 0.6.2'
   spec.add_runtime_dependency 'gettext-setup', '~> 0.24'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -18,6 +18,11 @@ keys = %w[BUNDLER_EDITOR BUNDLE_BIN_PATH BUNDLE_GEMFILE
 keys.each do |k|
   bundler_env[k] = ENV[k] if ENV.key? k
 end
+
+# bundler won't install bundler into the --path, so in order to access ::Bundler.with_clean_env
+# from within pdk during spec tests, we have to manually re-add the global gem path :(
+bundler_env['GEM_PATH'] += ":#{File.absolute_path(File.join(`bundle show bundler`, '..', '..'))}"
+
 # dup to avoid pollution from specinfra
 Specinfra.configuration.env = bundler_env.dup
 


### PR DESCRIPTION
I had to do this to get acceptance tests running in my environment, opening the PR to see if it passes Travis/Appveyor.