### PR TITLE
(SDK-323) Change color of default answer to cyan

### DIFF
--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -180,7 +180,7 @@ module PDK
           },
         ]
 
-        prompt = TTY::Prompt.new
+        prompt = TTY::Prompt.new(help_color: :cyan)
 
         interview = PDK::CLI::Util::Interview.new(prompt)
 


### PR DESCRIPTION
Cyan is less likely to conflict with a users background color than the
default (bright black).

Users can also avoid this by enabling their terminal's 'minimum
contrast' feature.