### PR TITLE
(SDK-147) Improve text report formatting

### DIFF
--- a/lib/pdk/report/event.rb
+++ b/lib/pdk/report/event.rb
@@ -95,8 +95,10 @@ module PDK
         location = [file, line, column].compact.join(':')
         location = nil if location.empty?
 
-        # TODO: maybe add trace
-        [location, severity, message].compact.join(': ')
+        result = [location, severity, test].compact.join(': ')
+        result += "\n--> " + message if message
+        result += "\n" + trace.join("\n") if trace
+        result
       end
 
       # Renders the event as a JUnit XML testcase.

--- a/spec/acceptance/validate_metadata_spec.rb
+++ b/spec/acceptance/validate_metadata_spec.rb
@@ -46,7 +46,7 @@ describe 'Running metadata validation' do
 
     describe command('pdk validate metadata') do
       its(:exit_status) { is_expected.not_to eq(0) }
-      its(:stdout) { is_expected.to match(%r{^metadata\.json:.+warning.+open ended dependency}) }
+      its(:stdout) { is_expected.to match(%r{^metadata\.json:.+warning.+open ended dependency}m) }
       its(:stderr) { is_expected.to match(spinner_text) }
     end
 

--- a/spec/acceptance/validate_puppet_spec.rb
+++ b/spec/acceptance/validate_puppet_spec.rb
@@ -159,7 +159,7 @@ class foo {
 
     describe command('pdk validate puppet') do
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stdout) { is_expected.to match(%r{^#{Regexp.escape(init_pp)}.+class not documented}i) }
+      its(:stdout) { is_expected.to match(%r{^#{Regexp.escape(init_pp)}.+class not documented}mi) }
       its(:stderr) { is_expected.to match(syntax_spinner_text) }
       its(:stderr) { is_expected.to match(lint_spinner_text) }
     end
@@ -279,7 +279,7 @@ class foo {
 
     describe command('pdk validate puppet') do
       its(:exit_status) { is_expected.not_to eq(0) }
-      its(:stdout) { is_expected.to match(%r{#{Regexp.escape(example_pp)}.+autoload module layout}i) }
+      its(:stdout) { is_expected.to match(%r{#{Regexp.escape(example_pp)}.+autoload module layout}mi) }
       its(:stderr) { is_expected.to match(syntax_spinner_text) }
       its(:stderr) { is_expected.to match(lint_spinner_text) }
     end

--- a/spec/acceptance/validate_ruby_spec.rb
+++ b/spec/acceptance/validate_ruby_spec.rb
@@ -61,7 +61,7 @@ describe 'pdk validate ruby', module_command: true do
 
     describe command('pdk validate ruby') do
       its(:exit_status) { is_expected.not_to eq(0) }
-      its(:stdout) { is_expected.to match(%r{#{Regexp.escape(spec_violation_rb)}.*useless assignment}i) }
+      its(:stdout) { is_expected.to match(%r{#{Regexp.escape(spec_violation_rb)}.*useless assignment}mi) }
       its(:stderr) { is_expected.to match(%r{Checking Ruby code style}i) }
     end
 

--- a/spec/pdk/report/event_spec.rb
+++ b/spec/pdk/report/event_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe PDK::Report::Event do
-  subject(:junit_event) { event.to_junit }
-
-  subject(:text_event) { event.to_text }
-
   subject { event }
 
   let(:event) { described_class.new(default_data.merge(data)) }
@@ -301,7 +297,11 @@ describe PDK::Report::Event do
   end
 
   context 'when generating text output' do
+    subject(:text_event) { event.to_text }
+
     it 'contains the file name at the start of the string' do
+      # puts text_event
+      # require'pry';binding.pry
       expect(text_event).to match(%r{\Atestfile\.rb})
     end
 
@@ -350,7 +350,7 @@ describe PDK::Report::Event do
       end
 
       it 'includes the message at the end of the string' do
-        expect(text_event).to match(%r{\Atestfile\.rb: test message\Z})
+        expect(text_event).to match(%r{\Atestfile\.rb.*test message\Z}m)
       end
 
       context 'and a severity is provided' do
@@ -362,13 +362,15 @@ describe PDK::Report::Event do
         end
 
         it 'includes the severity before the message' do
-          expect(text_event).to match(%r{\Atestfile\.rb: critical: test message\Z})
+          expect(text_event).to match(%r{\Atestfile\.rb: critical.*test message\Z}m)
         end
       end
     end
   end
 
   context 'when generating junit output' do
+    subject(:junit_event) { event.to_junit }
+
     it 'sets the classname attribute to the event source' do
       expect(junit_event.attributes['classname']).to eq('test-validator')
     end
@@ -472,7 +474,7 @@ describe PDK::Report::Event do
       end
 
       it 'puts a textual representation of the event into the failure element' do
-        expect(junit_event.children.first.text).to eq(text_event)
+        expect(junit_event.children.first.text).to eq(event.to_text)
       end
     end
   end


### PR DESCRIPTION
This changes the default output to this:

```
$ pdk test unit
[✔] Checking for missing Gemfile dependencies
[✔] Checking for required Bundler binstubs
[✖] Running unit tests
  Evaluated 3 tests in 0.260818434 seconds: 3 failures, 0 pending
./spec/classes/foo_spec.rb:8: failed: foo on debian-8-x86_64 should not compile into a catalogue without dependency cycles
--> expected that the catalogue would not compile but it does
/home/david/git/pdk/foo/spec/classes/foo_spec.rb:8:in `block (4 levels) in <top (required)>'
./spec/classes/foo_spec.rb:8: failed: foo on ubuntu-16.04-x86_64 should not compile into a catalogue without dependency cycles
--> expected that the catalogue would not compile but it does
/home/david/git/pdk/foo/spec/classes/foo_spec.rb:8:in `block (4 levels) in <top (required)>'
./spec/classes/foo_spec.rb:8: failed: foo on redhat-7-x86_64 should not compile into a catalogue without dependency cycles
--> expected that the catalogue would not compile but it does
/home/david/git/pdk/foo/spec/classes/foo_spec.rb:8:in `block (4 levels) in <top (required)>'
$ pdk test unit
[✔] Checking for missing Gemfile dependencies
[✔] Checking for required Bundler binstubs
[✖] Running unit tests
  Evaluated 3 tests in 0.193075581 seconds: 3 failures, 0 pending
./spec/classes/foo_spec.rb:8: failed: foo on debian-8-x86_64 should compile into a catalogue without dependency cycles
--> error during compilation: This Name has no effect. A Host Class Definition can not end with a value-producing expression without other effect at /home/david/git/pdk/foo/spec/fixtures/modules/foo/manifests/init.pp:9:12 on node davids.corp.puppetlabs.net
/home/david/git/pdk/foo/spec/classes/foo_spec.rb:8:in `block (4 levels) in <top (required)>'
./spec/classes/foo_spec.rb:8: failed: foo on ubuntu-16.04-x86_64 should compile into a catalogue without dependency cycles
--> error during compilation: This Name has no effect. A Host Class Definition can not end with a value-producing expression without other effect at /home/david/git/pdk/foo/spec/fixtures/modules/foo/manifests/init.pp:9:12 on node davids.corp.puppetlabs.net
/home/david/git/pdk/foo/spec/classes/foo_spec.rb:8:in `block (4 levels) in <top (required)>'
./spec/classes/foo_spec.rb:8: failed: foo on redhat-7-x86_64 should compile into a catalogue without dependency cycles
--> error during compilation: This Name has no effect. A Host Class Definition can not end with a value-producing expression without other effect at /home/david/git/pdk/foo/spec/fixtures/modules/foo/manifests/init.pp:9:12 on node davids.corp.puppetlabs.net
/home/david/git/pdk/foo/spec/classes/foo_spec.rb:8:in `block (4 levels) in <top (required)>'
$
```