### PR TITLE
(MAINT) Remove spinner for `bundle check` command

### DIFF
--- a/lib/pdk/util/bundler.rb
+++ b/lib/pdk/util/bundler.rb
@@ -62,14 +62,12 @@ module PDK
         end
 
         def installed?
+          PDK.logger.debug(_('Checking for missing Gemfile dependencies.'))
+
           argv = ['check', "--gemfile=#{gemfile}"]
           argv << "--path=#{bundle_cachedir}" if PDK::Util.gem_install?
 
-          command = bundle_command(*argv).tap do |c|
-            c.add_spinner(_('Checking for missing Gemfile dependencies'))
-          end
-
-          result = command.execute!
+          result = bundle_command(*argv).execute!
 
           unless result[:exit_code].zero?
             $stderr.puts result[:stdout]

--- a/spec/acceptance/bundle_management_spec.rb
+++ b/spec/acceptance/bundle_management_spec.rb
@@ -10,9 +10,9 @@ describe 'Managing Gemfile dependencies' do
       # @result = shell_ex("#{path_to_pdk} ", chdir: target_dir)
     end
 
-    describe command('pdk test unit') do
+    describe command('pdk test unit --debug') do
       its(:exit_status) { is_expected.to eq 0 }
-      its(:stderr) { is_expected.to match(%r{Checking for missing Gemfile dependencies}i) }
+      its(:stdout) { is_expected.to match(%r{Checking for missing Gemfile dependencies}i) }
 
       describe file('Gemfile.lock') do
         it { is_expected.to be_file }

--- a/spec/util/bundler_spec.rb
+++ b/spec/util/bundler_spec.rb
@@ -132,7 +132,8 @@ RSpec.describe PDK::Util::Bundler do
       end
 
       it 'checks for missing but does not install anything' do
-        expect_command([bundle_regex, 'check', any_args], nil, %r{checking for missing}i)
+        expect_command([bundle_regex, 'check', any_args])
+        expect(logger).to receive(:debug).with(%r{checking for missing}i)
         expect(PDK::CLI::Exec::Command).not_to receive(:new).with(bundle_regex, 'install', any_args)
 
         described_class.ensure_bundle!


### PR DESCRIPTION
Since this runs pretty much every time and doesn't have potential for taking very long (as opposed to `bundle lock` or `bundle install`) I think it's more appropriate as a debug log message.