### PR TITLE
(SDK-275) Run tests against VM with package install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,9 @@ build-iPhoneSimulator/
 /log/
 /repo-config/
 /acceptance_hosts.yml
+/junit/
+/archive/
+/sut-files.tgz
 
 +# Puppet packaging files
  +/ext/packaging/

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,10 @@ group :test do
 end
 
 group :acceptance do
-  gem 'beaker-hostgenerator'
   gem 'serverspec'
+end
+
+# beaker should not be installed on the SUT during package testing
+group :package_testing do
+  gem 'beaker'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -43,11 +43,9 @@ RSpec::Core::RakeTask.new(:spec) do |t|
 end
 
 namespace :acceptance do
-  desc 'Run acceptance tests against a pdk package'
-  RSpec::Core::RakeTask.new(:package) do |t|
+  desc 'Run acceptance tests against a puppet-sdk package'
+  task(:package) do
     require 'beaker-hostgenerator'
-
-    ENV['BEAKER_TESTMODE'] = 'agent'
 
     unless ENV['SHA']
       abort 'Environment variable SHA must be set to the SHA or tag of a pdk build'
@@ -70,7 +68,7 @@ namespace :acceptance do
       puts 'No TEST_TARGET set, falling back to regular beaker config'
     end
 
-    t.pattern = 'spec/acceptance/**.rb'
+    sh('bundle exec beaker -h acceptance_hosts.yml --options-file package-testing/config/options.rb --tests package-testing/tests/')
   end
 
   desc 'Run acceptance tests against current code'

--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,7 @@ RSpec::Core::RakeTask.new(:spec) do |t|
 end
 
 namespace :acceptance do
-  desc 'Run acceptance tests against a puppet-sdk package'
+  desc 'Run acceptance tests against a pdk package'
   task(:package) do
     require 'beaker-hostgenerator'
 

--- a/package-testing/config/options.rb
+++ b/package-testing/config/options.rb
@@ -1,0 +1,11 @@
+{
+  helper: 'package-testing/lib/helper.rb',
+  pre_suite: [
+    'package-testing/pre/000_install_package.rb',
+    'package-testing/pre/010_update_rubygems_cert.rb',
+    'package-testing/pre/020_copy_tests_to_sut.rb',
+  ],
+  post_suite: [
+    'package-testing/post/000_archive_results.rb',
+  ],
+}

--- a/package-testing/lib/helper.rb
+++ b/package-testing/lib/helper.rb
@@ -1,0 +1,1 @@
+$LOAD_PATH << File.expand_path(File.dirname(__FILE__))

--- a/package-testing/lib/pdk/pdk_helper.rb
+++ b/package-testing/lib/pdk/pdk_helper.rb
@@ -1,0 +1,48 @@
+# Memoized working directory to run the tests from
+
+# NOTE: currently there is an issue with beaker's create_tmpdir_on helper on cygwin
+# and OSX platforms:  the `chown` command always fails with an error about not
+# recognizing the Administrator:Administrator user/group.  Also, the call to
+# check user presence via `getent` also fails. Until this is fixed, we add this
+# shim that delegates to a non-`chown`/non-`getent`-executing version for the
+# purposes of our test setup.
+#
+# TODO: fix via: https://tickets.puppetlabs.com/browse/BKR-496
+def tmpdir_on(hosts, path_prefix = '', user = nil)
+  first_host = Array(hosts).first
+
+  return create_tmpdir_on(hosts, path_prefix, user) unless \
+    first_host.is_cygwin? || first_host.platform =~ %r{osx}
+
+  block_on hosts do |host|
+    # use default user logged into this host
+    unless user
+      user = host['user']
+    end
+
+    raise 'Host platform not supported by `tmpdir_on`.' unless defined? host.tmpdir
+    host.tmpdir(path_prefix)
+  end
+end
+
+def target_dir
+  $target_dir ||= tmpdir_on(workstation, 'pdk_acceptance') # rubocop:disable Style/GlobalVars
+end
+
+def install_dir(host)
+  if host.platform =~ %r{windows}
+    '/cygdrive/c/Program\ Files/Puppet\ Labs/DevelopmentKit'
+  else
+    '/opt/puppetlabs/sdk'
+  end
+end
+
+def pdk_rubygems_cert_dir(host)
+  "#{install_dir(host)}/private/ruby/2.1.9/lib/ruby/2.1.0/rubygems/ssl_certs"
+end
+
+def command_prefix(host)
+  command = "PATH=#{install_dir(host)}/bin:#{install_dir(host)}/private/ruby/2.1.9/bin:#{install_dir(host)}/private/git/bin:$PATH && cd #{target_dir} &&"
+  command = "#{command} cmd.exe /C" unless host.platform !~ %r{windows}
+  command
+end

--- a/package-testing/post/000_archive_results.rb
+++ b/package-testing/post/000_archive_results.rb
@@ -1,0 +1,6 @@
+test_name 'Archive test results'
+require 'pdk/pdk_helper.rb'
+
+step 'Archive rspec results' do
+  archive_file_from(workstation, "#{target_dir}/results.out")
+end

--- a/package-testing/pre/000_install_package.rb
+++ b/package-testing/pre/000_install_package.rb
@@ -1,14 +1,14 @@
-test_name 'Install puppet-sdk package on workstation host' do
+test_name 'Install pdk package on workstation host' do
   workstation = find_at_most_one('workstation')
 
-  step 'Install puppet-sdk package' do
+  step 'Install pdk package' do
     if workstation['platform'] =~ %r{windows}
       # BKR-1109 requests a neater way to install an MSI
-      msi_url = "http://#{ENV['BUILD_SERVER']}/puppet-sdk/#{ENV['SHA']}/repos/windows/puppet-sdk-x64.msi"
+      msi_url = "http://#{ENV['BUILD_SERVER']}/pdk/#{ENV['SHA']}/repos/windows/pdk-x64.msi"
       generic_install_msi_on(workstation, msi_url)
     else
-      install_puppetlabs_dev_repo(workstation, 'puppet-sdk', ENV['SHA'], 'repo-config')
-      workstation.install_package('puppet-sdk')
+      install_puppetlabs_dev_repo(workstation, 'pdk', ENV['SHA'], 'repo-config')
+      workstation.install_package('pdk')
     end
   end
 end

--- a/package-testing/pre/000_install_package.rb
+++ b/package-testing/pre/000_install_package.rb
@@ -1,0 +1,14 @@
+test_name 'Install puppet-sdk package on workstation host' do
+  workstation = find_at_most_one('workstation')
+
+  step 'Install puppet-sdk package' do
+    if workstation['platform'] =~ %r{windows}
+      # BKR-1109 requests a neater way to install an MSI
+      msi_url = "http://#{ENV['BUILD_SERVER']}/puppet-sdk/#{ENV['SHA']}/repos/windows/puppet-sdk-x64.msi"
+      generic_install_msi_on(workstation, msi_url)
+    else
+      install_puppetlabs_dev_repo(workstation, 'puppet-sdk', ENV['SHA'], 'repo-config')
+      workstation.install_package('puppet-sdk')
+    end
+  end
+end

--- a/package-testing/pre/010_update_rubygems_cert.rb
+++ b/package-testing/pre/010_update_rubygems_cert.rb
@@ -1,0 +1,13 @@
+test_name 'Update rubygems cert (if Windows)'
+require 'pdk/pdk_helper'
+
+skip_test 'Only need to do this on Windows' unless workstation.platform =~ %r{windows}
+
+step 'Get current rubygems cert' do
+  # TODO: do not depend on internet connectivity to get this file
+  on(workstation, 'curl -O https://raw.githubusercontent.com/rubygems/rubygems/master/lib/rubygems/ssl_certs/index.rubygems.org/GlobalSignRootCA.pem')
+end
+
+step 'Move cert to pdk cert folder' do
+  on(workstation, "cp GlobalSignRootCA.pem #{pdk_rubygems_cert_dir(workstation)}")
+end

--- a/package-testing/pre/020_copy_tests_to_sut.rb
+++ b/package-testing/pre/020_copy_tests_to_sut.rb
@@ -1,0 +1,39 @@
+test_name 'Copy pdk acceptance to the System Under Test and bundle install' do
+  require 'pdk/pdk_helper.rb'
+
+  # TODO: Need assurance that the ref of the acceptance tests is
+  # correct for the ref of the package being tested.
+
+  step 'Create target directory' do
+    on(workstation, "mkdir -p #{target_dir}")
+  end
+
+  # Required directories from pdk repo to run tests
+  %w[spec lib locales exe].each do |dir|
+    step "Copy #{dir} dir from pdk repo to System Under Test" do
+      scp_to(workstation, dir, "#{target_dir}/#{dir}")
+    end
+  end
+
+  # Required files from pdk repo to run tests
+  %w[Gemfile pdk.gemspec].each do |file|
+    step "Copy #{file} from pdk repo to System Under Test" do
+      scp_to(workstation, file, target_dir)
+    end
+  end
+
+  # This is required on Windows - git otherwise only allows 260 chars in a path.
+  step 'Allow long paths in git before running bundle install' do
+    on(workstation, "#{command_prefix(workstation)} git config --global core.longpaths true")
+  end
+
+  step 'Install pdk gem bundle using pdk\'s ruby' do
+    on(workstation, "#{command_prefix(workstation)} bundle install --path vendor/bundle --without development package_testing --jobs 4 --retry 4")
+  end
+
+  step 'Check rspec is ready' do
+    on(workstation, "#{command_prefix(workstation)} bundle exec rspec --version") do |outcome|
+      assert_match(%r{[0-9\.]*}, outcome.stdout, 'rspec --version outputs some version number')
+    end
+  end
+end

--- a/package-testing/tests/run_acceptance.rb
+++ b/package-testing/tests/run_acceptance.rb
@@ -1,0 +1,12 @@
+test_name 'Run acceptance spec against package'
+require 'pdk/pdk_helper.rb'
+
+step 'Run the tests' do
+  # TODO: Need to add junit formatter to allow junit XML output for CI to parse
+  # TODO: json formatter causes rspec to crash when encoding results in json
+  rspec_command = "#{command_prefix(workstation)} bundle exec rspec --pattern 'spec/acceptance/**.rb' --format documentation --out results.out"
+  on(workstation, rspec_command, accept_all_exit_codes: true) do |outcome|
+    assert_equal('', outcome.stderr, 'rspec stderr should be blank')
+    assert_equal(0, outcome.exit_code, 'rspec acceptance tests should exit with 0')
+  end
+end


### PR DESCRIPTION
The _acceptance:package_ command will now:

1. Install package on VM
2. Copy acceptance tests over to VM
3. (Using the ruby and git vendored with pdk package) bundle install acceptance test dependencies
4. Invoke rspec on the VM
5. On completion; copy the rspec results back to the machine that executed _acceptance:package_

Still a number of things to fix; but I'd like to review and commit the basis of this work then finish off the details.

Still TODO:

- Acceptance tests do not completely pass on either Linux or Windows
- Need to add junit XML formatter to rspec so the test results can be used by CI server
- Need some assurance (I'm not sure in advance how CI will be set up) that the version of tests that are run is the same pdk ref as the package being tested - currently tests may fail if the tests are from a different ref of pdk than what's built into the package
- Document how to work with acceptance tests
- Test on other platforms like Debian and OSX