### PR TITLE
(SDK-305) Answer file to cache module interview answers, template-url etc

### DIFF
--- a/lib/pdk.rb
+++ b/lib/pdk.rb
@@ -1,3 +1,4 @@
+require 'pdk/answer_file'
 require 'pdk/generate'
 require 'pdk/i18n'
 require 'pdk/logger'

--- a/lib/pdk/answer_file.rb
+++ b/lib/pdk/answer_file.rb
@@ -1,0 +1,112 @@
+require 'json'
+
+module PDK
+  # Singleton accessor to the current answer file being used by the PDK.
+  #
+  # @return [PDK::AnswerFile] The AnswerFile instance currently being used by
+  #   the PDK.
+  def self.answers
+    @answer_file ||= PDK::AnswerFile.new
+  end
+
+  class AnswerFile
+    attr_reader :answers
+    attr_reader :answer_file_path
+
+    # Initialises the AnswerFile object, which stores the responses to certain
+    # interactive questions.
+    #
+    # @param answer_file_path [String, nil] The path on disk to the file where
+    #   the answers will be stored and read from. If not specified (or `nil`),
+    #   the default path will be used (see #default_answer_file_path).
+    #
+    # @raise (see #read_from_disk)
+    def initialize(answer_file_path = nil)
+      @answer_file_path = answer_file_path || default_answer_file_path
+      @answers = read_from_disk
+    end
+
+    # Retrieve the stored answer to a question.
+    #
+    # @param question [String] The question name/identifying string.
+    #
+    # @return [Object] The answer to the question, or `nil` if no answer found.
+    def [](question)
+      answers[question]
+    end
+
+    # Update the stored answers in memory and then save them to disk.
+    #
+    # @param new_answers [Hash{String => Object}] The new questions and answers
+    #   to be merged into the existing answers.
+    #
+    # @raise [PDK::CLI::FatalError] if the new answers are not provided as
+    #   a Hash.
+    # @raise (see #save_to_disk)
+    def update!(new_answers = {})
+      unless new_answers.is_a?(Hash)
+        raise PDK::CLI::FatalError, _('Answer file can only be updated with a Hash')
+      end
+
+      answers.merge!(new_answers)
+
+      save_to_disk
+    end
+
+    private
+
+    # Determine the default path to the answer file.
+    #
+    # @return [String] The path on disk to the default answer file.
+    def default_answer_file_path
+      File.join(PDK::Util.cachedir, 'answers.json')
+    end
+
+    # Read existing answers into memory from the answer file on disk.
+    #
+    # @raise [PDK::CLI::FatalError] If the answer file exists but can not be
+    #   read.
+    #
+    # @return [Hash{String => Object}] The existing questions and answers.
+    def read_from_disk
+      return {} if !File.file?(answer_file_path) || File.zero?(answer_file_path)
+
+      unless File.readable?(answer_file_path)
+        raise PDK::CLI::FatalError, _("Unable to open '%{file}' for reading") % {
+          file: answer_file_path,
+        }
+      end
+
+      answers = JSON.parse(File.read(answer_file_path))
+      if answers.is_a?(Hash)
+        answers
+      else
+        PDK.logger.warn _("Answer file '%{path}' did not contain a valid set of answers, recreating it") % {
+          path: answer_file_path,
+        }
+        {}
+      end
+    rescue JSON::JSONError
+      PDK.logger.warn _("Answer file '%{path}' did not contain valid JSON, recreating it") % {
+        path: answer_file_path,
+      }
+      {}
+    end
+
+    # Save the in memory answer set to the answer file on disk.
+    #
+    # @raise [PDK::CLI::FatalError] if the answer file can not be written to.
+    def save_to_disk
+      FileUtils.mkdir_p(File.dirname(answer_file_path))
+
+      File.open(answer_file_path, 'w') do |answer_file|
+        answer_file.puts JSON.pretty_generate(answers)
+      end
+    rescue SystemCallError, IOError => e
+      raise PDK::CLI::FatalError, _("Unable to write '%{file}': %{msg}") % {
+        file: answer_file_path,
+        msg:  e.message,
+      }
+    end
+  end
+end

--- a/lib/pdk/answer_file.rb
+++ b/lib/pdk/answer_file.rb
@@ -9,6 +9,14 @@ module PDK
     @answer_file ||= PDK::AnswerFile.new
   end
 
+  # Specify the path to a custom answer file that the PDK should use.
+  #
+  # @param path [String] A path on disk to the file where the PDK should store
+  #   answers to interactive questions.
+  def self.answer_file=(value)
+    @answer_file = PDK::AnswerFile.new(value)
+  end
+
   class AnswerFile
     attr_reader :answers
     attr_reader :answer_file_path

--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -66,6 +66,10 @@ module PDK::CLI
     flag :d, :debug, _('Enable debug output.') do |_, _|
       PDK.logger.enable_debug_output
     end
+
+    option nil, 'answer-file', _('Path to an answer file'), argument: :required, hidden: true do |value|
+      PDK.answer_file = value
+    end
   end
 
   require 'pdk/cli/new'

--- a/lib/pdk/cli/util/interview.rb
+++ b/lib/pdk/cli/util/interview.rb
@@ -27,9 +27,9 @@ module PDK
           num_questions = @questions.count
           @questions.each do |question_name, question|
             @name = question_name
-            puts pastel.bold(_('[Q %{current_number}/%{questions_total}]') % { current_number: i, questions_total: num_questions })
-            puts pastel.bold(question[:question])
-            puts question[:help]
+            @prompt.print pastel.bold(_('[Q %{current_number}/%{questions_total}]') % { current_number: i, questions_total: num_questions })
+            @prompt.print pastel.bold(question[:question])
+            @prompt.print question[:help]
             ask(_('-->')) do |q|
               q.required(question.fetch(:required, false))
 
@@ -40,7 +40,7 @@ module PDK
               q.default(question[:default]) if question.key?(:default)
             end
             i += 1
-            puts ''
+            @prompt.print ''
           end
           @answers
         rescue TTY::Prompt::Reader::InputInterrupt

--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -181,7 +181,7 @@ module PDK
         answers = interview.run
 
         if answers.nil?
-          puts _('Interview cancelled, aborting...')
+          PDK.logger.info _('Interview cancelled, not generating the module.')
           exit 0
         end
 
@@ -198,7 +198,7 @@ module PDK
         puts
 
         unless prompt.yes?(_('About to generate this module; continue?'))
-          puts _('Aborting...')
+          PDK.logger.info _('Module not generated.')
           exit 0
         end
 

--- a/spec/acceptance/support/in_a_new_module.rb
+++ b/spec/acceptance/support/in_a_new_module.rb
@@ -2,7 +2,13 @@ require 'open3'
 
 shared_context 'in a new module' do |name|
   before(:all) do
-    output, status = Open3.capture2e('pdk', 'new', 'module', name, '--skip-interview', '--template-url', "file://#{RSpec.configuration.template_dir}")
+    argv = [
+      'pdk', 'new', 'module', name,
+      '--skip-interview',
+      '--template-url', "file:///#{RSpec.configuration.template_dir}",
+      '--answer-file', File.join(Dir.pwd, "#{name}_answers.json")
+    ]
+    output, status = Open3.capture2e(*argv)
 
     raise "Failed to create test module:\n#{output}" unless status.success?
 
@@ -12,5 +18,6 @@ shared_context 'in a new module' do |name|
   after(:all) do
     Dir.chdir('..')
     FileUtils.rm_rf(name)
+    FileUtils.rm("#{name}_answers.json")
   end
 end

--- a/spec/pdk/answer_file_spec.rb
+++ b/spec/pdk/answer_file_spec.rb
@@ -1,0 +1,206 @@
+require 'spec_helper'
+require 'stringio'
+
+shared_context 'a valid answer file' do
+  before(:each) do
+    allow(File).to receive(:file?).with(default_path).and_return(true)
+    allow(File).to receive(:zero?).with(default_path).and_return(false)
+    allow(File).to receive(:readable?).with(default_path).and_return(true)
+    allow(File).to receive(:read).with(default_path).and_return('{"question": "answer"}')
+  end
+
+  subject(:answer_file) { described_class.new }
+end
+
+describe PDK::AnswerFile do
+  let(:default_path) { File.join(PDK::Util.cachedir, 'answers.json') }
+
+  describe '#initialize' do
+    context 'when not provided a path to an answer file' do
+      it 'uses the default path' do
+        expect(described_class.new).to have_attributes(answer_file_path: default_path)
+      end
+    end
+
+    context 'when provided a path to an answer file' do
+      let(:path) { '/path/to/answers.json' }
+
+      it 'uses the provided path' do
+        expect(described_class.new(path)).to have_attributes(answer_file_path: path)
+      end
+    end
+  end
+
+  describe '#read_from_disk' do
+    context 'when the answer file does not exist' do
+      before(:each) do
+        allow(File).to receive(:file?).with(default_path).and_return(false)
+      end
+
+      it 'creates an empty set of answers' do
+        expect(described_class.new).to have_attributes(answers: {})
+      end
+    end
+
+    context 'when the answer file exists' do
+      before(:each) do
+        allow(File).to receive(:file?).with(default_path).and_return(true)
+      end
+
+      context 'and contains no data' do
+        before(:each) do
+          allow(File).to receive(:zero?).with(default_path).and_return(true)
+        end
+
+        it 'creates an empty set of answers' do
+          expect(described_class.new).to have_attributes(answers: {})
+        end
+      end
+
+      context 'and is unreadable' do
+        before(:each) do
+          allow(File).to receive(:zero?).with(default_path).and_return(false)
+          allow(File).to receive(:readable?).with(default_path).and_return(false)
+        end
+
+        it 'raises a FatalError' do
+          expect { described_class.new }.to raise_error(PDK::CLI::FatalError, %r{unable to open .+ for reading}i)
+        end
+      end
+
+      context 'and is readable' do
+        let(:file_contents) {}
+
+        before(:each) do
+          allow(File).to receive(:zero?).with(default_path).and_return(false)
+          allow(File).to receive(:readable?).with(default_path).and_return(true)
+          allow(File).to receive(:read).with(default_path).and_return(file_contents)
+        end
+
+        context 'but contains invalid JSON' do
+          let(:file_contents) { 'this is not JSON' }
+          let(:warning_message) { a_string_matching(%r{answer file .+ did not contain valid JSON}i) }
+
+          it 'warns the user that the file could not be parsed' do
+            expect(logger).to receive(:warn).with(warning_message)
+
+            described_class.new
+          end
+
+          it 'creates a new empty set of answers' do
+            allow(logger).to receive(:warn).with(warning_message)
+
+            expect(described_class.new).to have_attributes(answers: {})
+          end
+        end
+
+        context 'but contains valid JSON that is not a Hash of answers' do
+          let(:file_contents) { '["this", "is", "an", "array"]' }
+          let(:warning_message) { a_string_matching(%r{answer file .+ did not contain a valid set of answers}i) }
+
+          it 'warns the user that the answers are invalid' do
+            expect(logger).to receive(:warn).with(warning_message)
+
+            described_class.new
+          end
+
+          it 'creates a new empty set of answers' do
+            allow(logger).to receive(:warn).with(warning_message)
+
+            expect(described_class.new).to have_attributes(answers: {})
+          end
+        end
+
+        context 'and contains a valid JSON Hash of answers' do
+          let(:file_contents) { '{"question": "answer"}' }
+
+          it 'populates the answer set with the values from the file' do
+            expect(described_class.new).to have_attributes(answers: { 'question' => 'answer' })
+          end
+        end
+      end
+    end
+  end
+
+  describe '#[]' do
+    include_context 'a valid answer file'
+
+    it 'returns the answer to the question if stored' do
+      expect(answer_file['question']).to eq('answer')
+    end
+
+    it 'returns nil to the question if not stored' do
+      expect(answer_file['unknown question']).to be_nil
+    end
+  end
+
+  describe '#update!' do
+    include_context 'a valid answer file'
+
+    before(:each) do
+      allow(answer_file).to receive(:save_to_disk)
+    end
+
+    it 'takes a hash of new answers and merges it into the existing answer set' do
+      answer_file.update!('another question' => 'different answer')
+
+      expect(answer_file).to have_attributes(answers: { 'question' => 'answer', 'another question' => 'different answer' })
+    end
+
+    it 'raises a FatalError if not passed a Hash' do
+      expect {
+        answer_file.update!('an answer without a question')
+      }.to raise_error(PDK::CLI::FatalError, %r{answer file can only be updated with a hash}i)
+    end
+  end
+
+  describe '#save_to_disk' do
+    include_context 'a valid answer file'
+
+    context 'when the file can be written to' do
+      let(:fake_file) { StringIO.new }
+
+      before(:each) do
+        allow(File).to receive(:open).with(default_path, 'w').and_yield(fake_file)
+      end
+
+      it 'writes the answer set to disk' do
+        answer_file.update!
+
+        fake_file.rewind
+        expect(fake_file.read).not_to be_empty
+      end
+
+      it 'writes out the answers as valid JSON' do
+        answer_file.update!
+
+        fake_file.rewind
+        expect(JSON.parse(fake_file.read)).to eq('question' => 'answer')
+      end
+    end
+
+    context 'when an IOError is raised' do
+      before(:each) do
+        allow(File).to receive(:open).with(any_args).and_call_original
+        allow(File).to receive(:open).with(default_path, 'w').and_raise(IOError, 'some error message')
+      end
+
+      it 'raises a FatalError' do
+        message = %r{\Aunable to write '#{Regexp.escape(default_path)}': .*some error message}i
+        expect { answer_file.update! }.to raise_error(PDK::CLI::FatalError, message)
+      end
+    end
+
+    context 'when a SystemCallError is raised' do
+      before(:each) do
+        allow(File).to receive(:open).with(any_args).and_call_original
+        allow(File).to receive(:open).with(default_path, 'w').and_raise(SystemCallError, 'some other error')
+      end
+
+      it 'raises a FatalError' do
+        message = %r{\Aunable to write '#{Regexp.escape(default_path)}': .*some other error}i
+        expect { answer_file.update! }.to raise_error(PDK::CLI::FatalError, message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the `PDK::AnswerFile` class to handle reading and saving user-supplied answers to questions.

The responses from the module interview for the following questions are saved and used as the default values for new modules:
 * Forge username
 * Author name
 * License

If the license is specified on the command line with `--license`, then that value is saved to the answer file as well.

Additionally, if the user specifies their own module template using `--template-url`, that value is also saved and used automatically for any subsequent modules.

I had to add a hidden option to the CLI (`--answer-file`) in order to run the acceptance tests with clean answer files. Not sure if we want to make this option visible or not (my gut reaction is to keep it hidden unless there is a need for it).