### PR TITLE
(maint) Add unit test for PDK.logger

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,10 +18,16 @@ Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 RSpec.shared_context :stubbed_logger do
   let(:logger) { instance_double('PDK::Logger').as_null_object }
 
-  before(:each) { allow(PDK).to receive(:logger).and_return(logger) }
+  before(:each) do |example|
+    allow(PDK).to receive(:logger).and_return(logger) if example.metadata[:use_stubbed_logger]
+  end
 end
 
 RSpec.configure do |c|
+  c.define_derived_metadata do |metadata|
+    metadata[:use_stubbed_logger] = true unless metadata.key?(:use_stubbed_logger)
+  end
+
   c.include_context :stubbed_logger
 end
 

--- a/spec/unit/pdk_spec.rb
+++ b/spec/unit/pdk_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe PDK do
+  describe '.logger', use_stubbed_logger: false do
+    subject { described_class.logger }
+
+    it { is_expected.to be_an_instance_of(PDK::Logger) }
+  end
+end


### PR DESCRIPTION
Simple test, just to finish off the coverage of that class. Slight change to how the stubbed logger context is included so that it can be optionally disabled in order to test the actual behaviour of `PDK.logger`.