### PR TITLE
(maint) Expose message when FileUtils.mkdir_p fails during module generation

### DIFF
--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -112,8 +112,11 @@ module PDK
         ].each do |dir|
           begin
             FileUtils.mkdir_p(dir)
-          rescue SystemCallError
-            raise PDK::CLI::FatalError, _("Unable to create directory '%{dir}'") % { dir: dir }
+          rescue SystemCallError => e
+            raise PDK::CLI::FatalError, _("Unable to create directory '%{dir}': %{message}") % {
+              dir:     dir,
+              message: e.message,
+            }
           end
         end
       end

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -498,6 +498,18 @@ describe PDK::Generate::Module do
 
       described_class.prepare_module_directory(path)
     end
+
+    context 'when it fails to create a directory' do
+      before(:each) do
+        allow(FileUtils).to receive(:mkdir_p).with(anything).and_raise(SystemCallError, 'some message')
+      end
+
+      it 'raises a FatalError' do
+        expect {
+          described_class.prepare_module_directory(path)
+        }.to raise_error(PDK::CLI::FatalError, %r{unable to create directory.+some message}i)
+      end
+    end
   end
 
   describe '.username_from_login' do


### PR DESCRIPTION
Was adding a spec for this failure case and noticed that we're not displaying the message for the caught exception here.