### PR TITLE
(DISCUSS) (SDK-331) Use vendored Gemfile.lock for new modules if present

### DIFF
--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -50,6 +50,15 @@ module PDK
 
         PDK.answers.update!('template-url' => template_url)
 
+        # In packaged installs, try to use vendored Gemfile.lock as a starting point.
+        if PDK::Util.package_install?
+          vendored_gemfile_lock = File.join(PDK::Util.package_cachedir, 'Gemfile.lock')
+
+          if File.exist?(vendored_gemfile_lock)
+            FileUtils.cp(vendored_gemfile_lock, File.join(temp_target_dir, 'Gemfile.lock'))
+          end
+        end
+
         FileUtils.mv(temp_target_dir, target_dir)
       end
 


### PR DESCRIPTION
This will be paired with a change in the packaging to vendor the generated Gemfile.lock.

Note that the Gemfile.lock will still be .gitignored.