### PR TITLE
(SDK-148) Implement pdk test unit --list

### DIFF
--- a/lib/pdk/cli/test/unit.rb
+++ b/lib/pdk/cli/test/unit.rb
@@ -24,27 +24,34 @@ module PDK::CLI
       report = nil
 
       if opts[:list]
-        puts _('List of all available unit tests: (TODO)')
-        exit 0
+        examples = PDK::Test::Unit.list
+        if examples.empty?
+          puts _('No examples found.')
+        else
+          puts _('Examples:')
+          examples.each do |example|
+            puts _("%{id}\t%{description}" % { id: example[:id], description: example[:full_description] })
+          end
+        end
+      else
+        report = PDK::Report.new
+        report_formats = if opts[:format]
+                           PDK::CLI::Util::OptionNormalizer.report_formats(opts[:format])
+                         else
+                           [{
+                             method: PDK::Report.default_format,
+                             target: PDK::Report.default_target,
+                           }]
+                         end
+
+        exit_code = PDK::Test::Unit.invoke(report, opts)
+
+        report_formats.each do |format|
+          report.send(format[:method], format[:target])
+        end
+
+        exit exit_code
       end
-
-      report = PDK::Report.new
-      report_formats = if opts[:format]
-                         PDK::CLI::Util::OptionNormalizer.report_formats(opts[:format])
-                       else
-                         [{
-                           method: PDK::Report.default_format,
-                           target: PDK::Report.default_target,
-                         }]
-                       end
-
-      exit_code = PDK::Test::Unit.invoke(report, opts)
-
-      report_formats.each do |format|
-        report.send(format[:method], format[:target])
-      end
-
-      exit exit_code
     end
   end
 end

--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -1,6 +1,7 @@
 require 'pdk'
 require 'pdk/cli/exec'
 require 'pdk/util/bundler'
+require 'json'
 
 module PDK
   module Test
@@ -96,6 +97,34 @@ module PDK
           failures: json_data['summary']['failure_count'],
           pending: json_data['summary']['pending_count'],
         }
+      end
+
+      # @return array of { :id, :full_description }
+      def self.list
+        PDK::Util::Bundler.ensure_bundle!
+        PDK::Util::Bundler.ensure_binstubs!('rspec-core')
+
+        command_argv = [File.join(PDK::Util.module_root, 'bin', 'rspec'), '--dry-run', '--format', 'json']
+        command_argv.unshift('ruby') if Gem.win_platform?
+        list_command = PDK::CLI::Exec::Command.new(*command_argv)
+        list_command.context = :module
+        output = list_command.execute!
+
+        rspec_json_output = JSON.parse(output[:stdout])
+        if rspec_json_output['examples'].empty?
+          rspec_message = rspec_json_output['messages'][0]
+          return [] if rspec_message == 'No examples found.'
+
+          raise PDK::CLI::FatalError, _('Unable to enumerate examples. rspec reported: %{message}' % { message: rspec_message })
+        else
+          examples = []
+          rspec_json_output['examples'].each do |example|
+            examples << { id: example['id'], full_description: example['full_description'] }
+          end
+          examples
+        end
+      rescue JSON::ParserError => e
+        raise PDK::CLI::FatalError, _('Failed to parse output from rspec: %{message}' % { message: e.message })
       end
     end
   end

--- a/spec/acceptance/test_unit_spec.rb
+++ b/spec/acceptance/test_unit_spec.rb
@@ -5,6 +5,11 @@ describe 'Running unit tests' do
   context 'with a fresh module' do
     include_context 'in a new module', 'unit_test_module_new'
 
+    describe command('pdk test unit --list') do
+      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to match(%r{No examples found}) }
+    end
+
     describe command('pdk test unit') do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to match(%r{running unit tests}i) }
@@ -22,18 +27,29 @@ describe 'Running unit tests' do
         f.puts <<-EOF
           require 'spec_helper'
 
-          RSpec.describe 'test' do
-            it 'should pass' do
-              expect(true).to eq(true)
+          RSpec.describe 'passing test' do
+            on_supported_os.each do |os, facts|
+              context "On OS \#{os}" do
+                it 'should pass' do
+                  expect(true).to eq(true)
+                end
+              end
             end
           end
         EOF
       end
     end
 
+    describe command('pdk test unit --list') do
+      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to match(%r{Examples:.*passing_spec.rb\[1:1:1\]}m) }
+      its(:stdout) { is_expected.to match(%r{passing_spec.rb\[1:2:1\]}) }
+      its(:stdout) { is_expected.to match(%r{passing_spec.rb\[1:3:1\]}) }
+    end
+
     describe command('pdk test unit') do
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stderr) { is_expected.to match(%r{running unit tests.*1 tests.*0 failures}im) }
+      its(:stderr) { is_expected.to match(%r{running unit tests.*3 tests.*0 failures}im) }
     end
   end
 
@@ -84,6 +100,41 @@ describe 'Running unit tests' do
     describe command('pdk test unit') do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to match(%r{running unit tests.*1 tests.*0 failures.*1 pending}im) }
+    end
+  end
+
+  context 'with syntax errors' do
+    include_context 'in a new module', 'unit_test_module_pending'
+
+    before(:all) do
+      FileUtils.mkdir_p('spec/unit')
+      spec_file = File.join('spec/unit/syntax_spec.rb')
+      File.open(spec_file, 'w') do |f|
+        f.puts <<-EOF
+          require 'spec_helper'
+
+          RSpec.describe 'syntax error' do
+            on_supported_os.each do |os, facts|
+              context "On OS \#{os}" # THIS LINE IS BAD
+                it 'should return a blank instance' do
+                  Hash.new.should == {}
+                end
+              end
+            end
+          end
+        EOF
+      end
+    end
+
+    describe command('pdk test unit --list') do
+      its(:exit_status) { is_expected.not_to eq(0) }
+      its(:stdout) { is_expected.to match(%r{Unable to enumerate examples.*SyntaxError}m) }
+    end
+
+    describe command('pdk test unit') do
+      its(:exit_status) { is_expected.not_to eq(0) }
+      its(:stderr) { is_expected.to match(%r{An error occurred while loading.*syntax_spec.rb}) }
+      its(:stderr) { is_expected.to match(%r{SyntaxError}) }
     end
   end
 end


### PR DESCRIPTION
Implements the _pdk test unit --list_ option that outputs a list of the module's spec tests