### PR TITLE
(#158) (#166) Resolve issue loading bundler from gem installs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     - RUBY_VERSION: 21-x64
 
 install:
-  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
   - SET LOG_SPEC_ORDER=true
   - bundle install --jobs 4 --retry 2 --without development
 
@@ -23,8 +23,8 @@ test_script:
 
 # Uncomment this block to enable RDP access to the AppVeyor test instance for
 # debugging purposes.
-# on_finish:
-#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#on_finish:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 notifications:
   - provider: HipChat

--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -112,10 +112,12 @@ module PDK
               @process.environment['GEM_HOME'] = File.join(PDK::Util.cachedir, 'ruby', RbConfig::CONFIG['ruby_version'])
 
               # This allows the subprocess to find the 'bundler' gem, which isn't in the cachedir above for gem installs.
-              # bundler_gem_path = File.absolute_path(File.join(Gem.loaded_specs['bundler'].gem_dir, '..', '..', '..', '..', '..'))
-              bundler_gem_path = File.absolute_path(File.join(`bundle show bundler`, '..', '..'))
+              bundler_gem_path = File.absolute_path(File.join(`gem which bundler`, '..', '..', '..', '..'))
               @process.environment['GEM_PATH'] = bundler_gem_path
             end
+
+            # Make sure invocation of Ruby prefers our private installation.
+            @process.environment['PATH'] = [RbConfig::CONFIG['bindir'], ENV['PATH']].compact.join(File::PATH_SEPARATOR)
 
             mod_root = PDK::Util.module_root
 
@@ -127,13 +129,7 @@ module PDK
 
             Dir.chdir(mod_root) do
               ::Bundler.with_clean_env do
-                tmp = ENV['PATH']
-                begin
-                  ENV['PATH'] = [RbConfig::CONFIG['bindir'], ENV['PATH']].compact.join(File::PATH_SEPARATOR)
-                  run_process!
-                ensure
-                  ENV['PATH'] = tmp
-                end
+                run_process!
               end
             end
           else

--- a/spec/acceptance/test_unit_spec.rb
+++ b/spec/acceptance/test_unit_spec.rb
@@ -23,12 +23,13 @@ describe 'Running unit tests' do
 
     before(:all) do
       FileUtils.mkdir_p('spec/unit')
+      # FIXME: facterversion pin and facterdb issues
       File.open('spec/unit/passing_spec.rb', 'w') do |f|
         f.puts <<-EOF
           require 'spec_helper'
 
           RSpec.describe 'passing test' do
-            on_supported_os.each do |os, facts|
+            on_supported_os(:facterversion => '2.4.6').each do |os, facts|
               context "On OS \#{os}" do
                 it 'should pass' do
                   expect(true).to eq(true)


### PR DESCRIPTION
This changes the method for resolving the installation path of a user
managed bundler gem to make it not depend on bundler itself.

Also cleans up the management of subprocess PATH from SDK-319.