### PR TITLE
(SDK-299) Check metadata.json syntax before linting

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,6 @@ RSpec/FilePath:
     - 'spec/template_file_spec.rb'
     - 'spec/util/bundler_spec.rb'
     - 'spec/validate_spec.rb'
-    - 'spec/validations/metadata_spec.rb'
 
 # Offense count: 34
 RSpec/MultipleExpectations:

--- a/lib/pdk/validate.rb
+++ b/lib/pdk/validate.rb
@@ -1,11 +1,11 @@
-require 'pdk/validators/metadata'
+require 'pdk/validators/metadata_validator'
 require 'pdk/validators/puppet_validator'
 require 'pdk/validators/ruby_validator'
 
 module PDK
   module Validate
     def self.validators
-      @validators ||= [Metadata, PuppetValidator, RubyValidator].freeze
+      @validators ||= [MetadataValidator, PuppetValidator, RubyValidator].freeze
     end
   end
 end

--- a/lib/pdk/validators/metadata/metadata_json_lint.rb
+++ b/lib/pdk/validators/metadata/metadata_json_lint.rb
@@ -6,13 +6,13 @@ require 'pathname'
 
 module PDK
   module Validate
-    class Metadata < BaseValidator
+    class MetadataJSONLint < BaseValidator
       # Validate each metadata file separately, as metadata-json-lint does not
       # support multiple targets.
       INVOKE_STYLE = :per_target
 
       def self.name
-        'metadata'
+        'metadata-json-lint'
       end
 
       def self.cmd
@@ -42,7 +42,7 @@ module PDK
           json_data = []
         end
 
-        raise ArgumentError, 'More that 1 target provided to PDK::Validate::Metadata' if targets.count > 1
+        raise ArgumentError, 'More that 1 target provided to PDK::Validate::MetadataJSONLint' if targets.count > 1
 
         if json_data.empty?
           report.add_event(

--- a/lib/pdk/validators/metadata/metadata_syntax.rb
+++ b/lib/pdk/validators/metadata/metadata_syntax.rb
@@ -1,0 +1,88 @@
+require 'pdk'
+require 'pdk/cli/exec'
+require 'pdk/validators/base_validator'
+require 'pathname'
+
+module PDK
+  module Validate
+    class MetadataSyntax < BaseValidator
+      def self.name
+        'metadata-syntax'
+      end
+
+      def self.pattern
+        'metadata.json'
+      end
+
+      def self.invoke(report, options = {})
+        targets = parse_targets(options)
+
+        return 0 if targets.empty?
+
+        return_val = 0
+
+        # The pure ruby JSON parser gives much nicer parse error messages than
+        # the C extension at the cost of slightly slower parsing. We require it
+        # here and restore the C extension at the end of the method (if it was
+        # being used).
+        require 'json/pure'
+        JSON.parser = JSON::Pure::Parser
+
+        targets.each do |target|
+          unless File.file?(target)
+            report.add_event(
+              file:     target,
+              source:   name,
+              state:    :failure,
+              severity: 'error',
+              message:  _('not a file'),
+            )
+            return_val = 1
+            next
+          end
+
+          unless File.readable?(target)
+            report.add_event(
+              file: target,
+              source: name,
+              state: :failure,
+              severity: 'error',
+              message: _('could not be read'),
+            )
+            return_val = 1
+            next
+          end
+
+          begin
+            JSON.parse(File.read(target))
+
+            report.add_event(
+              file:     target,
+              source:   name,
+              state:    :passed,
+              severity: 'ok',
+            )
+          rescue JSON::ParserError => e
+            # Because the message contains a raw segment of the file, we use
+            # String#dump here to unescape any escape characters like newlines.
+            # We then strip out the surrounding quotes and the exclaimation
+            # point that json_pure likes to put in exception messages.
+            sane_message = e.message.dump[%r{\A"(.+?)!?"\Z}, 1]
+
+            report.add_event(
+              file:     target,
+              source:   name,
+              state:    :failure,
+              severity: 'error',
+              message:  sane_message,
+            )
+            return_val = 1
+          end
+        end
+
+        JSON.parser = JSON::Ext::Parser if defined?(JSON::Ext::Parser)
+        return_val
+      end
+    end
+  end
+end

--- a/lib/pdk/validators/metadata/metadata_syntax.rb
+++ b/lib/pdk/validators/metadata/metadata_syntax.rb
@@ -80,8 +80,9 @@ module PDK
           end
         end
 
-        JSON.parser = JSON::Ext::Parser if defined?(JSON::Ext::Parser)
         return_val
+      ensure
+        JSON.parser = JSON::Ext::Parser if defined?(JSON::Ext::Parser)
       end
     end
   end

--- a/lib/pdk/validators/metadata_validator.rb
+++ b/lib/pdk/validators/metadata_validator.rb
@@ -2,6 +2,7 @@ require 'pdk'
 require 'pdk/cli/exec'
 require 'pdk/validators/base_validator'
 require 'pdk/validators/metadata/metadata_json_lint'
+require 'pdk/validators/metadata/metadata_syntax'
 
 module PDK
   module Validate
@@ -11,7 +12,7 @@ module PDK
       end
 
       def self.metadata_validators
-        [MetadataJSONLint]
+        [MetadataSyntax, MetadataJSONLint]
       end
 
       def self.invoke(report, options = {})

--- a/lib/pdk/validators/metadata_validator.rb
+++ b/lib/pdk/validators/metadata_validator.rb
@@ -1,0 +1,29 @@
+require 'pdk'
+require 'pdk/cli/exec'
+require 'pdk/validators/base_validator'
+require 'pdk/validators/metadata/metadata_json_lint'
+
+module PDK
+  module Validate
+    class MetadataValidator < BaseValidator
+      def self.name
+        'metadata'
+      end
+
+      def self.metadata_validators
+        [MetadataJSONLint]
+      end
+
+      def self.invoke(report, options = {})
+        exit_code = 0
+
+        metadata_validators.each do |validator|
+          exit_code = validator.invoke(report, options)
+          break if exit_code != 0
+        end
+
+        exit_code
+      end
+    end
+  end
+end

--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'gettext-setup', '~> 0.24'
   spec.add_runtime_dependency 'tty-spinner', '~> 0.4'
   spec.add_runtime_dependency 'tty-prompt', '~> 0.12'
+  spec.add_runtime_dependency 'json_pure', '~> 2.1.0'
 
   # Used in the pdk-module-template
   spec.add_runtime_dependency 'deep_merge', '~> 1.1'

--- a/spec/cli/validate_spec.rb
+++ b/spec/cli/validate_spec.rb
@@ -42,7 +42,7 @@ describe 'Running `pdk validate` in a module' do
   end
 
   context 'when a single validator is provided as an argument' do
-    let(:validator) { PDK::Validate::Metadata }
+    let(:validator) { PDK::Validate::MetadataValidator }
 
     it 'only invokes the given validator and exits zero' do
       expect(validator).to receive(:invoke).with(report, {}).and_return(0)
@@ -63,7 +63,7 @@ describe 'Running `pdk validate` in a module' do
     let(:invoked_validators) do
       [
         PDK::Validate::PuppetValidator,
-        PDK::Validate::Metadata,
+        PDK::Validate::MetadataValidator,
       ]
     end
 
@@ -98,7 +98,7 @@ describe 'Running `pdk validate` in a module' do
   end
 
   context 'when targets are provided as arguments' do
-    let(:validator) { PDK::Validate::Metadata }
+    let(:validator) { PDK::Validate::MetadataValidator }
 
     it 'invokes the specified validator with the target as an option' do
       expect(validator).to receive(:invoke).with(report, targets: ['lib/', 'manifests/']).and_return(0)

--- a/spec/pdk/validate/metadata_json_lint_spec.rb
+++ b/spec/pdk/validate/metadata_json_lint_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe PDK::Validate::Metadata do
+describe PDK::Validate::MetadataJSONLint do
   it 'invokes `metadata-json-lint`' do
     allow(PDK::Util).to receive(:module_root).and_return('/')
 

--- a/spec/pdk/validate/metadata_syntax_spec.rb
+++ b/spec/pdk/validate/metadata_syntax_spec.rb
@@ -1,0 +1,209 @@
+require 'spec_helper'
+
+describe PDK::Validate::MetadataSyntax do
+  let(:module_root) { File.join('path', 'to', 'test', 'module') }
+
+  before(:each) do
+    allow(PDK::Util).to receive(:module_root).and_return(module_root)
+    allow(File).to receive(:directory?).with(module_root).and_return(true)
+  end
+
+  describe '.parse_targets' do
+    subject { described_class.parse_targets(targets: targets) }
+
+    context 'when given no targets' do
+      let(:module_metadata_json) { File.join(module_root, 'metadata.json') }
+      let(:glob_pattern) { File.join(module_root, described_class.pattern) }
+      let(:targets) { [] }
+
+      context 'and the module contains a metadata.json file' do
+        before(:each) do
+          allow(Dir).to receive(:glob).with(glob_pattern).and_return(module_metadata_json)
+        end
+
+        it 'returns the path to metadata.json in the module' do
+          is_expected.to eq([module_metadata_json])
+        end
+      end
+
+      context 'and the module does not contain a metadata.json file' do
+        before(:each) do
+          allow(Dir).to receive(:glob).with(glob_pattern).and_return([])
+        end
+
+        it 'returns no targets' do
+          is_expected.to eq([])
+        end
+      end
+    end
+
+    context 'when given specific target files' do
+      let(:targets) { ['target1', 'target2.json'] }
+
+      before(:each) do
+        targets.each do |target|
+          allow(File).to receive(:directory?).with(target).and_return(false)
+        end
+      end
+
+      it 'returns the targets' do
+        is_expected.to eq(targets)
+      end
+    end
+
+    context 'when given a specific target directory' do
+      let(:targets) { [File.join('path', 'to', 'target', 'directory')] }
+      let(:glob_pattern) { File.join(targets.first, described_class.pattern) }
+
+      before(:each) do
+        allow(File).to receive(:directory?).with(targets.first).and_return(true)
+      end
+
+      context 'and the directory contains a metadata.json file' do
+        let(:expected_targets) { [File.join(targets.first, 'metadata.json')] }
+
+        before(:each) do
+          allow(Dir).to receive(:glob).with(glob_pattern).and_return(expected_targets)
+        end
+
+        it 'returns the path to the metadata.json file in the target directory' do
+          is_expected.to eq(expected_targets)
+        end
+      end
+
+      context 'and the directory does not contain a metadata.json file' do
+        before(:each) do
+          allow(Dir).to receive(:glob).with(glob_pattern).and_return([])
+        end
+
+        it 'returns no targets' do
+          is_expected.to eq([])
+        end
+      end
+    end
+  end
+
+  describe '.invoke' do
+    subject(:return_value) { described_class.invoke(report, targets: targets.map { |r| r[:name] }) }
+
+    let(:report) { PDK::Report.new }
+    let(:targets) { [] }
+
+    before(:each) do
+      targets.each do |target|
+        allow(File).to receive(:directory?).with(target[:name]).and_return(target.fetch(:directory, false))
+        allow(File).to receive(:file?).with(target[:name]).and_return(target.fetch(:file, true))
+        allow(File).to receive(:readable?).with(target[:name]).and_return(target.fetch(:readable, true))
+        allow(File).to receive(:read).with(target[:name]).and_return(target.fetch(:content, ''))
+      end
+    end
+
+    context 'when no valid targets are provided' do
+      it 'does not attempt to validate files' do
+        expect(report).not_to receive(:add_event)
+        expect(return_value).to eq(0)
+      end
+    end
+
+    context 'when a target is provided that is not a file' do
+      let(:targets) do
+        [
+          { name: 'not_file', file: false },
+        ]
+      end
+
+      it 'adds a failure event to the report' do
+        expect(report).to receive(:add_event).with(
+          file:     targets.first[:name],
+          source:   'metadata-syntax',
+          state:    :failure,
+          severity: 'error',
+          message:  'not a file',
+        )
+        expect(return_value).to eq(1)
+      end
+    end
+
+    context 'when a target is provided that is an unreadable file' do
+      let(:targets) do
+        [
+          { name: 'not_readable', readable: false },
+        ]
+      end
+
+      it 'adds a failure event to the report' do
+        expect(report).to receive(:add_event).with(
+          file:     targets.first[:name],
+          source:   'metadata-syntax',
+          state:    :failure,
+          severity: 'error',
+          message:  'could not be read',
+        )
+        expect(return_value).to eq(1)
+      end
+    end
+
+    context 'when a target is provided that contains valid JSON' do
+      let(:targets) do
+        [
+          { name: 'valid_file', content: '{"test": "value"}' },
+        ]
+      end
+
+      it 'adds a passing event to the report' do
+        expect(report).to receive(:add_event).with(
+          file:     targets.first[:name],
+          source:   'metadata-syntax',
+          state:    :passed,
+          severity: 'ok',
+        )
+        expect(return_value).to eq(0)
+      end
+    end
+
+    context 'when a target is provided that contains invalid JSON' do
+      let(:targets) do
+        [
+          { name: 'invalid_file', content: '{"test"": "value"}' },
+        ]
+      end
+
+      it 'adds a failure event to the report' do
+        expect(report).to receive(:add_event).with(
+          file:     targets.first[:name],
+          source:   'metadata-syntax',
+          state:    :failure,
+          severity: 'error',
+          message:  a_string_matching(%r{\Aexpected ':' in object}),
+        )
+        expect(return_value).to eq(1)
+      end
+    end
+
+    context 'when targets are provided that contain valid and invalid JSON' do
+      let(:targets) do
+        [
+          { name: 'invalid_file', content: '{"test": "value",}' },
+          { name: 'valid_file', content: '{"test": "value"}' },
+        ]
+      end
+
+      it 'adds events for all targets to the report' do
+        expect(report).to receive(:add_event).with(
+          file:     'invalid_file',
+          source:   'metadata-syntax',
+          state:    :failure,
+          severity: 'error',
+          message:  a_string_matching(%r{\Aexpected next name}),
+        )
+        expect(report).to receive(:add_event).with(
+          file:     'valid_file',
+          source:   'metadata-syntax',
+          state:    :passed,
+          severity: 'ok',
+        )
+        expect(return_value).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/pdk/validate/metadata_validator_spec.rb
+++ b/spec/pdk/validate/metadata_validator_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe PDK::Validate::MetadataValidator do
+  let(:report) { PDK::Report.new }
+
+  describe '.invoke' do
+    subject(:return_value) { described_class.invoke(report, {}) }
+
+    context 'when the MetadataSyntax validator fails' do
+      before(:each) do
+        allow(PDK::Validate::MetadataSyntax).to receive(:invoke).with(report, anything).and_return(1)
+      end
+
+      it 'does not run the MetadataJSONLint validator and returns 1' do
+        expect(PDK::Validate::MetadataJSONLint).not_to receive(:invoke)
+        expect(return_value).to eq(1)
+      end
+    end
+
+    context 'when the MetadataSyntax validator succeeds' do
+      before(:each) do
+        allow(PDK::Validate::MetadataSyntax).to receive(:invoke).with(report, anything).and_return(0)
+      end
+
+      context 'and the MetadataJSONLint validator fails' do
+        before(:each) do
+          allow(PDK::Validate::MetadataJSONLint).to receive(:invoke).with(report, anything).and_return(1)
+        end
+
+        it 'returns 1' do
+          expect(return_value).to eq(1)
+        end
+      end
+
+      context 'and the MetadataJSONLint validator succeeds' do
+        before(:each) do
+          allow(PDK::Validate::MetadataJSONLint).to receive(:invoke).with(report, anything).and_return(0)
+        end
+
+        it 'returns 0' do
+          expect(return_value).to eq(0)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ end
 RSpec.shared_context :validators do
   let(:validators) do
     [
-      PDK::Validate::Metadata,
+      PDK::Validate::MetadataValidator,
       PDK::Validate::PuppetValidator,
       PDK::Validate::RubyValidator,
     ]


### PR DESCRIPTION
Adds a new validator (`metadata-syntax`) that uses json_pure to ensure the JSON files are syntactically correct before `PDK::Validate::MetadataJSONLint` is invoked. I'm forcing it to use json_pure for this because it provides much more useful error messages than the C extension.