### PR TITLE
(#137) Nicer response when binary doesn't exist

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'tty-spinner', '~> 0.4'
   spec.add_runtime_dependency 'tty-prompt', '~> 0.12'
   spec.add_runtime_dependency 'json_pure', '~> 2.1.0'
+  spec.add_runtime_dependency 'tty-which', '~> 0.3.0'
 
   # Used in the pdk-module-template
   spec.add_runtime_dependency 'deep_merge', '~> 1.1'


### PR DESCRIPTION
As reported in #137, when a user installs the PDK gem on a fresh machine that
does not have git installed, they get an unhelpful message about git failing
with a misleading reference to files inside the PDK.

With this change, we instead check that the binary being called exists before
attempting to execute it and raise an error suggesting that the user needs to
install the appropriate package before trying again.

This won't be a big issue once we have system packages going out, but it
provides a nicer initial experience for users installing the gem.

```
root@stretch:~# pdk new module foo --skip-interview
pdk (INFO): Creating new module: foo
pdk (FATAL): Unable to find `git`. Check that it is installed and try again.

root@stretch:~# apt-get install -y git
[output trimmed]

root@stretch:~# pdk new module foo --skip-interview
pdk (INFO): Creating new module: foo
root@stretch:~#
```

Fixes #137