### PR TITLE
(maint) Make binstub generation quiet unless it fails

### DIFF
--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -149,15 +149,12 @@ module PDK
         protected
 
         def run_process!
+          command_string = argv.join(' ')
+          PDK.logger.debug(_("Executing '%{command}'") % { command: command_string })
           begin
             @process.start
           rescue ChildProcess::LaunchError => e
-            msg = if @process.respond_to?(:argv)
-                    _("Failed to execute '%{command}': %{message}") % { command: @process.argv.join(' '), message: e.message }
-                  else
-                    _('Failed to execute process: %{message}') % { message: e.message }
-                  end
-            raise PDK::CLI::FatalError, msg
+            raise PDK::CLI::FatalError, _("Failed to execute '%{command}': %{message}") % { command: command_string, message: e.message }
           end
 
           if timeout

--- a/lib/pdk/util/bundler.rb
+++ b/lib/pdk/util/bundler.rb
@@ -107,13 +107,12 @@ module PDK
         end
 
         def binstubs!(gems)
-          command = bundle_command('binstubs', gems.join(' '), '--force').tap do |c|
-            c.add_spinner(_('Checking for required Bundler binstubs'))
-          end
+          command = bundle_command('binstubs', gems.join(' '), '--force')
 
           result = command.execute!
 
           unless result[:exit_code].zero?
+            PDK.logger.error(_('Failed to generate binstubs for %{gems}') % { gems: gems.join(' ') })
             $stderr.puts result[:stdout]
             $stderr.puts result[:stderr]
           end

--- a/lib/pdk/validators/base_validator.rb
+++ b/lib/pdk/validators/base_validator.rb
@@ -47,8 +47,6 @@ module PDK
         cmd_argv = parse_options(options, targets).unshift(cmd_path)
         cmd_argv.unshift('ruby') if Gem.win_platform?
 
-        PDK.logger.debug(_('Running %{cmd}') % { cmd: cmd_argv.join(' ') })
-
         command = PDK::CLI::Exec::Command.new(*cmd_argv).tap do |c|
           c.context = :module
           c.add_spinner(spinner_text)


### PR DESCRIPTION
Currently, the output of the validators is overly noisy. Each validator needs to ensure the presence of its appropriate binstub, which prints a "Checking for required Bundler binstubs" spinner for each validator.

```
$ ../bin/pdk validate
pdk (INFO): Running all available validators...
[✔] Checking for missing Gemfile dependencies
[✔] Checking for required Bundler binstubs
[✔] Checking metadata.json
[✔] Checking for required Bundler binstubs
[✔] Checking Puppet manifest style
[✔] Checking for required Bundler binstubs
[✔] Checking Puppet manifest syntax
[✔] Checking for required Bundler binstubs
[✔] Checking Ruby code style
```

This change instead makes the binstub generation silent unless it fails, as binstub generation is quick and is an implementation detail that the user shouldn't have to care about.

```
$ ../bin/pdk validate
pdk (INFO): Running all available validators...
[✔] Checking for missing Gemfile dependencies
[✔] Checking metadata.json
[✔] Checking Puppet manifest style
[✔] Checking Puppet manifest syntax
[✔] Checking Ruby code style
```