### PR TITLE
Unit test baseline

### DIFF
--- a/lib/pdk/cli/util/interview.rb
+++ b/lib/pdk/cli/util/interview.rb
@@ -19,7 +19,7 @@ module PDK
         end
 
         def num_questions
-          @questions.count
+          (@questions ||= {}).count
         end
 
         def run

--- a/spec/unit/pdk/cli/bundle_spec.rb
+++ b/spec/unit/pdk/cli/bundle_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'Running `pdk bundle`' do
+  subject(:test_cmd) { PDK::CLI.instance_variable_get(:@bundle_cmd) }
+
+  it { is_expected.not_to be_nil }
+end

--- a/spec/unit/pdk/cli/errors_spec.rb
+++ b/spec/unit/pdk/cli/errors_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'PDK FatalError' do
+  subject(:fatal_error) { PDK::CLI::FatalError }
+
+  it 'has a message' do
+    error = fatal_error.new
+    expect(error.message).not_to be_nil
+  end
+end

--- a/spec/unit/pdk/cli/exec_spec.rb
+++ b/spec/unit/pdk/cli/exec_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'PDK::CLI::Exec' do
+  subject(:exec) { PDK::CLI::Exec }
+
+  it { is_expected.not_to be_nil }
+end

--- a/spec/unit/pdk/cli/test/unit_spec.rb
+++ b/spec/unit/pdk/cli/test/unit_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'PDK test unit' do
+  subject(:test_unit_cmd) { PDK::CLI.instance_variable_get(:@test_unit_cmd) }
+
+  it { is_expected.not_to be_nil }
+end

--- a/spec/unit/pdk/cli/util/interview_spec.rb
+++ b/spec/unit/pdk/cli/util/interview_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'Module interview' do
+  subject(:interview) { PDK::CLI::Util::Interview }
+
+  it 'initially has 0 questions' do
+    expect(interview.new({}, {}).num_questions).to eq(0)
+  end
+end

--- a/spec/unit/pdk/cli/util_spec.rb
+++ b/spec/unit/pdk/cli/util_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+require 'pdk/cli/util'
+
+describe 'PDK::CLI::Util' do
+  context 'ensure_in_module! method' do
+    subject(:ensure_in_module) { PDK::CLI::Util.ensure_in_module! }
+
+    it 'raises an error when not in a module directory' do
+      expect { ensure_in_module }.to raise_error(PDK::CLI::FatalError)
+    end
+  end
+end

--- a/spec/unit/pdk/cli/validate_spec.rb
+++ b/spec/unit/pdk/cli/validate_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'Running `pdk validate`' do
+  subject(:validate_cmd) { PDK::CLI.instance_variable_get(:@validate_cmd) }
+
+  it { is_expected.not_to be_nil }
+end

--- a/spec/unit/pdk/module/template_dir_spec.rb
+++ b/spec/unit/pdk/module/template_dir_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe PDK::Module::TemplateDir do
+  it 'has a metadata method' do
+    expect(described_class.instance_methods(false)).to include(:metadata)
+  end
+end

--- a/spec/unit/pdk/test/unit_spec.rb
+++ b/spec/unit/pdk/test/unit_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'pdk/tests/unit'
+
+describe PDK::Test::Unit do
+  it 'has an invoke method' do
+    expect(described_class.methods(false)).to include(:invoke)
+  end
+end

--- a/spec/unit/pdk/util/version_spec.rb
+++ b/spec/unit/pdk/util/version_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe PDK::Util::Version do
+  context 'Getting the version_string' do
+    subject(:version_string) { described_class.version_string }
+
+    it { is_expected.not_to be_nil }
+  end
+end

--- a/spec/unit/pdk/validate/base_validator_spec.rb
+++ b/spec/unit/pdk/validate/base_validator_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe PDK::Validate::BaseValidator do
+  context 'a class inheriting from BaseValidator' do
+    subject(:validator) { Class.new(described_class) }
+
+    it 'has an invoke method' do
+      expect(validator.methods).to include(:invoke)
+    end
+  end
+end

--- a/spec/unit/pdk/version_spec.rb
+++ b/spec/unit/pdk/version_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'PDK version string' do
+  it 'has major minor and patch numbers' do
+    expect(PDK::VERSION).to match(%r{^[0-9]+\.[0-9]+\.[0-9]+})
+  end
+end


### PR DESCRIPTION
Coveralls appears to only count coverage of code required by spec tests.
This commit adds at least a placeholder for all our code files; to set a baseline for Coveralls