### PR TITLE
removes some incorrect info from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,7 @@ To get started, generate a new module from the default template.
 pdk new module my_module
 ```
 
-This generates the basic components of a new module and initializes Git for you. The `pdk new module` command sets some default values based on your environment. Check the `metadata.json` to make sure that these values are correct. The new module now contains all the infrastructure to use the other capabilities of `pdk`.
-
-### Add a new resource provider
-
-If you need to manage a specific resource that is not covered by either Puppet's basic resource types or an existing module, create a new resource provider.
-
-1. From within an existing module, run `pdk add provider`, specifying the new provider name as well as any attributes along with their data types.
-
-For example:
-
-```
-pdk add provider new_provider String:content 'Enum[absent, present]:ensure'
-```
-
-This creates all the files required to define a resource type, its provider, and the associated basic tests. In this example, the resource type has an `ensure` property with the expected values, and a `String` property named `content`. If your types use Bash special characters, such as 'Enum[absent, present]:ensure' above, you must quote to avoid issues with the shell.
+This generates the basic components of a new module. The `pdk new module` command sets some default metadata values based on your environment. Check the `metadata.json` to make sure that these values are correct. The new module now contains all the infrastructure to use the other capabilities of `pdk`.
 
 ### Running validations
 


### PR DESCRIPTION
Removes the following info, which I am given to understand is not accurate:

* Creating a module initializes Git for you
* You can create a resource provider with pdk

I also added a sentence clarification, but it's pretty small.