### PR TITLE
(maint) Performance improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :development do
     # required for github_changelog_generator
     gem 'rack', '~> 1.0'
   end
+  gem 'ruby-prof'
 end
 
 group :test do

--- a/lib/pdk/util/bundler.rb
+++ b/lib/pdk/util/bundler.rb
@@ -107,6 +107,9 @@ module PDK
         end
 
         def binstubs!(gems)
+          binstub_dir = File.join(File.dirname(gemfile), 'bin')
+          return true if gems.all? { |gem| File.file?(File.join(binstub_dir, gem)) }
+
           command = bundle_command('binstubs', gems.join(' '), '--force')
 
           result = command.execute!

--- a/spec/acceptance/support/in_a_new_module.rb
+++ b/spec/acceptance/support/in_a_new_module.rb
@@ -2,7 +2,7 @@ require 'open3'
 
 shared_context 'in a new module' do |name|
   before(:all) do
-    output, status = Open3.capture2e('pdk', 'new', 'module', name, '--skip-interview')
+    output, status = Open3.capture2e('pdk', 'new', 'module', name, '--skip-interview', '--template-url', "file://#{RSpec.configuration.template_dir}")
 
     raise "Failed to create test module:\n#{output}" unless status.success?
 


### PR DESCRIPTION
2 performance improvements for the PDK itself:
 * Fetch the bundler load path entry from `Gem.loaded_specs` rather than shelling out to `bundle show bundler`
 * Avoid regenerating binstubs that already exist. We can't just remove the `--force` because bundler returns != 0 if the named binstubs already exist. There are gems out there whose executables don't match the gem name so this short circuit won't work for them, but it handles the majority of cases. 

1 performance improvement for the acceptance tests:
 * Pull down the pdk-module-template repo into a temporary directory at the start of the run and use that local repo as the template when creating modules during tests, avoiding subsequent network traffic.

These 3 changes dropped the execution time of `rake acceptance:local` on my machine from 3m40 to 2m08