### PR TITLE
(SDK-298) Handle exception raised when an invalid report format is specified on the CLI

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -60,15 +60,7 @@ module PDK::CLI
     ) % { available_formats: PDK::Report.formats.join("', '") }
 
     option :f, :format, format_desc, argument: :required, multiple: true do |values|
-      values.compact.each do |v|
-        if v.include?(':')
-          format = v.split(':', 2).first
-
-          Util::OptionValidator.enum(format, PDK::Report.formats)
-        else
-          Util::OptionValidator.enum(v, PDK::Report.formats)
-        end
-      end
+      PDK::CLI::Util::OptionNormalizer.report_formats(values.compact)
     end
 
     flag :d, :debug, _('Enable debug output.') do |_, _|

--- a/lib/pdk/cli/util/option_normalizer.rb
+++ b/lib/pdk/cli/util/option_normalizer.rb
@@ -28,7 +28,7 @@ module PDK
 
             begin
               OptionValidator.enum(format, PDK::Report.formats)
-            rescue
+            rescue ArgumentError
               raise PDK::CLI::FatalError, _("'%{name}' is not a valid report format (%{valid})") % {
                 name:  format,
                 valid: PDK::Report.formats.join(', '),

--- a/lib/pdk/cli/util/option_validator.rb
+++ b/lib/pdk/cli/util/option_validator.rb
@@ -11,7 +11,7 @@ module PDK
           invalid_entries = vals.reject { |e| valid_entries.include?(e) }
 
           unless invalid_entries.empty?
-            raise _('Error: the following values are invalid: %{invalid_entries}') % { invalid_entries: invalid_entries }
+            raise ArgumentError, _('Error: the following values are invalid: %{invalid_entries}') % { invalid_entries: invalid_entries }
           end
 
           val

--- a/spec/pdk/cli_spec.rb
+++ b/spec/pdk/cli_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe PDK::CLI do
+  context 'when provided an invalid report format' do
+    it 'informs the user and exits' do
+      expect(logger).to receive(:fatal).with(a_string_matching(%r{'non_existant_format'.*valid report format}))
+
+      expect {
+        described_class.run(['--format', 'non_existant_format'])
+      }.to raise_error(SystemExit) { |error|
+        expect(error.status).not_to eq(0)
+      }
+    end
+  end
+
+  context 'when provided a valid report format' do
+    it 'does not exit early with an error' do
+      expect(logger).not_to receive(:fatal).with(a_string_matching(%r{valid report format}))
+      allow($stdout).to receive(:puts).with(anything)
+
+      described_class.run(['--format', 'text'])
+    end
+  end
+
+  context 'when not provided any report formats' do
+    it 'does not exit early with an error' do
+      expect(logger).not_to receive(:fatal).with(a_string_matching(%r{valid report format}))
+      allow($stdout).to receive(:puts).with(anything)
+
+      described_class.run([])
+    end
+  end
+end


### PR DESCRIPTION
Changes the option validation code for `--format` over to using `PDK::CLI::Util::OptionNormalizer.report_formats` which raises a `PDK::CLI::FatalError` exception when given an invalid report format name, which is then automatically handled by the CLI and presented to the user in a nicer format than a stack trace.