### PR TITLE
(SDK-319) force usage of our ruby

### DIFF
--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -117,8 +117,6 @@ module PDK
               @process.environment['GEM_PATH'] = bundler_gem_path
             end
 
-            # TODO: we should probably more carefully manage PATH and maybe other things too
-
             mod_root = PDK::Util.module_root
 
             unless mod_root
@@ -129,7 +127,13 @@ module PDK
 
             Dir.chdir(mod_root) do
               ::Bundler.with_clean_env do
-                run_process!
+                tmp = ENV['PATH']
+                begin
+                  ENV['PATH'] = [RbConfig::CONFIG['bindir'], ENV['PATH']].compact.join(File::PATH_SEPARATOR)
+                  run_process!
+                ensure
+                  ENV['PATH'] = tmp
+                end
               end
             end
           else


### PR DESCRIPTION
When running commands in module context, we always want to use our private
ruby. Especially bundler's binstubs are using ruby from the PATH, which
led to weird failures, as the multiple rubies would not agree on installed
gems, etc.