### PR TITLE
(MAINT) Replace #sort.last with #max

### DIFF
--- a/lib/pdk/validators/base_validator.rb
+++ b/lib/pdk/validators/base_validator.rb
@@ -76,7 +76,7 @@ module PDK
           parse_output(report, result, invokation_targets)
         end
 
-        exit_codes.sort.last
+        exit_codes.max
       end
     end
   end


### PR DESCRIPTION
A fix requested by @DavidS in #144 