### PR TITLE
Acceptance tidy-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,31 @@ bundle binstubs pdk --path ~/bin
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/puppetlabs/pdk.
 
+### Running tests
+
+pdk has three testing rake tasks
+
+#### spec
+
+Run unit tests.
+
+#### acceptance:local
+
+Run acceptance tests on the current pdk code. These tests are executed on commits and pull requests to this repo using both travis and appveyor.
+
+#### acceptance:package
+
+Run acceptance tests against a package install. This task is for Puppet's packaging CI, and contributors outside of Puppet, Inc. don't need to worry about executing it. It uses [beaker](https://github.com/puppetlabs/beaker) to provision a VM, fetch and install a pdk installation package, and then run the acceptance tests on that VM.
+It requires some environment variables to be set in order to specify what beaker will set up:
+
+Environment Variable | Usage
+---------------------|------
+**SHA** | The SHA or tag of a package build i.e. the folder name on the build server that packages will be found in.
+**TEST_TARGET** | A beaker-hostgenerator string for the OS of the VM you want to test on e.g. _redhat7-64workstation._ or _windows2012r2-64workstation._ (The period character after workstation is required by beaker-hostgenerator).
+**BUILD_SERVER** | (Only required if the tests will run on a Windows VM). The hostname of the build server that hosts packages. A Puppet JIRA ticket ([BKR-1109](https://tickets.puppetlabs.com/browse/BKR-1109)) has been filed to update beaker so this would never be required.
+
+On completion of this testing task, the results from the VM will be available in a folder named _archive_.
+
 ### Release Process
 
 1. Bump the version in `lib/pdk/version.rb`.

--- a/Rakefile
+++ b/Rakefile
@@ -52,20 +52,15 @@ namespace :acceptance do
     end
 
     test_target = ENV['TEST_TARGET']
-    if test_target
-      unless ENV['BUILD_SERVER'] || test_target !~ %r{win}
-        abort 'Testing against Windows requires environment variable BUILD_SERVER '\
-              'to be set to the hostname of your build server (JIRA BKR-1109)'
-      end
-      puts "Generating beaker hosts using TEST_TARGET value #{test_target}"
-      cli = BeakerHostGenerator::CLI.new(["#{test_target}{type=foss}", '--disable-default-role'])
-      ENV['BEAKER_setfile'] = generated_hosts_filename = 'acceptance_hosts.yml'
-      File.open(generated_hosts_filename, 'w') do |hosts_file|
-        hosts_file.print(cli.execute)
-      end
-
-    else
-      puts 'No TEST_TARGET set, falling back to regular beaker config'
+    abort 'TEST_TARGET must be set to a beaker-hostgenerator string for a workstation host e.g. redhat7-64workstation.' unless test_target
+    unless ENV['BUILD_SERVER'] || test_target !~ %r{win}
+      abort 'Testing against Windows requires environment variable BUILD_SERVER '\
+            'to be set to the hostname of your build server (JIRA BKR-1109)'
+    end
+    puts "Generating beaker hosts using TEST_TARGET value #{test_target}"
+    cli = BeakerHostGenerator::CLI.new(["#{test_target}{type=foss}", '--disable-default-role'])
+    File.open('acceptance_hosts.yml', 'w') do |hosts_file|
+      hosts_file.print(cli.execute)
     end
 
     sh('bundle exec beaker -h acceptance_hosts.yml --options-file package-testing/config/options.rb --tests package-testing/tests/')

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,8 +1,0 @@
-HOSTS:
-  centos-7-x64:
-    roles:
-      - workstation
-    platform: el-7-x86_64
-    box: puppetlabs/centos-7.0-64-nocm
-    hypervisor: vagrant
-    type: foss

--- a/spec/acceptance/nodesets/none.yml
+++ b/spec/acceptance/nodesets/none.yml
@@ -1,6 +1,0 @@
-HOSTS:
-  dummy-host:
-    roles:
-      - workstation
-    platform: el-7-x86_64 # Mandatory key and must be a supported value
-    hypervisor: none


### PR DESCRIPTION
Some tidy up around acceptance:
 * Remove Rakefile code relating to old vagrant-based acceptance testing (this is a leftover from before the acceptance:local task was available)
 * Remove spec/acceptance/nodesets directory that was also intended for vagrant-based acceptance testing.
 * Update README.md with guidance on the available testing rake tasks.