### PR TITLE
(MAINT) Update CLI::Exec to use tty-spinner on Windows

### DIFF
--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -105,7 +105,14 @@ module PDK
           @success_message = opts.delete(:success)
           @failure_message = opts.delete(:failure)
 
-          @spinner = Gem.win_platform? ? WindowsSpinner.new(message, opts) : TTY::Spinner.new("[:spinner] #{message}", opts)
+          if Gem.win_platform?
+            # Guard against explicit nil passed for opts.
+            opts ||= {}
+            opts[:success_mark] = '*'
+            opts[:error_mark] = 'X'
+          end
+
+          @spinner = TTY::Spinner.new("[:spinner] #{message}", opts)
         end
 
         def execute!
@@ -199,30 +206,6 @@ module PDK
             # Wait indfinitely if no timeout set.
             @process.wait
           end
-        end
-      end
-
-      # This is a placeholder until we integrate ansicon into Windows packaging
-      # or come up with some other progress indicator for Windows.
-      class WindowsSpinner
-        def initialize(message, _opts = {})
-          @message = message
-        end
-
-        def auto_spin
-          $stderr.print @message << '...'
-        end
-
-        def success(message = '')
-          message = 'done.' if message.nil? || message.empty?
-
-          $stderr.print message << "\n"
-        end
-
-        def error(message = '')
-          message = 'FAILED' if message.nil? || message.empty?
-
-          $stderr.print message << "\n"
         end
       end
     end


### PR DESCRIPTION
Trying to get the default utf-8 success/error marks to work under Windows default terminal emulator is a river of tears. Just falling back to ASCII alternatives for now. 

We may in the future be able to detect when they are running under ConEmu or something that handles utf-8 better and improve the experience for those users.