### PR TITLE
(maint) Support for skipped/pending tests

### DIFF
--- a/lib/pdk/report.rb
+++ b/lib/pdk/report.rb
@@ -59,6 +59,7 @@ module PDK
         testsuite.attributes['tests'] = testcases.length
         testsuite.attributes['errors'] = testcases.select(&:error?).length
         testsuite.attributes['failures'] = testcases.select(&:failure?).length
+        testsuite.attributes['skipped'] = testcases.select(&:skipped?).length
         testsuite.attributes['time'] = 0
         testsuite.attributes['timestamp'] = Time.now.strftime('%Y-%m-%dT%H:%M:%S')
         testsuite.attributes['hostname'] = Socket.gethostname

--- a/lib/pdk/report/event.rb
+++ b/lib/pdk/report/event.rb
@@ -81,6 +81,7 @@ module PDK
       end
 
       # Checks if the event is the result of test that was not run.
+      # This includes pending tests (that are run but have an expected failure result).
       #
       # @return [Boolean] true if the test was skipped, otherwise false.
       def skipped?

--- a/spec/fixtures/JUnit.xsd
+++ b/spec/fixtures/JUnit.xsd
@@ -4,7 +4,7 @@
 	 elementFormDefault="qualified"
 	 attributeFormDefault="unqualified">
 	<xs:annotation>
-		<xs:documentation xml:lang="en">JUnit test result schema for the Apache Ant JUnit and JUnitReport tasks
+		<xs:documentation xml:lang="en">Derived from JUnit test result schema for the Apache Ant JUnit and JUnitReport tasks
 Copyright © 2011, Windy Road Technology Pty. Limited
 The Apache Ant JUnit XML Schema is distributed under the terms of the Apache License Version 2.0 http://www.apache.org/licenses/
 Permission to waive conditions of this license may be requested from Windy Road Support (http://windyroad.org/support).</xs:documentation>
@@ -113,6 +113,11 @@ Permission to waive conditions of this license may be requested from Windy Road 
 								</xs:simpleContent>
 							</xs:complexType>
 						</xs:element>
+                                                <xs:element name="skipped">
+                        <xs:annotation>
+                                <xs:documentation xml:lang="en">Indicates that the test was skipped. A skipped test is a test that the test runner evaluates it can skip execution without reaching a pass or failure result.</xs:documentation>
+                        </xs:annotation>
+                                                </xs:element>
 					</xs:choice>
 					<xs:attribute name="name" type="xs:token" use="required">
 						<xs:annotation>
@@ -192,6 +197,11 @@ Permission to waive conditions of this license may be requested from Windy Road 
 				<xs:documentation xml:lang="en">The total number of tests in the suite that errored. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
+                <xs:attribute name="skipped" type="xs:int" use="required">
+                        <xs:annotation>
+                                <xs:documentation xml:lang="en">The total number of tests in the suite that were skipped. A skipped test is one that is not expected to currently pass or fail e.g. the feature tested is not complete, or the test is not applicable for the current test environment.</xs:documentation>
+                        </xs:annotation>
+                </xs:attribute>
 		<xs:attribute name="time" type="xs:decimal" use="required">
 			<xs:annotation>
 				<xs:documentation xml:lang="en">Time taken (in seconds) to execute the tests in the suite</xs:documentation>


### PR DESCRIPTION
Documents that skipped tests will include rspec pending examples.
Adds skipped tests to our XML reports
Updates the test fixture XML schema to allow for skipped tests