### PR TITLE
(SDK-322) Acceptance test for spec tests of new class

### DIFF
--- a/spec/acceptance/new_class_spec.rb
+++ b/spec/acceptance/new_class_spec.rb
@@ -86,6 +86,14 @@ describe 'pdk new class', module_command: true do
           is_expected.to match(%r{new_class::bar::baz})
         end
       end
+
+      context 'when running the generated spec tests' do
+        describe command('pdk test unit') do
+          its(:exit_status) { is_expected.to eq 0 }
+          its(:stderr) { is_expected.to match(%r{0 failures}) }
+          its(:stderr) { is_expected.not_to match(%r{No examples found}) }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
SDK-322 was a bug where 0 examples ran for a new class due to a facter release leaving us with 0 facts for rspec-puppet-facts to use.
This commit adds an acceptance test to ensure that a new class will have more than 0 working examples when pdk test unit is run.