### PR TITLE
(SDK-294) Avoid module name conflict in acceptance tests.

### DIFF
--- a/spec/acceptance/bundle_management_spec.rb
+++ b/spec/acceptance/bundle_management_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Managing Gemfile dependencies' do
-  include_context 'in a new module', 'foo'
+  include_context 'in a new module', 'bundle_management'
 
   context 'when there is no Gemfile.lock' do
     before(:all) do

--- a/spec/acceptance/new_class_spec.rb
+++ b/spec/acceptance/new_class_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper_acceptance'
 
 describe 'pdk new class', module_command: true do
   context 'in a new module' do
-    include_context 'in a new module', 'foo'
+    include_context 'in a new module', 'new_class'
 
     context 'when creating the main class' do
-      describe command('pdk new class foo') do
+      describe command('pdk new class new_class') do
         its(:exit_status) { is_expected.to eq 0 }
         its(:stdout) { is_expected.to match(%r{Creating .* from template}) }
         its(:stdout) { is_expected.not_to match(%r{WARN|ERR}) }
@@ -20,20 +20,20 @@ describe 'pdk new class', module_command: true do
       describe file('manifests/init.pp') do
         it { is_expected.to be_file }
         its(:content) do
-          is_expected.to match(%r{class foo })
+          is_expected.to match(%r{class new_class })
         end
       end
 
-      describe file('spec/classes/foo_spec.rb') do
+      describe file('spec/classes/new_class_spec.rb') do
         it { is_expected.to be_file }
         its(:content) do
-          is_expected.to match(%r{foo})
+          is_expected.to match(%r{new_class})
         end
       end
     end
 
     context 'when creating an ancillary class' do
-      describe command('pdk new class foo::bar') do
+      describe command('pdk new class new_class::bar') do
         its(:exit_status) { is_expected.to eq 0 }
         its(:stdout) { is_expected.to match(%r{Creating .* from template}) }
         its(:stdout) { is_expected.not_to match(%r{WARN|ERR}) }
@@ -48,20 +48,20 @@ describe 'pdk new class', module_command: true do
       describe file('manifests/bar.pp') do
         it { is_expected.to be_file }
         its(:content) do
-          is_expected.to match(%r{class foo::bar})
+          is_expected.to match(%r{class new_class::bar})
         end
       end
 
       describe file('spec/classes/bar_spec.rb') do
         it { is_expected.to be_file }
         its(:content) do
-          is_expected.to match(%r{foo::bar})
+          is_expected.to match(%r{new_class::bar})
         end
       end
     end
 
     context 'when creating a deeply nested class' do
-      describe command('pdk new class foo::bar::baz') do
+      describe command('pdk new class new_class::bar::baz') do
         its(:exit_status) { is_expected.to eq 0 }
         its(:stdout) { is_expected.to match(%r{Creating .* from template}) }
         its(:stdout) { is_expected.not_to match(%r{WARN|ERR}) }
@@ -76,14 +76,14 @@ describe 'pdk new class', module_command: true do
       describe file('manifests/bar/baz.pp') do
         it { is_expected.to be_file }
         its(:content) do
-          is_expected.to match(%r{class foo::bar::baz})
+          is_expected.to match(%r{class new_class::bar::baz})
         end
       end
 
       describe file('spec/classes/bar/baz_spec.rb') do
         it { is_expected.to be_file }
         its(:content) do
-          is_expected.to match(%r{foo::bar::baz})
+          is_expected.to match(%r{new_class::bar::baz})
         end
       end
     end

--- a/spec/acceptance/validate_all_spec.rb
+++ b/spec/acceptance/validate_all_spec.rb
@@ -4,15 +4,15 @@ describe 'Running all validations' do
   let(:junit_xsd) { File.join(RSpec.configuration.fixtures_path, 'JUnit.xsd') }
 
   context 'with a fresh module' do
-    include_context 'in a new module', 'foo'
+    include_context 'in a new module', 'validate_all'
 
     init_pp = File.join('manifests', 'init.pp')
 
     before(:all) do
       File.open(init_pp, 'w') do |f|
         f.puts <<-EOS
-# foo
-class foo { }
+# validate_all
+class validate_all { }
         EOS
       end
     end

--- a/spec/acceptance/validate_metadata_spec.rb
+++ b/spec/acceptance/validate_metadata_spec.rb
@@ -4,7 +4,7 @@ describe 'Running metadata validation' do
   let(:spinner_text) { %r{checking metadata\.json}i }
 
   context 'with a fresh module' do
-    include_context 'in a new module', 'foo'
+    include_context 'in a new module', 'metadata_validation_module'
 
     describe command('pdk validate metadata') do
       its(:exit_status) { is_expected.to eq(0) }

--- a/spec/acceptance/validate_puppet_spec.rb
+++ b/spec/acceptance/validate_puppet_spec.rb
@@ -10,7 +10,7 @@ describe 'pdk validate puppet', module_command: true do
   example_pp = File.join('manifests', 'example.pp')
 
   context 'with no .pp files' do
-    include_context 'in a new module', 'foo'
+    include_context 'in a new module', 'validate_puppet_module'
 
     describe command('pdk validate puppet') do
       its(:exit_status) { is_expected.to eq(0) }

--- a/spec/acceptance/validate_ruby_spec.rb
+++ b/spec/acceptance/validate_ruby_spec.rb
@@ -4,7 +4,7 @@ describe 'pdk validate ruby', module_command: true do
   let(:junit_xsd) { File.join(RSpec.configuration.fixtures_path, 'JUnit.xsd') }
 
   context 'with a fresh module' do
-    include_context 'in a new module', 'foo'
+    include_context 'in a new module', 'validate_ruby_module'
 
     example_rb = File.join('spec', 'example.rb')
 


### PR DESCRIPTION
SDK-294 is a bug where one acceptance test fails to create 'foo' as a module folder, in spite of the previous acceptance test apparently deleting it.

This commit does not directly fix that issue; but instead has acceptance tests use unique folder names instead of all using 'foo'