### PR TITLE
(maint) Remove nil values from metadata before generating JSON

### DIFF
--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -67,7 +67,7 @@ module PDK
       end
 
       def to_json
-        JSON.pretty_generate(@data)
+        JSON.pretty_generate(@data.dup.delete_if { |_key, value| value.nil? })
       end
 
       private


### PR DESCRIPTION
A new release of metadata-json-lint was pushed out a couple of days ago that included https://github.com/voxpupuli/metadata-json-lint/pull/68 which causes the data types for the metadata values to get validated. This is causing our acceptance tests to fail because we include `nil` values (translated to `null` in JSON) in our generated metadata.json.

This change compacts the metadata hash to remove those keys with `nil` values (optional metadata elements like issues_url) before generating the JSON structure.