### PR TITLE
(SDK-297) Fixes writing reports to a file

### DIFF
--- a/lib/pdk/report.rb
+++ b/lib/pdk/report.rb
@@ -48,6 +48,12 @@ module PDK
     # @param target [#write] an IO object that the report will be written to.
     #   Defaults to PDK::Report.default_target.
     def write_junit(target = self.class.default_target)
+      # Extra defaulting here, b/c the Class.send method will pass in nil
+      target ||= self.class.default_target
+
+      # Open a File Object for IO if target is a string containing a filename or path
+      target = File.open(target, 'w') if target.is_a? String
+
       document = REXML::Document.new
       document << REXML::XMLDecl.new
       testsuites = REXML::Element.new('testsuites')
@@ -76,6 +82,8 @@ module PDK
 
       document.elements << testsuites
       document.write(target, 2)
+    ensure
+      target.close if target.is_a? File
     end
 
     # Renders the report as plain text.
@@ -89,11 +97,16 @@ module PDK
       # Extra defaulting here, b/c the Class.send method will pass in nil
       target ||= self.class.default_target
 
+      # Open a File Object for IO if target is a string containing a filename or path
+      target = File.open(target, 'w') if target.is_a? String
+
       events.each do |_tool, tool_events|
         tool_events.each do |event|
           target.puts(event.to_text) unless event.pass?
         end
       end
+    ensure
+      target.close if target.is_a? File
     end
   end
 end

--- a/spec/acceptance/report_spec.rb
+++ b/spec/acceptance/report_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper_acceptance'
+
+describe 'Saves report to a file' do
+  let(:junit_xsd) { File.join(RSpec.configuration.fixtures_path, 'JUnit.xsd') }
+
+  context 'with a fresh module' do
+    include_context 'in a new module', 'foo'
+
+    init_pp = File.join('manifests', 'init.pp')
+
+    before(:all) do
+      File.open(init_pp, 'w') do |f|
+        f.puts <<-EOS
+class foo { }
+        EOS
+      end
+    end
+
+    # Tests writing reports to a file
+    describe command('pdk validate puppet manifests/init.pp --format=text:report.txt') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stdout) { is_expected.to match(%r{\A\Z}) }
+      its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
+      its(:stderr) { is_expected.to match(%r{Checking Puppet manifest style}i) }
+
+      describe file('report.txt') do
+        it { is_expected.to exist }
+        its(:content) { is_expected.to match %r{^#{Regexp.escape(init_pp)}.*warning.*class not documented} }
+      end
+    end
+
+    # Tests writing reports to stdout doesn't actually write a file named stdout
+    describe command('pdk validate puppet manifests/init.pp --format=text:stdout') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
+      its(:stderr) { is_expected.to match(%r{Checking Puppet manifest style}i) }
+      its(:stdout) { is_expected.to match(%r{^#{Regexp.escape(init_pp)}.*warning.*class not documented}) }
+
+      describe file('stdout') do
+        it { is_expected.not_to exist }
+      end
+    end
+
+    # Tests writing reports to stderr doesn't actually write a file named stderr
+    describe command('pdk validate puppet manifests/init.pp --format=text:stderr') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stdout) { is_expected.to match(%r{\A\Z}) }
+      its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
+      its(:stderr) { is_expected.to match(%r{Checking Puppet manifest style}i) }
+      its(:stderr) { is_expected.to match(%r{^#{Regexp.escape(init_pp)}.*warning.*class not documented}) }
+
+      describe file('stderr') do
+        it { is_expected.not_to exist }
+      end
+    end
+  end
+end


### PR DESCRIPTION
There is a bug where writing reports to a file isn't working so `--format=text:report.txt` or `--format=junit:report.xml` is doing nothing, results are not being written anywhere. This fixes that.

Also adds some sanity acceptance tests to make sure reports are being written to the right place.