### PR TITLE
(SDK-285) Add --auto-correct flag to validators that support it

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ Running validations on `new_module`:
 [...]
 ```
 
+Some validators support automatic correction of detected problems (for example,
+both rubocop and puppet-lint can automatically correct many common code style
+problems). To enable this functionality, run `pdk validate` with the
+`--auto-correct` option.
+
+```
+$ pdk validate --auto-correct
+pdk (INFO): Running all available validators...
+[✔] Checking for missing Gemfile dependencies
+[✔] Checking metadata.json
+[✔] Checking Puppet manifest style
+[✔] Checking Puppet manifest syntax
+[✔] Checking Ruby code style
+manifests/init.pp:1:10: corrected: double quoted string containing no variables
+```
+
 ### Run unit tests
 
 The default template sets up [rspec](http://rspec.info/) for Ruby-level unit testing, and [rspec-puppet](https://github.com/rodjek/rspec-puppet/) for catalog-level unit testing.

--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -8,6 +8,7 @@ module PDK::CLI
     description _('Run metadata, puppet, or ruby validation.')
 
     flag nil, :list, _('list all available validators')
+    flag :a, 'auto-correct', _('automatically correct problems (where possible)')
 
     run do |opts, args, _cmd|
       validator_names = PDK::Validate.validators.map { |v| v.name }
@@ -62,6 +63,7 @@ module PDK::CLI
                        end
 
       options = targets.empty? ? {} : { targets: targets }
+      options[:auto_correct] = true if opts.key?(:'auto-correct')
 
       exit_code = 0
 

--- a/lib/pdk/validators/puppet/puppet_lint.rb
+++ b/lib/pdk/validators/puppet/puppet_lint.rb
@@ -22,8 +22,10 @@ module PDK
         _('Checking Puppet manifest style')
       end
 
-      def self.parse_options(_options, targets)
+      def self.parse_options(options, targets)
         cmd_options = ['--json']
+
+        cmd_options << '--fix' if options[:auto_correct]
 
         cmd_options.concat(targets)
       end
@@ -49,7 +51,7 @@ module PDK
             column:   offense['column'],
             message:  offense['message'],
             test:     offense['check'],
-            severity: offense['kind'],
+            severity: (offense['kind'] == 'fixed') ? 'corrected' : offense['kind'],
             state:    :failure,
           )
         end

--- a/lib/pdk/validators/ruby/rubocop.rb
+++ b/lib/pdk/validators/ruby/rubocop.rb
@@ -20,8 +20,12 @@ module PDK
         _('Checking Ruby code style')
       end
 
-      def self.parse_options(_options, targets)
+      def self.parse_options(options, targets)
         cmd_options = ['--format', 'json']
+
+        if options[:auto_correct]
+          cmd_options << '--auto-correct'
+        end
 
         cmd_options.concat(targets)
       end
@@ -45,7 +49,7 @@ module PDK
                   line:     offense['location']['line'],
                   column:   offense['location']['column'],
                   message:  offense['message'],
-                  severity: offense['severity'],
+                  severity: (offense['corrected']) ? 'corrected' : offense['severity'],
                   test:     offense['cop_name'],
                   state:    :failure,
                 ),

--- a/spec/acceptance/support/in_a_new_module.rb
+++ b/spec/acceptance/support/in_a_new_module.rb
@@ -1,7 +1,11 @@
+require 'open3'
 
 shared_context 'in a new module' do |name|
   before(:all) do
-    system("pdk new module #{name} --skip-interview") || raise
+    output, status = Open3.capture2e('pdk', 'new', 'module', name, '--skip-interview')
+
+    raise "Failed to create test module:\n#{output}" unless status.success?
+
     Dir.chdir(name)
   end
 

--- a/spec/acceptance/validate_puppet_spec.rb
+++ b/spec/acceptance/validate_puppet_spec.rb
@@ -222,4 +222,29 @@ describe 'pdk validate puppet', module_command: true do
       end
     end
   end
+
+  context 'when auto-correcting manifest style problems' do
+    include_context 'in a new module', 'foo'
+
+    before(:all) do
+      File.open(example_pp, 'w') do |f|
+        f.puts 'notify { "test": }'
+      end
+    end
+
+    describe command('pdk validate puppet') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stdout) { is_expected.to match(%r{^#{Regexp.escape(example_pp)}.*warning.*double quoted string}) }
+    end
+
+    describe command('pdk validate puppet --auto-correct') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stdout) { is_expected.to match(%r{^#{Regexp.escape(example_pp)}.*corrected.*double quoted string}) }
+    end
+
+    describe command('pdk validate puppet') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stdout) { is_expected.to match(empty_string) }
+    end
+  end
 end

--- a/spec/acceptance/validate_ruby_spec.rb
+++ b/spec/acceptance/validate_ruby_spec.rb
@@ -120,4 +120,29 @@ describe 'pdk validate ruby', module_command: true do
       end
     end
   end
+
+  context 'when auto-correcting violations' do
+    include_context 'in a new module', 'foo'
+
+    before(:all) do
+      File.open('test.rb', 'w') do |f|
+        f.puts "puts({'a' => 'b'}.inspect)"
+      end
+    end
+
+    describe command('pdk validate ruby') do
+      its(:exit_status) { is_expected.not_to eq(0) }
+      its(:stdout) { is_expected.to match(%r{^test\.rb.*space inside (\{|\}) missing}i) }
+    end
+
+    describe command('pdk validate ruby --auto-correct') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stdout) { is_expected.to match(%r{^test\.rb.*corrected.*space inside (\{|\}) missing}i) }
+    end
+
+    describe command('pdk validate ruby') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stdout) { is_expected.to match(%r{\A\Z}) }
+    end
+  end
 end


### PR DESCRIPTION
This will just silently no-op for validators that don't support auto correction. There's no acceptance tests for puppet-lint integration at the moment, so I've only added an acceptance test for auto-correcting rubocop violations.