### PR TITLE
(maint) Guard PDK::Util::Bundle.ensure_bundle! to only run once

### DIFF
--- a/spec/util/bundler_spec.rb
+++ b/spec/util/bundler_spec.rb
@@ -66,9 +66,16 @@ RSpec.describe PDK::Util::Bundler do
       end
 
       it 'installs missing gems' do
+        allow(described_class).to receive(:already_bundled?).and_return(false)
         expect_command([bundle_regex, 'install', any_args])
 
         expect { described_class.ensure_bundle! }.to output(%r{installing missing gemfile}i).to_stderr
+      end
+
+      it 'only attempts to install the gems once' do
+        expect(PDK::CLI::Exec::Command).not_to receive(:new)
+        expect(logger).to receive(:debug).with(%r{already been installed})
+        expect { described_class.ensure_bundle! }.to output(%r{\A\Z}).to_stderr
       end
     end
 
@@ -79,6 +86,7 @@ RSpec.describe PDK::Util::Bundler do
       end
 
       it 'checks for missing but does not install anything' do
+        allow(described_class).to receive(:already_bundled?).and_return(false)
         expect_command([bundle_regex, 'check', any_args])
 
         expect(PDK::CLI::Exec::Command).not_to receive(:new).with(bundle_regex, 'install', any_args)


### PR DESCRIPTION
Adds a guard into `PDK::Util::Bundle.ensure_bundle!` so that it more or less idempotent. We'll need to be calling this in multiple places when we shell out to commands inside the bundle and although this method won't actually change anything on subsequent executions as it is, it will cause the spinner to be displayed multiple times.