### PR TITLE
(SDK-296) Allow target selection for the metadata validator

### DIFF
--- a/lib/pdk/validators/base_validator.rb
+++ b/lib/pdk/validators/base_validator.rb
@@ -42,7 +42,7 @@ module PDK
         targets
       end
 
-      def self.spinner_text
+      def self.spinner_text(_targets = nil)
         _('Invoking %{cmd}') % { cmd: cmd }
       end
 
@@ -67,7 +67,7 @@ module PDK
 
           command = PDK::CLI::Exec::Command.new(*cmd_argv).tap do |c|
             c.context = :module
-            c.add_spinner(spinner_text)
+            c.add_spinner(spinner_text(invokation_targets))
           end
 
           result = command.execute!

--- a/lib/pdk/validators/base_validator.rb
+++ b/lib/pdk/validators/base_validator.rb
@@ -4,6 +4,14 @@ require 'pdk/cli/exec'
 module PDK
   module Validate
     class BaseValidator
+      # Controls how many times the validator is invoked.
+      #
+      #   :once -       The validator will be invoked once and passed all the
+      #                 targets.
+      #   :per_target - The validator will be invoked for each target
+      #                 separately.
+      INVOKE_STYLE = :once
+
       def self.cmd_path
         File.join(PDK::Util.module_root, 'bin', cmd)
       end
@@ -44,19 +52,31 @@ module PDK
         return 0 if targets.empty?
 
         PDK::Util::Bundler.ensure_binstubs!(cmd)
-        cmd_argv = parse_options(options, targets).unshift(cmd_path)
-        cmd_argv.unshift('ruby', '-W0') if Gem.win_platform?
 
-        command = PDK::CLI::Exec::Command.new(*cmd_argv).tap do |c|
-          c.context = :module
-          c.add_spinner(spinner_text)
+        # If invoking :per_target, split the targets array into an array of
+        # single element arrays (one per target). If invoking :once, wrap the
+        # targets array in another array. This is so we can loop through the
+        # invokes with the same logic, regardless of which invoke style is
+        # needed.
+        targets = (self::INVOKE_STYLE == :per_target) ? targets.combination(1).to_a : Array[targets]
+        exit_codes = []
+
+        targets.each do |invokation_targets|
+          cmd_argv = parse_options(options, invokation_targets).unshift(cmd_path)
+          cmd_argv.unshift('ruby', '-W0') if Gem.win_platform?
+
+          command = PDK::CLI::Exec::Command.new(*cmd_argv).tap do |c|
+            c.context = :module
+            c.add_spinner(spinner_text)
+          end
+
+          result = command.execute!
+          exit_codes << result[:exit_code]
+
+          parse_output(report, result, invokation_targets)
         end
 
-        result = command.execute!
-
-        parse_output(report, result, targets)
-
-        result[:exit_code]
+        exit_codes.sort.last
       end
     end
   end

--- a/lib/pdk/validators/metadata.rb
+++ b/lib/pdk/validators/metadata.rb
@@ -6,6 +6,8 @@ require 'pdk/util/bundler'
 module PDK
   module Validate
     class Metadata < BaseValidator
+      INVOKE_STYLE = :per_target
+
       def self.name
         'metadata'
       end
@@ -28,12 +30,14 @@ module PDK
         cmd_options.concat(targets)
       end
 
-      def self.parse_output(report, result, _targets)
+      def self.parse_output(report, result, targets)
         begin
           json_data = JSON.parse(result[:stdout])
         rescue JSON::ParserError
           json_data = []
         end
+
+        raise ArgumentError, 'More that 1 target provided to PDK::Validate::Metadata' if targets.count > 1
 
         if json_data.empty?
           report.add_event(
@@ -52,7 +56,7 @@ module PDK
               event_type = type[%r{\A(.+?)s?\Z}, 1]
 
               report.add_event(
-                file:     'metadata.json',
+                file:     targets.first,
                 source:   cmd,
                 message:  offense['msg'],
                 test:     offense['check'],

--- a/lib/pdk/validators/puppet/puppet_lint.rb
+++ b/lib/pdk/validators/puppet/puppet_lint.rb
@@ -18,7 +18,7 @@ module PDK
         '**/*.pp'
       end
 
-      def self.spinner_text
+      def self.spinner_text(_targets = nil)
         _('Checking Puppet manifest style')
       end
 

--- a/lib/pdk/validators/puppet/puppet_syntax.rb
+++ b/lib/pdk/validators/puppet/puppet_syntax.rb
@@ -17,7 +17,7 @@ module PDK
         '**/**.pp'
       end
 
-      def self.spinner_text
+      def self.spinner_text(_targets = nil)
         _('Checking Puppet manifest syntax')
       end
 

--- a/lib/pdk/validators/ruby/rubocop.rb
+++ b/lib/pdk/validators/ruby/rubocop.rb
@@ -16,7 +16,7 @@ module PDK
         'rubocop'
       end
 
-      def self.spinner_text
+      def self.spinner_text(_targets = nil)
         _('Checking Ruby code style')
       end
 

--- a/spec/acceptance/validate_all_spec.rb
+++ b/spec/acceptance/validate_all_spec.rb
@@ -25,7 +25,7 @@ class validate_all { }
     describe command('pdk validate') do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stdout) { is_expected.to match(%r{Running all available validators}i) }
-      its(:stderr) { is_expected.to match(%r{Checking metadata.json}i) }
+      its(:stderr) { is_expected.to match(%r{Checking metadata \(metadata\.json\)}i) }
       its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
       its(:stderr) { is_expected.to match(%r{Checking Puppet manifest style}i) }
       its(:stderr) { is_expected.to match(%r{Checking Ruby code style}i) }


### PR DESCRIPTION
In order to accommodate this functionality, I needed to refactor the base validator a bit so that we can optionally invoke the validator once per target (as metadata-json-lint only supports testing a single file). 