### PR TITLE
(MAINT) Create a class-based subprocess executor.

### DIFF
--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -62,7 +62,7 @@ module PDK
           @stderr.sync = true
         end
 
-        def add_spinner(message, opts={})
+        def add_spinner(message, opts = {})
           @success_message = opts.delete(:success)
           @failure_message = opts.delete(:failure)
 
@@ -92,7 +92,7 @@ module PDK
 
           # Stop spinning when done (if configured).
           if @spinner
-            if @process.exit_code == 0 && @success_message
+            if @process.exit_code.zero? && @success_message
               @spinner.success(@success_message)
             elsif @failure_message
               @spinner.error(@failure_message)

--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -77,7 +77,7 @@ module PDK
           @success_message = opts.delete(:success)
           @failure_message = opts.delete(:failure)
 
-          @spinner = TTY::Spinner.new(message, opts)
+          @spinner = TTY::Spinner.new("[:spinner] #{message}", opts)
         end
 
         def execute!
@@ -98,12 +98,10 @@ module PDK
 
           # Stop spinning when done (if configured).
           if @spinner
-            if @process.exit_code.zero? && @success_message
+            if @process.exit_code.zero?
               @spinner.success(@success_message)
-            elsif @failure_message
-              @spinner.error(@failure_message)
             else
-              @spinner.stop
+              @spinner.error(@failure_message)
             end
           end
 

--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -66,11 +66,11 @@ module PDK
         end
 
         def context=(new_context)
-          if %i{system module}.include?(new_context)
-            @context = new_context
-          else
+          unless [:system, :module].include?(new_context)
             raise ArgumentError, _("Expected execution context to be :system or :module but got '%{context}'") % { context: new_contenxt }
           end
+
+          @context = new_context
         end
 
         def add_spinner(message, opts = {})


### PR DESCRIPTION
This provides a better API for setting up sub processes than the existing class/module method based approach.

`PDK::CLI::Exec.execute` is still provided for backwards compatibility and nothing has yet been updated to directly use the new `Command` class.

