### PR TITLE
(SDK-137) Adds Puppet Parser syntax validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in pdk.gemspec
 gemspec
 
-gem 'metadata-json-lint'
-gem 'puppet-lint'
-
 # avoid newer versions that do not support ruby 2.1 anymore
 gem 'nokogiri', '1.7.2'
 

--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -10,7 +10,6 @@ module PDK::CLI
     flag nil, :list, _('list all available validators')
 
     run do |opts, args, _cmd|
-
       validator_names = PDK::Validate.validators.map { |v| v.name }
       validators = PDK::Validate.validators
       targets = []

--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -1,3 +1,5 @@
+require 'pdk/util/bundler'
+
 module PDK::CLI
   @validate_cmd = @base_cmd.define_command do
     name 'validate'
@@ -8,7 +10,6 @@ module PDK::CLI
     flag nil, :list, _('list all available validators')
 
     run do |opts, args, _cmd|
-      require 'pdk/validate'
 
       validator_names = PDK::Validate.validators.map { |v| v.name }
       validators = PDK::Validate.validators
@@ -62,6 +63,9 @@ module PDK::CLI
       options = targets.empty? ? {} : { targets: targets }
 
       exit_code = 0
+
+      # Ensure that the bundle is installed and tools are available before running any validations.
+      PDK::Util::Bundler.ensure_bundle!
 
       validators.each do |validator|
         exit_code = validator.invoke(report, options)

--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -21,7 +21,7 @@ module PDK
           'name'         => "#{Etc.getlogin}-#{opts[:name]}",
           'version'      => '0.1.0',
           'dependencies' => [
-            { 'name' => 'puppetlabs-stdlib', 'version_requirement' => '>= 1.0.0' },
+            { 'name' => 'puppetlabs-stdlib', 'version_requirement' => '>= 4.13.1 < 5.0.0' },
           ],
         }
 
@@ -112,11 +112,11 @@ module PDK
         end
 
         puts ''
-        module_summary = PDK::CLI::Input.get(_('How would you describe this module in a single sentence?'))
+        module_summary = PDK::CLI::Input.get(_('How would you describe this module in a single sentence?'), metadata.data['summary'])
         metadata.update!('summary' => module_summary)
 
         puts ''
-        module_source = PDK::CLI::Input.get(_("Where is this module's source code repository?"))
+        module_source = PDK::CLI::Input.get(_("Where is this module's source code repository?"), metadata.data['source'])
         metadata.update!('source' => module_source)
 
         puts ''

--- a/lib/pdk/validators/base_validator.rb
+++ b/lib/pdk/validators/base_validator.rb
@@ -38,7 +38,7 @@ module PDK
         _('Invoking %{cmd}') % { cmd: cmd }
       end
 
-      def self.invoke(options = {})
+      def self.invoke(report, options = {})
         PDK::Util::Bundler.ensure_binstubs!(cmd)
 
         targets = parse_targets(options)

--- a/lib/pdk/validators/base_validator.rb
+++ b/lib/pdk/validators/base_validator.rb
@@ -20,7 +20,8 @@ module PDK
         targets.map { |target|
           if respond_to?(:pattern)
             if File.directory?(target)
-              Array[pattern].flatten.map { |p| Dir.glob(File.join(target, p)) }
+              files_glob = Array[pattern].flatten.map { |p| Dir.glob(File.join(target, p)) }
+              files_glob.flatten.empty? ? target : files_glob
             else
               target
             end

--- a/lib/pdk/validators/base_validator.rb
+++ b/lib/pdk/validators/base_validator.rb
@@ -4,6 +4,10 @@ require 'pdk/cli/exec'
 module PDK
   module Validate
     class BaseValidator
+      def self.cmd_path
+        File.join(PDK::Util.module_root, 'bin', cmd)
+      end
+
       def self.parse_targets(options)
         # If no targets are specified, then we will run validations from the
         # base module directory.
@@ -34,12 +38,11 @@ module PDK
         _('Invoking %{cmd}') % { cmd: cmd }
       end
 
-      def self.invoke(report, options = {})
-        PDK::Util::Bundler.ensure_bundle!
-        PDK::Util::Bundler.ensure_binstubs!(name)
+      def self.invoke(options = {})
+        PDK::Util::Bundler.ensure_binstubs!(cmd)
 
         targets = parse_targets(options)
-        cmd_argv = parse_options(options, targets).unshift(cmd)
+        cmd_argv = parse_options(options, targets).unshift(cmd_path)
         cmd_argv.unshift('ruby') if Gem.win_platform?
 
         PDK.logger.debug(_('Running %{cmd}') % { cmd: cmd_argv.join(' ') })

--- a/lib/pdk/validators/metadata.rb
+++ b/lib/pdk/validators/metadata.rb
@@ -17,6 +17,30 @@ module PDK
       def self.parse_targets(options)
         [File.join(PDK::Util.module_root, 'metadata.json')]
       end
+
+      def self.parse_options(_options, targets)
+        cmd_options = ['--format', 'json']
+
+        cmd_options.concat(targets)
+      end
+
+      def self.parse_output(report, json_data)
+        return if json_data.empty?
+
+        json_data.delete('result')
+        json_data.keys.each do |type|
+          json_data[type].each do |offense|
+            report.add_event(
+              file:     'metadata.json',
+              source:   cmd,
+              message:  offense['msg'],
+              test:     offense['check'],
+              severity: type,
+              state:    type == 'errors' ? :failure : :passed
+            )
+          end
+        end
+      end
     end
   end
 end

--- a/lib/pdk/validators/metadata.rb
+++ b/lib/pdk/validators/metadata.rb
@@ -11,21 +11,11 @@ module PDK
       end
 
       def self.cmd
-        File.join(PDK::Util.module_root, 'bin', 'metadata-json-lint')
+        'metadata-json-lint'
       end
 
-      def self.invoke(_report, options = {})
-        PDK::Util::Bundler.ensure_bundle!
-        PDK::Util::Bundler.ensure_binstubs!('metadata-json-lint')
-
-        options[:targets] = [File.join(PDK::Util.module_root, 'metadata.json')]
-
-        # result = super
-
-        # FIXME: this is weird so that it complies with the format
-        # of the other validators which are nested
-        # { 'metadata' => result }
-        0
+      def self.parse_targets(options)
+        [File.join(PDK::Util.module_root, 'metadata.json')]
       end
     end
   end

--- a/lib/pdk/validators/metadata.rb
+++ b/lib/pdk/validators/metadata.rb
@@ -14,7 +14,7 @@ module PDK
         'metadata-json-lint'
       end
 
-      def self.parse_targets(options)
+      def self.parse_targets(_options)
         [File.join(PDK::Util.module_root, 'metadata.json')]
       end
 
@@ -36,7 +36,7 @@ module PDK
               message:  offense['msg'],
               test:     offense['check'],
               severity: type,
-              state:    :failure
+              state:    :failure,
             )
           end
         end

--- a/lib/pdk/validators/metadata.rb
+++ b/lib/pdk/validators/metadata.rb
@@ -36,7 +36,7 @@ module PDK
               message:  offense['msg'],
               test:     offense['check'],
               severity: type,
-              state:    type == 'errors' ? :failure : :passed
+              state:    :failure
             )
           end
         end

--- a/lib/pdk/validators/puppet/puppet_lint.rb
+++ b/lib/pdk/validators/puppet/puppet_lint.rb
@@ -11,7 +11,7 @@ module PDK
       end
 
       def self.cmd
-        File.join(PDK::Util.module_root, 'bin', 'puppet-lint')
+        'puppet-lint'
       end
 
       def self.pattern

--- a/lib/pdk/validators/puppet/puppet_parser.rb
+++ b/lib/pdk/validators/puppet/puppet_parser.rb
@@ -10,7 +10,11 @@ module PDK
       end
 
       def self.cmd
-        'pwd'
+        'puppet'
+      end
+
+      def self.parse_options(_options, targets)
+        ['parser', 'validate'].concat(targets)
       end
     end
   end

--- a/lib/pdk/validators/puppet/puppet_parser.rb
+++ b/lib/pdk/validators/puppet/puppet_parser.rb
@@ -13,8 +13,20 @@ module PDK
         'puppet'
       end
 
+      def self.pattern
+        '**/**.pp'
+      end
+
+      def self.spinner_text
+        _('Checking Puppet manifest syntax')
+      end
+
       def self.parse_options(_options, targets)
         ['parser', 'validate'].concat(targets)
+      end
+
+      def self.parse_output(report, json_data)
+        return
       end
     end
   end

--- a/lib/pdk/validators/puppet/puppet_parser.rb
+++ b/lib/pdk/validators/puppet/puppet_parser.rb
@@ -22,11 +22,12 @@ module PDK
       end
 
       def self.parse_options(_options, targets)
-        ['parser', 'validate'].concat(targets)
+        %w[parser validate].concat(targets)
       end
 
-      def self.parse_output(report, json_data)
-        return
+      def self.parse_output(report, _json_data)
+        # TODO: handle outputs
+        report.add_event(result.merge(state: :passed, severity: :ok))
       end
     end
   end

--- a/lib/pdk/validators/puppet_validator.rb
+++ b/lib/pdk/validators/puppet_validator.rb
@@ -12,7 +12,7 @@ module PDK
       end
 
       def self.puppet_validators
-        [PuppetLint]
+        [PuppetLint, PuppetParser]
       end
 
       def self.invoke(report, options = {})

--- a/lib/pdk/validators/ruby/rubocop.rb
+++ b/lib/pdk/validators/ruby/rubocop.rb
@@ -13,7 +13,7 @@ module PDK
       end
 
       def self.cmd
-        File.join(PDK::Util.module_root, 'bin', 'rubocop')
+        'rubocop'
       end
 
       def self.spinner_text
@@ -24,13 +24,6 @@ module PDK
         cmd_options = ['--format', 'json']
 
         cmd_options.concat(targets)
-      end
-
-      def self.invoke(report, options = {})
-        PDK::Util::Bundler.ensure_bundle!
-        PDK::Util::Bundler.ensure_binstubs!('rubocop')
-
-        super
       end
 
       def self.parse_output(report, json_data)

--- a/spec/cli/validate_spec.rb
+++ b/spec/cli/validate_spec.rb
@@ -8,6 +8,10 @@ describe 'Running `pdk validate` in a module' do
   let(:validator_names) { validators.map(&:name).join(', ') }
   let(:validator_success) { { exit_code: 0, stdout: 'success', stderr: '' } }
 
+  before(:each) do
+    allow(PDK::Util::Bundler).to receive(:ensure_bundle!)
+  end
+
   context 'when no arguments or options are provided' do
     it 'invokes each validator with no report and no options and exits zero' do
       validators.each do |validator|


### PR DESCRIPTION
Adds validation for puppet syntax using `puppet parser validate`.

This PR also includes various cleanups and refactoring of the validation handlers.