### PR TITLE
(maint) Remove unused vcs option from 'pdk new module'

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Generates a new module.
 Usage:
 
 ```
-pdk new module [--template-url=git_url] [--license=spdx_identifier] [--vcs=vcs_provider] module_name [target_dir]
+pdk new module [--template-url=git_url] [--license=spdx_identifier] module_name [target_dir]
 ```
 
 The `pdk new module` command accepts the following arguments and options. Arguments are optional unless otherwise specified.
@@ -110,10 +110,6 @@ Overrides the template to use for this module. If possible, please contribute yo
 #### `--license=spdx_identifier`
 
 Specifies the license this module is written under. See https://spdx.org/licenses/ for a list of open source licenses, or use `proprietary`. Defaults to `Apache-2.0`.
-
-#### `--vcs=vcs_provider`
-
-Specifies the version control driver. Valid values: `git`, `none`. Default: `git`.
 
 #### `--skip-interview`
 

--- a/lib/pdk/cli/new/module.rb
+++ b/lib/pdk/cli/new/module.rb
@@ -10,8 +10,6 @@ module PDK::CLI
     option nil, 'license', _('Specifies the license this module is written under. ' \
       "This should be a identifier from https://spdx.org/licenses/. Common values are 'Apache-2.0', 'MIT', or 'proprietary'."), argument: :required
 
-    option nil, 'vcs', _("Specifies the version control driver. Valid values: 'git', 'none'. Default: 'git'."), argument: :required
-
     flag nil, 'skip-interview', _('When specified, skips interactive querying of metadata.')
 
     run do |opts, args, _cmd|
@@ -35,7 +33,6 @@ module PDK::CLI
 
       opts[:name] = module_name
       opts[:target_dir] = target_dir.nil? ? module_name : target_dir
-      opts[:vcs] ||= 'git'
 
       PDK.logger.info(_('Creating new module: %{modname}') % { modname: module_name })
       PDK::Generate::Module.invoke(opts)

--- a/spec/unit/cli/new/module_spec.rb
+++ b/spec/unit/cli/new/module_spec.rb
@@ -55,24 +55,6 @@ describe 'Running `pdk new module`' do
       end
     end
 
-    context 'and the vcs option' do
-      let(:vcs) { 'svn' }
-
-      it 'passes the value of the vcs option to PDK::Generate::Module.invoke' do
-        expect(PDK::Generate::Module).to receive(:invoke).with(hash_including(vcs: vcs))
-        expect(logger).to receive(:info).with("Creating new module: #{module_name}")
-        PDK::CLI.run(['new', 'module', '--vcs', vcs, module_name])
-      end
-    end
-
-    context 'without the vcs option' do
-      it 'defaults the value of the vcs option to git' do
-        expect(PDK::Generate::Module).to receive(:invoke).with(hash_including(vcs: 'git'))
-        expect(logger).to receive(:info).with("Creating new module: #{module_name}")
-        PDK::CLI.run(['new', 'module', module_name])
-      end
-    end
-
     context 'and the license option' do
       let(:license) { 'MIT' }
 


### PR DESCRIPTION
This option doesn't currently do anything as it's waiting on getting libgit2 into the package (which is blocked on devkit in the windows packages). We should remove this option for now as it suggests functionality that doesn't exist.