### PR TITLE
(maint) Expand Windows 8.3 paths in templatedir

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,8 @@ AllCops:
     # binstubs, and other utilities
     - bin/**/*
     - vendor/**/*
+    # Puppet util code follows Puppet's style, not pdk's
+    - lib/puppet/**/*
 
 Layout/IndentHeredoc:
   Description: The `squiggly` style would be preferable, but is only available from ruby 2.3. We'll enable this when we can.

--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -135,7 +135,12 @@ module PDK
           begin
             @process.start
           rescue ChildProcess::LaunchError => e
-            raise PDK::CLI::FatalError, _("Failed to execute '%{command}': %{message}") % { command: argv.join(' '), message: e.message }
+            msg = if @process.respond_to?(:argv)
+                    _("Failed to execute '%{command}': %{message}") % { command: @process.argv.join(' '), message: e.message }
+                  else
+                    _('Failed to execute process: %{message}') % { message: e.message }
+                  end
+            raise PDK::CLI::FatalError, msg
           end
 
           if timeout

--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -52,7 +52,8 @@ module PDK
             PDK.logger.error clone_result[:stderr]
             raise PDK::CLI::FatalError, _("Unable to clone git repository '%{repo}' to '%{dest}'") % { repo: path_or_url, dest: temp_dir }
           end
-          @path = temp_dir
+
+          @path = PDK::Util.canonical_path(temp_dir)
           @repo = path_or_url
         end
 

--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -1,5 +1,6 @@
 require 'tmpdir'
 require 'tempfile'
+require 'puppet/util/windows'
 
 module PDK
   module Util
@@ -31,6 +32,23 @@ module PDK
       Dir::Tmpname.make_tmpname(File.join(Dir.tmpdir, base), nil)
     end
     module_function :make_tmpdir_name
+
+    # Return an expanded, absolute path
+    #
+    # @param path [String] Existing path that may not be canonical
+    #
+    # @return [String] Canonical path
+    def canonical_path(path)
+      if Gem.win_platform?
+        unless File.exist?(path)
+          raise PDK::CLI::FatalError, _("Cannot resolve a full path to '%{path}' as it does not currently exist") % { path: path }
+        end
+        Puppet::Util::Windows::File.get_long_pathname(path)
+      else
+        File.expand_path(path)
+      end
+    end
+    module_function :canonical_path
 
     # Returns the fully qualified path to a per-user PDK cachedir.
     #

--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -1,0 +1,14 @@
+module Puppet
+  module Util
+    module Windows
+      module File; end
+
+      if Gem.win_platform?
+        # these reference platform specific gems
+        require 'puppet/util/windows/api_types'
+        require 'puppet/util/windows/string'
+        require 'puppet/util/windows/file'
+      end
+    end
+  end
+end

--- a/lib/puppet/util/windows/api_types.rb
+++ b/lib/puppet/util/windows/api_types.rb
@@ -1,0 +1,278 @@
+require 'ffi'
+require 'puppet/util/windows/string'
+
+module Puppet::Util::Windows::APITypes
+  module ::FFI
+    WIN32_FALSE = 0
+
+    # standard Win32 error codes
+    ERROR_SUCCESS = 0
+  end
+
+  module ::FFI::Library
+    # Wrapper method for attach_function + private
+    def attach_function_private(*args)
+      attach_function(*args)
+      private args[0]
+    end
+  end
+
+  class ::FFI::Pointer
+    NULL_HANDLE = 0
+
+    def self.from_string_to_wide_string(str, &block)
+      str = Puppet::Util::Windows::String.wide_string(str)
+      FFI::MemoryPointer.new(:byte, str.bytesize) do |ptr|
+        # uchar here is synonymous with byte
+        ptr.put_array_of_uchar(0, str.bytes.to_a)
+
+        yield ptr
+      end
+
+      # ptr has already had free called, so nothing to return
+      nil
+    end
+
+    def read_win32_bool
+      # BOOL is always a 32-bit integer in Win32
+      # some Win32 APIs return 1 for true, while others are non-0
+      read_int32 != FFI::WIN32_FALSE
+    end
+
+    alias_method :read_dword, :read_uint32
+    alias_method :read_win32_ulong, :read_uint32
+    alias_method :read_qword, :read_uint64
+
+    alias_method :read_hresult, :read_int32
+
+    def read_handle
+      type_size == 4 ? read_uint32 : read_uint64
+    end
+
+    alias_method :read_wchar, :read_uint16
+    alias_method :read_word,  :read_uint16
+    alias_method :read_array_of_wchar, :read_array_of_uint16
+
+    def read_wide_string(char_length, dst_encoding = Encoding::UTF_8)
+      # char_length is number of wide chars (typically excluding NULLs), *not* bytes
+      str = get_bytes(0, char_length * 2).force_encoding('UTF-16LE')
+      str.encode(dst_encoding)
+    end
+
+    # @param max_char_length [Integer] Maximum number of wide chars to return (typically excluding NULLs), *not* bytes
+    # @param null_terminator [Symbol] Number of number of null wchar characters, *not* bytes, that determine the end of the string
+    #   null_terminator = :single_null, then the terminating sequence is two bytes of zero.   This is UNIT16 = 0
+    #   null_terminator = :double_null, then the terminating sequence is four bytes of zero.  This is UNIT32 = 0
+    def read_arbitrary_wide_string_up_to(max_char_length = 512, null_terminator = :single_null)
+      if null_terminator != :single_null && null_terminator != :double_null
+        raise _("Unable to read wide strings with %{null_terminator} terminal nulls") % { null_terminator: null_terminator }
+      end
+
+      terminator_width = null_terminator == :single_null ? 1 : 2
+      reader_method = null_terminator == :single_null ? :get_uint16 : :get_uint32
+
+      # Look for a null terminating characters; if found, read up to that null (exclusive)
+      (0...max_char_length - terminator_width).each do |i|
+        return read_wide_string(i) if send(reader_method, (i * 2)) == 0
+      end
+
+      # String is longer than the max; read just to the max
+      read_wide_string(max_char_length)
+    end
+
+    def read_win32_local_pointer(&block)
+      ptr = nil
+      begin
+        ptr = read_pointer
+        yield ptr
+      ensure
+        if ptr && ! ptr.null?
+          if FFI::WIN32::LocalFree(ptr.address) != FFI::Pointer::NULL_HANDLE
+            Puppet.debug "LocalFree memory leak"
+          end
+        end
+      end
+
+      # ptr has already had LocalFree called, so nothing to return
+      nil
+    end
+
+    def read_com_memory_pointer(&block)
+      ptr = nil
+      begin
+        ptr = read_pointer
+        yield ptr
+      ensure
+        FFI::WIN32::CoTaskMemFree(ptr) if ptr && ! ptr.null?
+      end
+
+      # ptr has already had CoTaskMemFree called, so nothing to return
+      nil
+    end
+
+
+    alias_method :write_dword, :write_uint32
+    alias_method :write_word, :write_uint16
+  end
+
+  # FFI Types
+  # https://github.com/ffi/ffi/wiki/Types
+
+  # Windows - Common Data Types
+  # https://msdn.microsoft.com/en-us/library/cc230309.aspx
+
+  # Windows Data Types
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383751(v=vs.85).aspx
+
+  FFI.typedef :uint16, :word
+  FFI.typedef :uint32, :dword
+  # uintptr_t is defined in an FFI conf as platform specific, either
+  # ulong_long on x64 or just ulong on x86
+  FFI.typedef :uintptr_t, :handle
+  FFI.typedef :uintptr_t, :hwnd
+
+  # buffer_inout is similar to pointer (platform specific), but optimized for buffers
+  FFI.typedef :buffer_inout, :lpwstr
+  # buffer_in is similar to pointer (platform specific), but optimized for CONST read only buffers
+  FFI.typedef :buffer_in, :lpcwstr
+  FFI.typedef :buffer_in, :lpcolestr
+
+  # string is also similar to pointer, but should be used for const char *
+  # NOTE that this is not wide, useful only for A suffixed functions
+  FFI.typedef :string, :lpcstr
+
+  # pointer in FFI is platform specific
+  # NOTE: for API calls with reserved lpvoid parameters, pass a FFI::Pointer::NULL
+  FFI.typedef :pointer, :lpcvoid
+  FFI.typedef :pointer, :lpvoid
+  FFI.typedef :pointer, :lpword
+  FFI.typedef :pointer, :lpbyte
+  FFI.typedef :pointer, :lpdword
+  FFI.typedef :pointer, :pdword
+  FFI.typedef :pointer, :phandle
+  FFI.typedef :pointer, :ulong_ptr
+  FFI.typedef :pointer, :pbool
+  FFI.typedef :pointer, :lpunknown
+
+  # any time LONG / ULONG is in a win32 API definition DO NOT USE platform specific width
+  # which is what FFI uses by default
+  # instead create new aliases for these very special cases
+  # NOTE: not a good idea to redefine FFI :ulong since other typedefs may rely on it
+  FFI.typedef :uint32, :win32_ulong
+  FFI.typedef :int32, :win32_long
+  # FFI bool can be only 1 byte at times,
+  # Win32 BOOL is a signed int, and is always 4 bytes, even on x64
+  # https://blogs.msdn.com/b/oldnewthing/archive/2011/03/28/10146459.aspx
+  FFI.typedef :int32, :win32_bool
+
+  # BOOLEAN (unlike BOOL) is a BYTE - typedef unsigned char BYTE;
+  FFI.typedef :uchar, :boolean
+
+  # Same as a LONG, a 32-bit signed integer
+  FFI.typedef :int32, :hresult
+
+  # NOTE: FFI already defines (u)short as a 16-bit (un)signed like this:
+  # FFI.typedef :uint16, :ushort
+  # FFI.typedef :int16, :short
+
+  # 8 bits per byte
+  FFI.typedef :uchar, :byte
+  FFI.typedef :uint16, :wchar
+
+  module ::FFI::WIN32
+    extend ::FFI::Library
+
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/aa373931(v=vs.85).aspx
+    # typedef struct _GUID {
+    #   DWORD Data1;
+    #   WORD  Data2;
+    #   WORD  Data3;
+    #   BYTE  Data4[8];
+    # } GUID;
+    class GUID < FFI::Struct
+      layout :Data1, :dword,
+             :Data2, :word,
+             :Data3, :word,
+             :Data4, [:byte, 8]
+
+      def self.[](s)
+        raise _('Bad GUID format.') unless s =~ /^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i
+
+        new.tap do |guid|
+          guid[:Data1] = s[0, 8].to_i(16)
+          guid[:Data2] = s[9, 4].to_i(16)
+          guid[:Data3] = s[14, 4].to_i(16)
+          guid[:Data4][0] = s[19, 2].to_i(16)
+          guid[:Data4][1] = s[21, 2].to_i(16)
+          s[24, 12].split('').each_slice(2).with_index do |a, i|
+            guid[:Data4][i + 2] = a.join('').to_i(16)
+          end
+        end
+      end
+
+      def ==(other) Windows.memcmp(other, self, size) == 0 end
+    end
+
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/ms724950(v=vs.85).aspx
+    # typedef struct _SYSTEMTIME {
+    #   WORD wYear;
+    #   WORD wMonth;
+    #   WORD wDayOfWeek;
+    #   WORD wDay;
+    #   WORD wHour;
+    #   WORD wMinute;
+    #   WORD wSecond;
+    #   WORD wMilliseconds;
+    # } SYSTEMTIME, *PSYSTEMTIME;
+    class SYSTEMTIME < FFI::Struct
+      layout :wYear, :word,
+             :wMonth, :word,
+             :wDayOfWeek, :word,
+             :wDay, :word,
+             :wHour, :word,
+             :wMinute, :word,
+             :wSecond, :word,
+             :wMilliseconds, :word
+
+      def to_local_time
+        Time.local(self[:wYear], self[:wMonth], self[:wDay],
+          self[:wHour], self[:wMinute], self[:wSecond], self[:wMilliseconds] * 1000)
+      end
+    end
+
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/ms724284(v=vs.85).aspx
+    # Contains a 64-bit value representing the number of 100-nanosecond
+    # intervals since January 1, 1601 (UTC).
+    # typedef struct _FILETIME {
+    #   DWORD dwLowDateTime;
+    #   DWORD dwHighDateTime;
+    # } FILETIME, *PFILETIME;
+    class FILETIME < FFI::Struct
+      layout :dwLowDateTime, :dword,
+             :dwHighDateTime, :dword
+    end
+
+    ffi_convention :stdcall
+
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/aa366730(v=vs.85).aspx
+    # HLOCAL WINAPI LocalFree(
+    #   _In_  HLOCAL hMem
+    # );
+    ffi_lib :kernel32
+    attach_function :LocalFree, [:handle], :handle
+
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/ms724211(v=vs.85).aspx
+    # BOOL WINAPI CloseHandle(
+    #   _In_  HANDLE hObject
+    # );
+    ffi_lib :kernel32
+    attach_function_private :CloseHandle, [:handle], :win32_bool
+
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/ms680722(v=vs.85).aspx
+    # void CoTaskMemFree(
+    #   _In_opt_  LPVOID pv
+    # );
+    ffi_lib :ole32
+    attach_function :CoTaskMemFree, [:lpvoid], :void
+  end
+end

--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -1,0 +1,488 @@
+require 'puppet/util/windows'
+
+module Puppet::Util::Windows::File
+  require 'ffi'
+  extend FFI::Library
+  extend Puppet::Util::Windows::String
+
+  FILE_ATTRIBUTE_READONLY      = 0x00000001
+
+  SYNCHRONIZE                 = 0x100000
+  STANDARD_RIGHTS_REQUIRED    = 0xf0000
+  STANDARD_RIGHTS_READ        = 0x20000
+  STANDARD_RIGHTS_WRITE       = 0x20000
+  STANDARD_RIGHTS_EXECUTE     = 0x20000
+  STANDARD_RIGHTS_ALL         = 0x1F0000
+  SPECIFIC_RIGHTS_ALL         = 0xFFFF
+
+  FILE_READ_DATA               = 1
+  FILE_WRITE_DATA              = 2
+  FILE_APPEND_DATA             = 4
+  FILE_READ_EA                 = 8
+  FILE_WRITE_EA                = 16
+  FILE_EXECUTE                 = 32
+  FILE_DELETE_CHILD            = 64
+  FILE_READ_ATTRIBUTES         = 128
+  FILE_WRITE_ATTRIBUTES        = 256
+
+  FILE_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | 0x1FF
+
+  FILE_GENERIC_READ =
+     STANDARD_RIGHTS_READ |
+     FILE_READ_DATA |
+     FILE_READ_ATTRIBUTES |
+     FILE_READ_EA |
+     SYNCHRONIZE
+
+  FILE_GENERIC_WRITE =
+     STANDARD_RIGHTS_WRITE |
+     FILE_WRITE_DATA |
+     FILE_WRITE_ATTRIBUTES |
+     FILE_WRITE_EA |
+     FILE_APPEND_DATA |
+     SYNCHRONIZE
+
+  FILE_GENERIC_EXECUTE =
+     STANDARD_RIGHTS_EXECUTE |
+     FILE_READ_ATTRIBUTES |
+     FILE_EXECUTE |
+     SYNCHRONIZE
+
+  REPLACEFILE_WRITE_THROUGH         = 0x1
+  REPLACEFILE_IGNORE_MERGE_ERRORS   = 0x2
+  REPLACEFILE_IGNORE_ACL_ERRORS     = 0x3
+
+  def replace_file(target, source)
+    target_encoded = wide_string(target.to_s)
+    source_encoded = wide_string(source.to_s)
+
+    flags = REPLACEFILE_IGNORE_MERGE_ERRORS
+    backup_file = nil
+    result = ReplaceFileW(
+      target_encoded,
+      source_encoded,
+      backup_file,
+      flags,
+      FFI::Pointer::NULL,
+      FFI::Pointer::NULL
+    )
+
+    return true if result != FFI::WIN32_FALSE
+    raise Puppet::Util::Windows::Error.new("ReplaceFile(#{target}, #{source})")
+  end
+  module_function :replace_file
+
+  def move_file_ex(source, target, flags = 0)
+    result = MoveFileExW(wide_string(source.to_s),
+                         wide_string(target.to_s),
+                         flags)
+
+    return true if result != FFI::WIN32_FALSE
+    raise Puppet::Util::Windows::Error.
+      new("MoveFileEx(#{source}, #{target}, #{flags.to_s(8)})")
+  end
+  module_function :move_file_ex
+
+  def symlink(target, symlink)
+    flags = File.directory?(target) ? 0x1 : 0x0
+    result = CreateSymbolicLinkW(wide_string(symlink.to_s),
+      wide_string(target.to_s), flags)
+    return true if result != FFI::WIN32_FALSE
+    raise Puppet::Util::Windows::Error.new(
+      "CreateSymbolicLink(#{symlink}, #{target}, #{flags.to_s(8)})")
+  end
+  module_function :symlink
+
+
+  def exist?(path)
+    path = path.to_str if path.respond_to?(:to_str) # support WatchedFile
+    path = path.to_s # support String and Pathname
+
+    seen_paths = []
+    # follow up to 64 symlinks before giving up
+    0.upto(64) do |depth|
+      # return false if this path has been seen before.  This is protection against circular symlinks
+      return false if seen_paths.include?(path.downcase)
+
+      result = get_attributes(path,false)
+
+      # return false for path not found
+      return false if result == INVALID_FILE_ATTRIBUTES
+
+      # return true if path exists and it's not a symlink
+      # Other file attributes are ignored. https://msdn.microsoft.com/en-us/library/windows/desktop/gg258117(v=vs.85).aspx
+      return true if (result & FILE_ATTRIBUTE_REPARSE_POINT) != FILE_ATTRIBUTE_REPARSE_POINT
+
+      # walk the symlink and try again...
+      seen_paths << path.downcase
+      path = readlink(path)
+    end
+
+    false
+  end
+  module_function :exist?
+
+
+  INVALID_FILE_ATTRIBUTES = 0xFFFFFFFF #define INVALID_FILE_ATTRIBUTES (DWORD (-1))
+
+  def get_attributes(file_name, raise_on_invalid = true)
+    result = GetFileAttributesW(wide_string(file_name.to_s))
+    if raise_on_invalid && result == INVALID_FILE_ATTRIBUTES
+      raise Puppet::Util::Windows::Error.new("GetFileAttributes(#{file_name})")
+    end
+
+    result
+  end
+  module_function :get_attributes
+
+  def add_attributes(path, flags)
+    oldattrs = get_attributes(path)
+
+    if (oldattrs | flags) != oldattrs
+      set_attributes(path, oldattrs | flags)
+    end
+  end
+  module_function :add_attributes
+
+  def remove_attributes(path, flags)
+    oldattrs = get_attributes(path)
+
+    if (oldattrs & ~flags) != oldattrs
+      set_attributes(path, oldattrs & ~flags)
+    end
+  end
+  module_function :remove_attributes
+
+  def set_attributes(path, flags)
+    success = SetFileAttributesW(wide_string(path), flags) != FFI::WIN32_FALSE
+    raise Puppet::Util::Windows::Error.new(_("Failed to set file attributes")) if !success
+
+    success
+  end
+  module_function :set_attributes
+
+  #define INVALID_HANDLE_VALUE ((HANDLE)(LONG_PTR)-1)
+  INVALID_HANDLE_VALUE = FFI::Pointer.new(-1).address
+  def self.create_file(file_name, desired_access, share_mode, security_attributes,
+    creation_disposition, flags_and_attributes, template_file_handle)
+
+    result = CreateFileW(wide_string(file_name.to_s),
+      desired_access, share_mode, security_attributes, creation_disposition,
+      flags_and_attributes, template_file_handle)
+
+    return result unless result == INVALID_HANDLE_VALUE
+    raise Puppet::Util::Windows::Error.new(
+      "CreateFile(#{file_name}, #{desired_access.to_s(8)}, #{share_mode.to_s(8)}, " +
+        "#{security_attributes}, #{creation_disposition.to_s(8)}, " +
+        "#{flags_and_attributes.to_s(8)}, #{template_file_handle})")
+  end
+
+  def self.get_reparse_point_data(handle, &block)
+    # must be multiple of 1024, min 10240
+    FFI::MemoryPointer.new(REPARSE_DATA_BUFFER.size) do |reparse_data_buffer_ptr|
+      device_io_control(handle, FSCTL_GET_REPARSE_POINT, nil, reparse_data_buffer_ptr)
+      yield REPARSE_DATA_BUFFER.new(reparse_data_buffer_ptr)
+    end
+
+    # underlying struct MemoryPointer has been cleaned up by this point, nothing to return
+    nil
+  end
+
+  def self.device_io_control(handle, io_control_code, in_buffer = nil, out_buffer = nil)
+    if out_buffer.nil?
+      raise Puppet::Util::Windows::Error.new(_("out_buffer is required"))
+    end
+
+    FFI::MemoryPointer.new(:dword, 1) do |bytes_returned_ptr|
+      result = DeviceIoControl(
+        handle,
+        io_control_code,
+        in_buffer, in_buffer.nil? ? 0 : in_buffer.size,
+        out_buffer, out_buffer.size,
+        bytes_returned_ptr,
+        nil
+      )
+
+      if result == FFI::WIN32_FALSE
+        raise Puppet::Util::Windows::Error.new(
+          "DeviceIoControl(#{handle}, #{io_control_code}, " +
+          "#{in_buffer}, #{in_buffer ? in_buffer.size : ''}, " +
+          "#{out_buffer}, #{out_buffer ? out_buffer.size : ''}")
+      end
+    end
+
+    out_buffer
+  end
+
+  FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+  def symlink?(file_name)
+    attributes = get_attributes(file_name, false)
+
+    return false if (attributes == INVALID_FILE_ATTRIBUTES)
+    (attributes & FILE_ATTRIBUTE_REPARSE_POINT) == FILE_ATTRIBUTE_REPARSE_POINT
+  end
+  module_function :symlink?
+
+  GENERIC_READ                  = 0x80000000
+  GENERIC_WRITE                 = 0x40000000
+  GENERIC_EXECUTE               = 0x20000000
+  GENERIC_ALL                   = 0x10000000
+  FILE_SHARE_READ               = 1
+  FILE_SHARE_WRITE              = 2
+  OPEN_EXISTING                 = 3
+  FILE_FLAG_OPEN_REPARSE_POINT  = 0x00200000
+  FILE_FLAG_BACKUP_SEMANTICS    = 0x02000000
+
+  def self.open_symlink(link_name)
+    begin
+      yield handle = create_file(
+      link_name,
+      GENERIC_READ,
+      FILE_SHARE_READ,
+      nil, # security_attributes
+      OPEN_EXISTING,
+      FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
+      0) # template_file
+    ensure
+      FFI::WIN32.CloseHandle(handle) if handle
+    end
+
+    # handle has had CloseHandle called against it, so nothing to return
+    nil
+  end
+
+  def readlink(link_name)
+    link = nil
+    open_symlink(link_name) do |handle|
+      link = resolve_symlink(handle)
+    end
+
+    link
+  end
+  module_function :readlink
+
+  ERROR_FILE_NOT_FOUND = 2
+  ERROR_PATH_NOT_FOUND = 3
+
+  def get_long_pathname(path)
+    converted = ''
+    FFI::Pointer.from_string_to_wide_string(path) do |path_ptr|
+      # includes terminating NULL
+      buffer_size = GetLongPathNameW(path_ptr, FFI::Pointer::NULL, 0)
+      FFI::MemoryPointer.new(:wchar, buffer_size) do |converted_ptr|
+        if GetLongPathNameW(path_ptr, converted_ptr, buffer_size) == FFI::WIN32_FALSE
+          raise Puppet::Util::Windows::Error.new(_("Failed to call GetLongPathName"))
+        end
+
+        converted = converted_ptr.read_wide_string(buffer_size - 1)
+      end
+    end
+
+    converted
+  end
+  module_function :get_long_pathname
+
+  def get_short_pathname(path)
+    converted = ''
+    FFI::Pointer.from_string_to_wide_string(path) do |path_ptr|
+      # includes terminating NULL
+      buffer_size = GetShortPathNameW(path_ptr, FFI::Pointer::NULL, 0)
+      FFI::MemoryPointer.new(:wchar, buffer_size) do |converted_ptr|
+        if GetShortPathNameW(path_ptr, converted_ptr, buffer_size) == FFI::WIN32_FALSE
+          raise Puppet::Util::Windows::Error.new("Failed to call GetShortPathName")
+        end
+
+        converted = converted_ptr.read_wide_string(buffer_size - 1)
+      end
+    end
+
+    converted
+  end
+  module_function :get_short_pathname
+
+  def stat(file_name)
+    file_name = file_name.to_s # accommodate PathName or String
+    stat = File.stat(file_name)
+    singleton_class = class << stat; self; end
+    target_path = file_name
+
+    if symlink?(file_name)
+      target_path = readlink(file_name)
+      link_ftype = File.stat(target_path).ftype
+
+      # sigh, monkey patch instance method for instance, and close over link_ftype
+      singleton_class.send(:define_method, :ftype) do
+        link_ftype
+      end
+    end
+
+    singleton_class.send(:define_method, :mode) do
+      Puppet::Util::Windows::Security.get_mode(target_path)
+    end
+
+    stat
+  end
+  module_function :stat
+
+  def lstat(file_name)
+    file_name = file_name.to_s # accommodate PathName or String
+    # monkey'ing around!
+    stat = File.lstat(file_name)
+
+    singleton_class = class << stat; self; end
+    singleton_class.send(:define_method, :mode) do
+      Puppet::Util::Windows::Security.get_mode(file_name)
+    end
+
+    if symlink?(file_name)
+      def stat.ftype
+        "link"
+      end
+    end
+    stat
+  end
+  module_function :lstat
+
+  private
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa364571(v=vs.85).aspx
+  FSCTL_GET_REPARSE_POINT = 0x900a8
+
+  def self.resolve_symlink(handle)
+    path = nil
+    get_reparse_point_data(handle) do |reparse_data|
+      offset = reparse_data[:PrintNameOffset]
+      length = reparse_data[:PrintNameLength]
+
+      ptr = reparse_data.pointer + reparse_data.offset_of(:PathBuffer) + offset
+      path = ptr.read_wide_string(length / 2) # length is bytes, need UTF-16 wchars
+    end
+
+    path
+  end
+
+  ffi_convention :stdcall
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa365512(v=vs.85).aspx
+  # BOOL WINAPI ReplaceFile(
+  #   _In_        LPCTSTR lpReplacedFileName,
+  #   _In_        LPCTSTR lpReplacementFileName,
+  #   _In_opt_    LPCTSTR lpBackupFileName,
+  #   _In_        DWORD dwReplaceFlags - 0x1 REPLACEFILE_WRITE_THROUGH,
+  #                                      0x2 REPLACEFILE_IGNORE_MERGE_ERRORS,
+  #                                      0x4 REPLACEFILE_IGNORE_ACL_ERRORS
+  #   _Reserved_  LPVOID lpExclude,
+  #   _Reserved_  LPVOID lpReserved
+  # );
+  ffi_lib :kernel32
+  attach_function_private :ReplaceFileW,
+    [:lpcwstr, :lpcwstr, :lpcwstr, :dword, :lpvoid, :lpvoid], :win32_bool
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa365240(v=vs.85).aspx
+  # BOOL WINAPI MoveFileEx(
+  #   _In_      LPCTSTR lpExistingFileName,
+  #   _In_opt_  LPCTSTR lpNewFileName,
+  #   _In_      DWORD dwFlags
+  # );
+  ffi_lib :kernel32
+  attach_function_private :MoveFileExW,
+    [:lpcwstr, :lpcwstr, :dword], :win32_bool
+
+  # BOOLEAN WINAPI CreateSymbolicLink(
+  #   _In_  LPTSTR lpSymlinkFileName, - symbolic link to be created
+  #   _In_  LPTSTR lpTargetFileName, - name of target for symbolic link
+  #   _In_  DWORD dwFlags - 0x0 target is a file, 0x1 target is a directory
+  # );
+  # rescue on Windows < 6.0 so that code doesn't explode
+  begin
+    ffi_lib :kernel32
+    attach_function_private :CreateSymbolicLinkW,
+      [:lpwstr, :lpwstr, :dword], :boolean
+  rescue LoadError
+  end
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa364944(v=vs.85).aspx
+  # DWORD WINAPI GetFileAttributes(
+  #   _In_  LPCTSTR lpFileName
+  # );
+  ffi_lib :kernel32
+  attach_function_private :GetFileAttributesW,
+    [:lpcwstr], :dword
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa365535(v=vs.85).aspx
+  # BOOL WINAPI SetFileAttributes(
+  #   _In_  LPCTSTR lpFileName,
+  #   _In_  DWORD dwFileAttributes
+  # );
+  ffi_lib :kernel32
+  attach_function_private :SetFileAttributesW,
+    [:lpcwstr, :dword], :win32_bool
+
+  # HANDLE WINAPI CreateFile(
+  #   _In_      LPCTSTR lpFileName,
+  #   _In_      DWORD dwDesiredAccess,
+  #   _In_      DWORD dwShareMode,
+  #   _In_opt_  LPSECURITY_ATTRIBUTES lpSecurityAttributes,
+  #   _In_      DWORD dwCreationDisposition,
+  #   _In_      DWORD dwFlagsAndAttributes,
+  #   _In_opt_  HANDLE hTemplateFile
+  # );
+  ffi_lib :kernel32
+  attach_function_private :CreateFileW,
+    [:lpcwstr, :dword, :dword, :pointer, :dword, :dword, :handle], :handle
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa363216(v=vs.85).aspx
+  # BOOL WINAPI DeviceIoControl(
+  #   _In_         HANDLE hDevice,
+  #   _In_         DWORD dwIoControlCode,
+  #   _In_opt_     LPVOID lpInBuffer,
+  #   _In_         DWORD nInBufferSize,
+  #   _Out_opt_    LPVOID lpOutBuffer,
+  #   _In_         DWORD nOutBufferSize,
+  #   _Out_opt_    LPDWORD lpBytesReturned,
+  #   _Inout_opt_  LPOVERLAPPED lpOverlapped
+  # );
+  ffi_lib :kernel32
+  attach_function_private :DeviceIoControl,
+    [:handle, :dword, :lpvoid, :dword, :lpvoid, :dword, :lpdword, :pointer], :win32_bool
+
+  MAXIMUM_REPARSE_DATA_BUFFER_SIZE = 16384
+
+  # REPARSE_DATA_BUFFER
+  # https://msdn.microsoft.com/en-us/library/cc232006.aspx
+  # https://msdn.microsoft.com/en-us/library/windows/hardware/ff552012(v=vs.85).aspx
+  # struct is always MAXIMUM_REPARSE_DATA_BUFFER_SIZE bytes
+  class REPARSE_DATA_BUFFER < FFI::Struct
+    layout :ReparseTag, :win32_ulong,
+           :ReparseDataLength, :ushort,
+           :Reserved, :ushort,
+           :SubstituteNameOffset, :ushort,
+           :SubstituteNameLength, :ushort,
+           :PrintNameOffset, :ushort,
+           :PrintNameLength, :ushort,
+           :Flags, :win32_ulong,
+           # max less above fields dword / uint 4 bytes, ushort 2 bytes
+           # technically a WCHAR buffer, but we care about size in bytes here
+           :PathBuffer, [:byte, MAXIMUM_REPARSE_DATA_BUFFER_SIZE - 20]
+  end
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa364980(v=vs.85).aspx
+  # DWORD WINAPI GetLongPathName(
+  #   _In_  LPCTSTR lpszShortPath,
+  #   _Out_ LPTSTR  lpszLongPath,
+  #   _In_  DWORD   cchBuffer
+  # );
+  ffi_lib :kernel32
+  attach_function_private :GetLongPathNameW,
+    [:lpcwstr, :lpwstr, :dword], :dword
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa364989(v=vs.85).aspx
+  # DWORD WINAPI GetShortPathName(
+  #   _In_  LPCTSTR lpszLongPath,
+  #   _Out_ LPTSTR  lpszShortPath,
+  #   _In_  DWORD   cchBuffer
+  # );
+  ffi_lib :kernel32
+  attach_function_private :GetShortPathNameW,
+    [:lpcwstr, :lpwstr, :dword], :dword
+end

--- a/lib/puppet/util/windows/string.rb
+++ b/lib/puppet/util/windows/string.rb
@@ -1,0 +1,16 @@
+require 'puppet/util/windows'
+
+module Puppet::Util::Windows::String
+  def wide_string(str)
+    # if given a nil string, assume caller wants to pass a nil pointer to win32
+    return nil if str.nil?
+    # ruby (< 2.1) does not respect multibyte terminators, so it is possible
+    # for a string to contain a single trailing null byte, followed by garbage
+    # causing buffer overruns.
+    #
+    # See http://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=41920&view=revision
+    newstr = str + "\0".encode(str.encoding)
+    newstr.encode!('UTF-16LE')
+  end
+  module_function :wide_string
+end

--- a/spec/acceptance/bundle_management_spec.rb
+++ b/spec/acceptance/bundle_management_spec.rb
@@ -15,7 +15,7 @@ describe 'Managing Gemfile dependencies' do
       its(:stderr) { is_expected.to match(%r{Checking for missing Gemfile dependencies}i) }
 
       describe file('Gemfile.lock') do
-        it { pending 'json install requires ruby devkit' if Gem.win_platform?; is_expected.to be_file }
+        it { is_expected.to be_file }
       end
     end
   end

--- a/spec/acceptance/bundle_management_spec.rb
+++ b/spec/acceptance/bundle_management_spec.rb
@@ -15,21 +15,21 @@ describe 'Managing Gemfile dependencies' do
       its(:stderr) { is_expected.to match(%r{Checking for missing Gemfile dependencies}i) }
 
       describe file('Gemfile.lock') do
-        it { is_expected.to be_file }
+        it { pending 'json install requires ruby devkit' if Gem.win_platform?; is_expected.to be_file }
       end
     end
   end
 
   context 'when there is an invalid Gemfile' do
     before(:all) do
-      FileUtils.mv('Gemfile', 'Gemfile.old')
+      FileUtils.mv('Gemfile', 'Gemfile.old', force: true)
       File.open('Gemfile', 'w') do |f|
         f.puts 'not a gemfile'
       end
     end
 
     after(:all) do
-      FileUtils.mv('Gemfile.old', 'Gemfile')
+      FileUtils.mv('Gemfile.old', 'Gemfile', force: true)
     end
 
     describe command('pdk test unit') do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -29,6 +29,10 @@ end
 
 tempdir = nil
 
+# bundler won't install bundler into the --path, so in order to access ::Bundler.with_clean_env
+# from within pdk during spec tests, we have to manually re-add the global gem path :(
+ENV['GEM_PATH'] = [ENV['GEM_PATH'], File.absolute_path(File.join(`bundle show bundler`, '..', '..')).to_s].compact.join(File::PATH_SEPARATOR)
+
 # Save bundle environment from being purged by specinfra. This needs to be repeated for every example, as specinfra does not correctly reset the environment after a `describe command()` block
 # presumably https://github.com/mizzy/specinfra/blob/79b62b37909545b67b7492574a97c300fb1dc91e/lib/specinfra/backend/exec.rb#L143-L165
 bundler_env = {}


### PR DESCRIPTION
PDK::Util.make_tmpdir_name might return a short (8.3) path on Windows.
This commits adds a canonical path method to allow assurance of using
the full path.

This fixes module generation on Windows; previously PDK was failing to
match C:\Users\Administrator and C:\Users\ADMIN~1