### PR TITLE
(maint) Finish off PDK::CLI::Validate unit tests

### DIFF
--- a/lib/pdk/cli/util/option_normalizer.rb
+++ b/lib/pdk/cli/util/option_normalizer.rb
@@ -40,6 +40,8 @@ module PDK
               target = $stdout
             when 'stderr'
               target = $stderr
+            when nil
+              target = PDK::Report.default_target
             end
 
             { method: "write_#{format}".to_sym, target: target }

--- a/lib/pdk/report.rb
+++ b/lib/pdk/report.rb
@@ -48,9 +48,6 @@ module PDK
     # @param target [#write] an IO object that the report will be written to.
     #   Defaults to PDK::Report.default_target.
     def write_junit(target = self.class.default_target)
-      # Extra defaulting here, b/c the Class.send method will pass in nil
-      target ||= self.class.default_target
-
       # Open a File Object for IO if target is a string containing a filename or path
       target = File.open(target, 'w') if target.is_a? String
 
@@ -94,9 +91,6 @@ module PDK
     # @param target [#write] an IO object that the report will be written to.
     #   Defaults to PDK::Report.default_target.
     def write_text(target = self.class.default_target)
-      # Extra defaulting here, b/c the Class.send method will pass in nil
-      target ||= self.class.default_target
-
       # Open a File Object for IO if target is a string containing a filename or path
       target = File.open(target, 'w') if target.is_a? String
 

--- a/spec/cli/option_normalizer_spec.rb
+++ b/spec/cli/option_normalizer_spec.rb
@@ -14,11 +14,11 @@ describe PDK::CLI::Util::OptionNormalizer do
 
   context 'when parsing report formats and targets' do
     context 'and given a single format with no target' do
-      it 'returns a single format specification with no target' do
+      it 'returns a single format specification with default target' do
         reports = described_class.report_formats(['text'])
         expect(reports.length).to eq(1)
         expect(reports[0][:method]).to eq(:write_text)
-        expect(reports[0][:target]).to eq(nil)
+        expect(reports[0][:target]).to eq(PDK::Report.default_target)
       end
     end
 
@@ -54,7 +54,7 @@ describe PDK::CLI::Util::OptionNormalizer do
         reports = described_class.report_formats(['text', 'junit:foo.junit'])
         expect(reports.length).to eq(2)
         expect(reports[0][:method]).to eq(:write_text)
-        expect(reports[0][:target]).to eq(nil)
+        expect(reports[0][:target]).to eq(PDK::Report.default_target)
         expect(reports[1][:method]).to eq(:write_junit)
         expect(reports[1][:target]).to eq('foo.junit')
       end

--- a/spec/cli/validate_spec.rb
+++ b/spec/cli/validate_spec.rb
@@ -7,15 +7,17 @@ describe 'Running `pdk validate` in a module' do
   include_context :validators
   let(:validator_names) { validators.map(&:name).join(', ') }
   let(:validator_success) { { exit_code: 0, stdout: 'success', stderr: '' } }
+  let(:report) { instance_double('PDK::Report').as_null_object }
 
   before(:each) do
     allow(PDK::Util::Bundler).to receive(:ensure_bundle!)
     allow(PDK::Util).to receive(:module_root).and_return('/path/to/testmodule')
+    allow(PDK::Report).to receive(:new).and_return(report)
   end
 
   context 'when no arguments or options are provided' do
     it 'invokes each validator with no report and no options and exits zero' do
-      expect(validators).to all(receive(:invoke).with(instance_of(PDK::Report), {}).and_return(0))
+      expect(validators).to all(receive(:invoke).with(report, {}).and_return(0))
 
       expect(logger).to receive(:info).with('Running all available validators...')
 
@@ -43,7 +45,7 @@ describe 'Running `pdk validate` in a module' do
     let(:validator) { PDK::Validate::Metadata }
 
     it 'only invokes the given validator and exits zero' do
-      expect(validator).to receive(:invoke).with(instance_of(PDK::Report), {}).and_return(0)
+      expect(validator).to receive(:invoke).with(report, {}).and_return(0)
 
       validators.reject { |r| r == validator }.each do |v|
         expect(v).not_to receive(:invoke)
@@ -66,7 +68,7 @@ describe 'Running `pdk validate` in a module' do
     end
 
     it 'invokes each given validator and exits zero' do
-      expect(invoked_validators).to all(receive(:invoke).with(instance_of(PDK::Report), {}).and_return(0))
+      expect(invoked_validators).to all(receive(:invoke).with(report, {}).and_return(0))
 
       (validators | invoked_validators).each do |validator|
         expect(validator).not_to receive(:invoke)
@@ -85,7 +87,7 @@ describe 'Running `pdk validate` in a module' do
 
     it 'warns about unknown validators, invokes known validators, and exits zero' do
       expect(logger).to receive(:warn).with("Unknown validator 'bad-val'. Available validators: #{validator_names}")
-      expect(validator).to receive(:invoke).with(instance_of(PDK::Report), {}).and_return(0)
+      expect(validator).to receive(:invoke).with(report, {}).and_return(0)
 
       expect {
         PDK::CLI.run(['validate', 'puppet,bad-val'])
@@ -99,7 +101,7 @@ describe 'Running `pdk validate` in a module' do
     let(:validator) { PDK::Validate::Metadata }
 
     it 'invokes the specified validator with the target as an option' do
-      expect(validator).to receive(:invoke).with(instance_of(PDK::Report), targets: ['lib/', 'manifests/']).and_return(0)
+      expect(validator).to receive(:invoke).with(report, targets: ['lib/', 'manifests/']).and_return(0)
 
       expect {
         PDK::CLI.run(['validate', 'metadata', 'lib/', 'manifests/'])
@@ -111,12 +113,55 @@ describe 'Running `pdk validate` in a module' do
 
   context 'when targets are provided as arguments and no validators are specified' do
     it 'invokes all validators with the target as an option' do
-      expect(validators).to all(receive(:invoke).with(instance_of(PDK::Report), targets: ['lib/', 'manifests/']).and_return(0))
+      expect(validators).to all(receive(:invoke).with(report, targets: ['lib/', 'manifests/']).and_return(0))
 
       expect(logger).to receive(:info).with('Running all available validators...')
 
       expect {
         PDK::CLI.run(['validate', 'lib/', 'manifests/'])
+      }.to raise_error(SystemExit) { |error|
+        expect(error.status).to eq(0)
+      }
+    end
+  end
+
+  context 'when no report formats are specified' do
+    it 'reports to stdout as text' do
+      expect(validators).to all(receive(:invoke).with(report, {}).and_return(0))
+      expect(report).to receive(:write_text).with($stdout)
+      expect(report).not_to receive(:write_junit)
+
+      expect {
+        PDK::CLI.run(['validate'])
+      }.to raise_error(SystemExit) { |error|
+        expect(error.status).to eq(0)
+      }
+    end
+  end
+
+  context 'when a report format is specified' do
+    it 'reports to stdout as the specified format' do
+      expect(validators).to all(receive(:invoke).with(report, {}).and_return(0))
+      expect(report).to receive(:write_junit).with($stdout)
+      expect(report).not_to receive(:write_text)
+
+      expect {
+        PDK::CLI.run(['validate', '--format', 'junit'])
+      }.to raise_error(SystemExit) { |error|
+        expect(error.status).to eq(0)
+      }
+    end
+  end
+
+  context 'when multiple report formats are specified' do
+    it 'reports to each target as the specified format' do
+      expect(validators).to all(receive(:invoke).with(report, {}).and_return(0))
+      expect(report).to receive(:write_text).with($stderr)
+      expect(report).to receive(:write_text).with($stdout)
+      expect(report).to receive(:write_junit).with('testfile.xml')
+
+      expect {
+        PDK::CLI.run(%w[validate --format text:stderr --format junit:testfile.xml --format text])
       }.to raise_error(SystemExit) { |error|
         expect(error.status).to eq(0)
       }


### PR DESCRIPTION
 * Changes `PDK::CLI::Util::OptionNormalizer.report_formats` to return the default target rather than `nil` if no target has been specified. With that we can get rid of the extra defaulting in the report methods themselves as we'll never be sending a nil value.
 * Adds unit test for report specification in `PDK::CLI::Validate`, which should bring us to 100% coverage of this class.