### PR TITLE
(maint) Add 2.1.9 as the minimum required ruby version in the gemspec

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.1.9'
+
   spec.add_runtime_dependency 'bundler', '~> 1.15'
   spec.add_runtime_dependency 'cri', '~> 2.9.1'
   spec.add_runtime_dependency 'childprocess', '~> 0.6.2'


### PR DESCRIPTION
Got a report of someone installing the PDK gem on Ruby 2.0.0 which threw syntax errors when trying to run any `pdk` commands. As 2.1.9 is the earliest Ruby version we're testing, we should specify that in the gemspec too.