### PR TITLE
(idea) More expressive RSpec matchers for JUnit XML content

### DIFF
--- a/spec/acceptance/support/have_junit_testcase.rb
+++ b/spec/acceptance/support/have_junit_testcase.rb
@@ -1,0 +1,79 @@
+require 'rexml/document'
+
+RSpec::Matchers.define :have_junit_testcase do
+  match do |xml_text|
+    document = REXML::Document.new(xml_text)
+
+    return false if document.root.nil?
+
+    testcases = document.elements.to_a("/testsuites/testsuite[@name=\"#{@testsuite_name}\"]/testcase")
+
+    if @expected_attributes
+      testcases.select! do |testcase|
+        @expected_attributes.all? do |attribute, expected_value|
+          values_match?(expected_value, testcase.attribute(attribute).value)
+        end
+      end
+    end
+
+    case @status
+    when :pass
+      testcases.reject! do |testcase|
+        testcase.has_elements?
+      end
+    when :skip
+      testcases.reject! do |testcase|
+        testcase.elements.to_a('skipped').empty?
+      end
+    when :fail
+      testcases.reject! do |testcase|
+        testcase.elements.to_a('failure').empty?
+      end
+
+      unless @failure_attributes.nil?
+        testcases.select! do |testcase|
+          @failure_attributes.all? do |attribute, expected_value|
+            failure_element = testcase.elements.to_a('failure').first
+
+            values_match?(expected_value, failure_element.attribute(attribute).value)
+          end
+        end
+      end
+    end
+
+    !testcases.empty?
+  end
+
+  chain :with_attributes do |attributes|
+    @expected_attributes = attributes
+  end
+
+  chain :in_testsuite do |testsuite_name|
+    @testsuite_name = testsuite_name
+  end
+
+  chain :that_passed do
+    @status = :pass
+  end
+
+  chain :that_was_skipped do
+    @status = :skip
+  end
+
+  chain :that_failed do |attributes = nil|
+    @status = :fail
+    @failure_attributes = attributes
+  end
+
+  failure_message do |body|
+    "expected to find a JUnit testcase#{chained_method_clause_sentences} in:\n#{body}"
+  end
+
+  failure_message_when_negated do |body|
+    "expected not to find a JUnit testcase#{chained_method_clause_sentences} in:\n#{body}"
+  end
+
+  description do
+    "have a JUnit testcase#{chained_method_clause_sentences}"
+  end
+end

--- a/spec/acceptance/support/have_junit_testsuite.rb
+++ b/spec/acceptance/support/have_junit_testsuite.rb
@@ -1,0 +1,43 @@
+require 'rexml/document'
+
+RSpec::Matchers.define :have_junit_testsuite do |testsuite_name|
+  match do |xml_text|
+    document = REXML::Document.new(xml_text)
+
+    return false if document.root.nil?
+
+    testsuites = document.elements.to_a("/testsuites/testsuite[@name=\"#{testsuite_name}\"]")
+
+    if @expected_attributes
+      testsuites.select! do |testsuite|
+        @expected_attributes.all? do |attribute, expected_value|
+          actual_value = case attribute
+                         when 'tests', 'failures', 'errors', 'skipped'
+                           testsuite.attribute(attribute).value.to_i
+                         else
+                           testsuite.attribute(attribute).value
+                         end
+          values_match?(expected_value, actual_value)
+        end
+      end
+    end
+
+    !testsuites.empty?
+  end
+
+  chain :with_attributes do |attributes|
+    @expected_attributes = attributes
+  end
+
+  failure_message do |body|
+    "expected to find a JUnit testsuite named '#{testsuite_name}'#{chained_method_clause_sentences} in:\n#{body}"
+  end
+
+  failure_message_when_negated do |body|
+    "expected not to find a JUnit testsuite named '#{testsuite_name}'#{chained_method_clause_sentences} in:\n#{body}"
+  end
+
+  description do
+    "have a JUnit testsuite named '#{testsuite_name}'#{chained_method_clause_sentences}"
+  end
+end

--- a/spec/acceptance/validate_metadata_spec.rb
+++ b/spec/acceptance/validate_metadata_spec.rb
@@ -18,9 +18,9 @@ describe 'Running metadata validation' do
       it_behaves_like :it_generates_valid_junit_xml
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="metadata-json-lint"]').with_attributes(
-          'failures' => '0',
-          'tests'    => '1',
+        is_expected.to have_junit_testsuite('metadata-json-lint').with_attributes(
+          'failures' => eq(0),
+          'tests'    => eq(1),
         )
       end
 
@@ -56,9 +56,9 @@ describe 'Running metadata validation' do
       it_behaves_like :it_generates_valid_junit_xml
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="metadata-json-lint"]').with_attributes(
-          'failures' => '1',
-          'tests'    => '1',
+        is_expected.to have_junit_testsuite('metadata-json-lint').with_attributes(
+          'failures' => eq(1),
+          'tests'    => eq(1),
         )
       end
 

--- a/spec/acceptance/validate_metadata_spec.rb
+++ b/spec/acceptance/validate_metadata_spec.rb
@@ -25,10 +25,10 @@ describe 'Running metadata validation' do
       end
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="metadata-json-lint"]/testcase').with_attributes(
+        is_expected.to have_junit_testcase.in_testsuite('metadata-json-lint').with_attributes(
           'classname' => 'metadata-json-lint',
           'name'      => 'metadata.json',
-        )
+        ).that_passed
       end
     end
   end
@@ -63,10 +63,10 @@ describe 'Running metadata validation' do
       end
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="metadata-json-lint"]/testcase').with_attributes(
+        is_expected.to have_junit_testcase.in_testsuite('metadata-json-lint').with_attributes(
           'classname' => 'metadata-json-lint.dependencies',
           'name'      => 'metadata.json',
-        )
+        ).that_failed
       end
     end
   end

--- a/spec/acceptance/validate_puppet_spec.rb
+++ b/spec/acceptance/validate_puppet_spec.rb
@@ -25,8 +25,8 @@ describe 'pdk validate puppet', module_command: true do
       its(:stderr) { is_expected.not_to match(lint_spinner_text) }
 
       its(:stdout) { is_expected.to pass_validation(junit_xsd) }
-      its(:stdout) { is_expected.not_to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]') }
-      its(:stdout) { is_expected.not_to have_xpath('/testsuites/testsuite[@name="puppet-lint"]') }
+      its(:stdout) { is_expected.not_to have_junit_testsuite('puppet-syntax') }
+      its(:stdout) { is_expected.not_to have_junit_testsuite('puppet-lint') }
     end
   end
 
@@ -56,13 +56,8 @@ class foo {
       its(:stderr) { is_expected.to match(lint_spinner_text) }
       its(:stdout) { is_expected.to pass_validation(junit_xsd) }
 
-      its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]')
-      end
-
-      its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-lint"]')
-      end
+      its(:stdout) { is_expected.to have_junit_testsuite('puppet-syntax') }
+      its(:stdout) { is_expected.to have_junit_testsuite('puppet-lint') }
     end
   end
 
@@ -98,9 +93,9 @@ class foo {
       its(:stdout) { is_expected.to pass_validation(junit_xsd) }
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]').with_attributes(
-          'failures' => satisfy { |v| v.to_i == 2 },
-          'tests'    => satisfy { |v| v.to_i == 2 },
+        is_expected.to have_junit_testsuite('puppet-syntax').with_attributes(
+          'failures' => eq(2),
+          'tests'    => eq(2),
         )
       end
 
@@ -126,9 +121,9 @@ class foo {
       end
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-lint"]').with_attributes(
-          'failures' => satisfy { |v| v.to_i > 0 },
-          'tests'    => satisfy { |v| v.to_i > 0 },
+        is_expected.to have_junit_testsuite('puppet-lint').with_attributes(
+          'failures' => a_value > 0,
+          'tests'    => a_value > 0,
         )
       end
 
@@ -171,9 +166,9 @@ class foo {
       its(:stdout) { is_expected.to pass_validation(junit_xsd) }
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]').with_attributes(
-          'failures' => '0',
-          'tests'    => '1',
+        is_expected.to have_junit_testsuite('puppet-syntax').with_attributes(
+          'failures' => eq(0),
+          'tests'    => eq(1),
         )
       end
 
@@ -185,9 +180,9 @@ class foo {
       end
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-lint"]').with_attributes(
-          'failures' => '1',
-          'tests'    => '1',
+        is_expected.to have_junit_testsuite('puppet-lint').with_attributes(
+          'failures' => eq(1),
+          'tests'    => eq(1),
         )
       end
 
@@ -233,9 +228,9 @@ class foo {
       its(:stdout) { is_expected.to pass_validation(junit_xsd) }
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]').with_attributes(
-          'failures' => satisfy { |v| v.to_i == 3 },
-          'tests'    => satisfy { |v| v.to_i == 3 },
+        is_expected.to have_junit_testsuite('puppet-syntax').with_attributes(
+          'failures' => eq(3),
+          'tests'    => eq(3),
         )
 
         is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]/testcase').with_attributes(
@@ -290,9 +285,9 @@ class foo {
       its(:stdout) { is_expected.to pass_validation(junit_xsd) }
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-lint"]').with_attributes(
-          'failures' => '1',
-          'tests'    => '1',
+        is_expected.to have_junit_testsuite('puppet-lint').with_attributes(
+          'failures' => eq(1),
+          'tests'    => eq(1),
         )
       end
 
@@ -328,9 +323,9 @@ class foo {
         its(:stdout) { is_expected.to pass_validation(junit_xsd) }
 
         its(:stdout) do
-          is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]').with_attributes(
-            'failures' => '0',
-            'tests'    => '1',
+          is_expected.to have_junit_testsuite('puppet-syntax').with_attributes(
+            'failures' => eq(0),
+            'tests'    => eq(1),
           )
         end
 
@@ -342,9 +337,9 @@ class foo {
         end
 
         its(:stdout) do
-          is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-lint"]').with_attributes(
-            'failures' => '0',
-            'tests'    => '1',
+          is_expected.to have_junit_testsuite('puppet-lint').with_attributes(
+            'failures' => eq(0),
+            'tests'    => eq(1),
           )
         end
 
@@ -383,9 +378,9 @@ class foo {
         its(:stdout) { is_expected.to pass_validation(junit_xsd) }
 
         its(:stdout) do
-          is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-lint"]').with_attributes(
-            'failures' => '2',
-            'tests'    => '2',
+          is_expected.to have_junit_testsuite('puppet-lint').with_attributes(
+            'failures' => eq(2),
+            'tests'    => eq(2),
           )
         end
 

--- a/spec/acceptance/validate_puppet_spec.rb
+++ b/spec/acceptance/validate_puppet_spec.rb
@@ -100,23 +100,22 @@ class foo {
       end
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]/testcase').with_attributes(
+        is_expected.to have_junit_testcase.in_testsuite('puppet-syntax').with_attributes(
           'classname' => 'puppet-syntax',
           'name'      => a_string_starting_with(init_pp),
+        ).that_failed(
+          'type'    => a_string_matching(%r{warning}i),
+          'message' => a_string_matching(%r{unrecognized escape sequence \'\\\[\'}i),
         )
       end
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]/testcase/failure').with_attributes(
+        is_expected.to have_junit_testcase.in_testsuite('puppet-syntax').with_attributes(
+          'classname' => 'puppet-syntax',
+          'name'      => a_string_starting_with(init_pp),
+        ).that_failed(
           'type'    => a_string_matching(%r{warning}i),
-          'message' => a_string_matching(%r{Unrecognized escape sequence \'\\\[\'}i),
-        )
-      end
-
-      its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]/testcase/failure').with_attributes(
-          'type'    => a_string_matching(%r{warning}i),
-          'message' => a_string_matching(%r{Unrecognized escape sequence \'\\\]\'}i),
+          'message' => a_string_matching(%r{unrecognized escape sequence \'\\\]\'}i),
         )
       end
 
@@ -128,14 +127,10 @@ class foo {
       end
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-lint"]/testcase').with_attributes(
+        is_expected.to have_junit_testcase.in_testsuite('puppet-lint').with_attributes(
           'classname' => a_string_starting_with('puppet-lint'),
           'name'      => a_string_starting_with(init_pp),
-        )
-      end
-
-      its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-lint"]/testcase/failure').with_attributes(
+        ).that_failed(
           'type'    => a_string_matching(%r{warning}i),
           'message' => a_string_matching(%r{double quoted string containing no variables}i),
         )
@@ -173,10 +168,10 @@ class foo {
       end
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]/testcase').with_attributes(
+        is_expected.to have_junit_testcase.in_testsuite('puppet-syntax').with_attributes(
           'classname' => 'puppet-syntax',
           'name'      => init_pp,
-        )
+        ).that_passed
       end
 
       its(:stdout) do
@@ -187,10 +182,10 @@ class foo {
       end
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-lint"]/testcase').with_attributes(
+        is_expected.to have_junit_testcase.in_testsuite('puppet-lint').with_attributes(
           'classname' => 'puppet-lint.documentation',
           'name'      => a_string_starting_with(init_pp),
-        )
+        ).that_failed
       end
     end
   end
@@ -232,31 +227,25 @@ class foo {
           'failures' => eq(3),
           'tests'    => eq(3),
         )
+      end
 
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]/testcase').with_attributes(
+      its(:stdout) do
+        is_expected.to have_junit_testcase.in_testsuite('puppet-syntax').with_attributes(
           'classname' => 'puppet-syntax',
           'name'      => a_string_starting_with(init_pp),
+        ).that_failed(
+          'type'    => 'Error',
+          'message' => a_string_matching(%r{This Name has no effect}i),
         )
       end
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]/testcase/failure').with_attributes(
+        is_expected.to have_junit_testcase.in_testsuite('puppet-syntax').with_attributes(
+          'classname' => 'puppet-syntax',
+          'name'      => a_string_starting_with(init_pp),
+        ).that_failed(
           'type'    => 'Error',
-          'message' => a_string_matching(%r{This Name has no effect. A Host Class Definition can not end with a value-producing expression without other effect}i),
-        )
-      end
-
-      its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]/testcase/failure').with_attributes(
-          'type'    => 'Error',
-          'message' => a_string_matching(%r{This Type-Name has no effect. A value was produced and then forgotten}i),
-        )
-      end
-
-      its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]/testcase/failure').with_attributes(
-          'type'    => 'Error',
-          'message' => a_string_matching(%r{Language validation logged 2 errors. Giving up}i),
+          'message' => a_string_matching(%r{This Type-Name has no effect}i),
         )
       end
     end
@@ -292,10 +281,10 @@ class foo {
       end
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-lint"]/testcase').with_attributes(
+        is_expected.to have_junit_testcase.in_testsuite('puppet-lint').with_attributes(
           'classname' => 'puppet-lint.autoloader_layout',
           'name'      => a_string_starting_with(example_pp),
-        )
+        ).that_failed
       end
     end
 
@@ -330,10 +319,10 @@ class foo {
         end
 
         its(:stdout) do
-          is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-syntax"]/testcase').with_attributes(
+          is_expected.to have_junit_testcase.in_testsuite('puppet-syntax').with_attributes(
             'classname' => 'puppet-syntax',
             'name'      => a_string_starting_with(clean_pp),
-          )
+          ).that_passed
         end
 
         its(:stdout) do
@@ -344,10 +333,10 @@ class foo {
         end
 
         its(:stdout) do
-          is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-lint"]/testcase').with_attributes(
+          is_expected.to have_junit_testcase.in_testsuite('puppet-lint').with_attributes(
             'classname' => 'puppet-lint',
             'name'      => a_string_starting_with(clean_pp),
-          )
+          ).that_passed
         end
       end
     end
@@ -385,14 +374,14 @@ class foo {
         end
 
         its(:stdout) do
-          is_expected.to have_xpath('/testsuites/testsuite[@name="puppet-lint"]/testcase').with_attributes(
+          is_expected.to have_junit_testcase.in_testsuite('puppet-lint').with_attributes(
             'classname' => a_string_starting_with('puppet-lint'),
             'name'      => a_string_starting_with(another_problem_pp),
-          )
+          ).that_failed
         end
 
         its(:stdout) do
-          is_expected.not_to have_xpath('/testsuites/testsuite[@name="puppet-lint"]/testcase').with_attributes(
+          is_expected.not_to have_junit_testcase.in_testsuite('puppet-lint').with_attributes(
             'classname' => a_string_starting_with('puppet-lint'),
             'name'      => a_string_starting_with(example_pp),
           )

--- a/spec/acceptance/validate_ruby_spec.rb
+++ b/spec/acceptance/validate_ruby_spec.rb
@@ -33,17 +33,17 @@ describe 'pdk validate ruby', module_command: true do
       end
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="rubocop"]/testcase').with_attributes(
+        is_expected.to have_junit_testcase.in_testsuite('rubocop').with_attributes(
           'classname' => 'rubocop',
           'name'      => example_rb,
-        )
+        ).that_passed
       end
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="rubocop"]/testcase').with_attributes(
+        is_expected.to have_junit_testcase.in_testsuite('rubocop').with_attributes(
           'classname' => 'rubocop',
           'name'      => File.join('spec', 'spec_helper.rb'),
-        )
+        ).that_passed
       end
     end
   end
@@ -106,17 +106,17 @@ describe 'pdk validate ruby', module_command: true do
       end
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="rubocop"]/testcase').with_attributes(
+        is_expected.to have_junit_testcase.in_testsuite('rubocop').with_attributes(
           'classname' => 'rubocop',
           'name'      => File.join('spec', 'spec_helper.rb'),
-        )
+        ).that_passed
       end
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="rubocop"]/testcase').with_attributes(
+        is_expected.to have_junit_testcase.in_testsuite('rubocop').with_attributes(
           'classname' => a_string_matching(%r{UselessAssignment}),
           'name'      => a_string_starting_with(File.join('spec', 'violation.rb')),
-        )
+        ).that_failed
       end
     end
   end

--- a/spec/acceptance/validate_ruby_spec.rb
+++ b/spec/acceptance/validate_ruby_spec.rb
@@ -26,9 +26,9 @@ describe 'pdk validate ruby', module_command: true do
       it_behaves_like :it_generates_valid_junit_xml
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="rubocop"]').with_attributes(
-          'failures' => '0',
-          'tests'    => satisfy { |v| v.to_i > 0 },
+        is_expected.to have_junit_testsuite('rubocop').with_attributes(
+          'failures' => eq(0),
+          'tests'    => a_value > 0,
         )
       end
 
@@ -99,9 +99,9 @@ describe 'pdk validate ruby', module_command: true do
       it_behaves_like :it_generates_valid_junit_xml
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="rubocop"]').with_attributes(
-          'failures' => satisfy { |v| v.to_i > 0 },
-          'tests'    => satisfy { |v| v.to_i >= 3 },
+        is_expected.to have_junit_testsuite('rubocop').with_attributes(
+          'failures' => a_value > 1,
+          'tests'    => a_value >= 3,
         )
       end
 


### PR DESCRIPTION
Just an idea that I was pondering tonight. I know that I am biased towards RSpec magic more than is probably healthy, so I just wanted to put this out there for the rest of you to consider. I'm not entirely sold on it and am happy to stick with the xpath matcher if that's the group consensus :)