### PR TITLE
(maint) Improvements to acceptance testing packages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -68,6 +68,7 @@ namespace :acceptance do
 
   desc 'Run acceptance tests against current code'
   RSpec::Core::RakeTask.new(:local) do |t|
+    t.rspec_opts = '--tag ~package' # Exclude package specific examples
     t.pattern = 'spec/acceptance/**.rb'
   end
   task local: [:binstubs]

--- a/package-testing/lib/pdk/pdk_helper.rb
+++ b/package-testing/lib/pdk/pdk_helper.rb
@@ -33,7 +33,7 @@ def install_dir(host)
   if host.platform =~ %r{windows}
     '/cygdrive/c/Program\ Files/Puppet\ Labs/DevelopmentKit'
   else
-    '/opt/puppetlabs/sdk'
+    '/opt/puppetlabs/pdk'
   end
 end
 

--- a/package-testing/lib/pdk/pdk_helper.rb
+++ b/package-testing/lib/pdk/pdk_helper.rb
@@ -37,12 +37,20 @@ def install_dir(host)
   end
 end
 
+def pdk_git_bin_dir(host)
+  if host.platform =~ %r{windows}
+    "#{install_dir(host)}/private/git/mingw64/bin"
+  else
+    "#{install_dir(host)}/private/git/bin"
+  end
+end
+
 def pdk_rubygems_cert_dir(host)
   "#{install_dir(host)}/private/ruby/2.1.9/lib/ruby/2.1.0/rubygems/ssl_certs"
 end
 
 def command_prefix(host)
-  command = "PATH=#{install_dir(host)}/bin:#{install_dir(host)}/private/ruby/2.1.9/bin:#{install_dir(host)}/private/git/bin:$PATH && cd #{target_dir} &&"
+  command = "PATH=#{install_dir(host)}/bin:#{install_dir(host)}/private/ruby/2.1.9/bin:#{pdk_git_bin_dir(host)}:$PATH && cd #{target_dir} &&"
   command = "#{command} cmd.exe /C" unless host.platform !~ %r{windows}
   command
 end

--- a/spec/acceptance/package_spec.rb
+++ b/spec/acceptance/package_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper_acceptance'
+
+describe 'When pdk is installed by a package', package: true do
+  describe command('which pdk') do
+    its(:exit_status) { is_expected.to eq 0 }
+    its(:stdout) { is_expected.to match(%r{#{default_installed_bin_dir}/pdk}) }
+    its(:stderr) { is_expected.to match(%r{\A\Z}) }
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -59,6 +59,9 @@ end
 Specinfra.configuration.env = bundler_env.dup
 
 RSpec.configure do |c|
+  # If testing a package, set serverspec path to install dir
+  set :path, "#{default_installed_bin_dir}:$PATH" unless c.inclusion_filter.opposite.rules[:package]
+
   c.before(:suite) do
     RSpec.configuration.template_dir = Dir.mktmpdir
     output, status = Open3.capture2e('git', 'clone', '--bare', PDK::Generate::Module::DEFAULT_TEMPLATE, RSpec.configuration.template_dir)

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -14,6 +14,16 @@ else
   set :backend, :exec
 end
 
+# The default directory pdk bin would be installed to on this machine
+def default_installed_bin_dir
+  if Gem.win_platform?
+    # TODO: Also support Windows without cygwin
+    '/cygdrive/c/Program\ Files/Puppet\ Labs/DevelopmentKit/bin'
+  else
+    '/opt/puppetlabs/bin'
+  end
+end
+
 module Specinfra
   module Backend
     class Cmd


### PR DESCRIPTION
Ensure that acceptance tests against a package install execute the installed pdk and NOT pdk from source

Also updates the beaker pre-suite to use the new install path /opt/puppetlabs/pdk instead of sdk