### PR TITLE
(SDK-274) Adds --version option

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -7,6 +7,7 @@ require 'pdk/generators/module'
 require 'pdk/i18n'
 require 'pdk/logger'
 require 'pdk/report'
+require 'pdk/version'
 
 module PDK::CLI
   def self.run(args)
@@ -40,6 +41,11 @@ module PDK::CLI
     summary _('Puppet Development Kit')
     description _('The shortest path to better modules.')
     default_subcommand 'help'
+
+    flag nil, :version, _('show version of pdk') do |_, _|
+      puts PDK.version_string
+      exit 0
+    end
 
     flag :h, :help, _('show help for this command') do |_, c|
       puts c.help

--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -7,7 +7,7 @@ require 'pdk/generators/module'
 require 'pdk/i18n'
 require 'pdk/logger'
 require 'pdk/report'
-require 'pdk/version'
+require 'pdk/util/version'
 
 module PDK::CLI
   def self.run(args)
@@ -43,7 +43,7 @@ module PDK::CLI
     default_subcommand 'help'
 
     flag nil, :version, _('show version of pdk') do |_, _|
-      puts PDK.version_string
+      puts PDK::Util::Version.version_string
       exit 0
     end
 

--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -35,6 +35,8 @@ module PDK
 
         module_interview(metadata, opts) unless opts[:'skip-interview'] # @todo Build way to get info by answers file
 
+        metadata.update!('pdk-version' => PDK.version_string)
+
         temp_target_dir = PDK::Util.make_tmpdir_name('pdk-module-target')
 
         prepare_module_directory(temp_target_dir)

--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -9,6 +9,7 @@ require 'pdk/module/templatedir'
 require 'pdk/cli/exec'
 require 'pdk/cli/input'
 require 'pdk/util'
+require 'pdk/util/version'
 
 module PDK
   module Generate
@@ -35,7 +36,7 @@ module PDK
 
         module_interview(metadata, opts) unless opts[:'skip-interview'] # @todo Build way to get info by answers file
 
-        metadata.update!('pdk-version' => PDK.version_string)
+        metadata.update!('pdk-version' => PDK::Util::Version.version_string)
 
         temp_target_dir = PDK::Util.make_tmpdir_name('pdk-module-target')
 

--- a/lib/pdk/util/version.rb
+++ b/lib/pdk/util/version.rb
@@ -1,0 +1,34 @@
+require 'pdk/version'
+require 'pdk/cli/exec'
+
+module PDK
+  module Util
+    module Version
+      def self.version_string
+        "#{PDK::VERSION} #{pdk_ref}".strip.freeze
+      end
+
+      def self.pdk_ref
+        ref = pkg_sha || git_ref
+        ref.nil? ? nil : "(#{ref})"
+      end
+
+      def self.pkg_sha
+        version_file = File.join(File.expand_path('../../..', File.dirname(__FILE__)), 'VERSION')
+
+        if File.exist? version_file
+          ver = File.read(version_file)
+          sha = ver.strip.split('.')[-1] unless ver.nil?
+        end
+
+        sha
+      end
+
+      def self.git_ref
+        ref_result = PDK::CLI::Exec.git('--git-dir', File.join(File.expand_path('../../..', File.dirname(__FILE__)), '.git'), 'describe', '--all', '--long')
+
+        ref_result[:stdout].strip if ref_result[:exit_code].zero?
+      end
+    end
+  end
+end

--- a/lib/pdk/util/version.rb
+++ b/lib/pdk/util/version.rb
@@ -9,8 +9,8 @@ module PDK
       end
 
       def self.pdk_ref
-        ref = pkg_sha || git_ref
-        ref.nil? ? nil : "(#{ref})"
+        ref = "#{pkg_sha} #{git_ref}".strip
+        ref.empty? ? nil : "(#{ref})"
       end
 
       def self.pkg_sha

--- a/lib/pdk/version.rb
+++ b/lib/pdk/version.rb
@@ -1,31 +1,3 @@
-require 'pdk/cli/exec'
-
 module PDK
   VERSION = '0.1.0'.freeze
-
-  def self.version_string
-    "#{VERSION} #{pdk_ref}".strip
-  end
-
-  def self.pdk_ref
-    ref = pkg_sha || git_ref
-    "(#{ref})"
-  end
-
-  def self.pkg_sha
-    version_file = File.join(File.expand_path('../..', File.dirname(__FILE__)), 'VERSION')
-
-    if File.exist? version_file
-      ver = File.read(version_file)
-      sha = ver.strip.split('.')[-1] unless ver.nil?
-    end
-
-    sha
-  end
-
-  def self.git_ref
-    ref_result = PDK::CLI::Exec.git('--git-dir', File.join(File.expand_path('../..', File.dirname(__FILE__)), '.git'), 'describe', '--all', '--long')
-
-    ref_result[:stdout].strip if ref_result[:exit_code].zero?
-  end
 end

--- a/lib/pdk/version.rb
+++ b/lib/pdk/version.rb
@@ -1,3 +1,31 @@
+require 'pdk/cli/exec'
+
 module PDK
   VERSION = '0.1.0'.freeze
+
+  def self.version_string
+    "#{VERSION} #{pdk_ref}".strip
+  end
+
+  def self.pdk_ref
+    ref = pkg_sha || git_ref
+    "(#{ref})"
+  end
+
+  def self.pkg_sha
+    version_file = File.join(File.expand_path('../..', File.dirname(__FILE__)), 'VERSION')
+
+    if File.exist? version_file
+      ver = File.read(version_file)
+      sha = ver.strip.split('.')[-1] unless ver.nil?
+    end
+
+    sha
+  end
+
+  def self.git_ref
+    ref_result = PDK::CLI::Exec.git('--git-dir', File.join(File.expand_path('../..', File.dirname(__FILE__)), '.git'), 'describe', '--all', '--long')
+
+    ref_result[:stdout].strip if ref_result[:exit_code].zero?
+  end
 end


### PR DESCRIPTION
To allow easy checking and reporting of the current pdk version, {{--version}} should report the installed version of PDK, as well as the vanagon build SHA from a built package or the git ref from a local git repo.