### PR TITLE
(MAINT) Update to official master of github-changelog-generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,27 @@
 All notable changes to this project will be documented in this file.
 
 
+## [v0.6.0.pre](https://github.com/puppetlabs/pdk/tree/v0.6.0.pre) (2017-08-01)
+
+[Full Changelog](https://github.com/puppetlabs/pdk/compare/v0.5.0...v0.6.0.pre)
+
+**Implemented enhancements:**
+
+- \(maint\) Remove unimplemented `add provider` from docs [\#200](https://github.com/puppetlabs/pdk/pull/200) ([DavidS](https://github.com/DavidS))
+- Update PowerShell install instructions [\#194](https://github.com/puppetlabs/pdk/pull/194) ([jpogran](https://github.com/jpogran))
+- \(maint\) Remove unused vcs option from 'pdk new module' [\#192](https://github.com/puppetlabs/pdk/pull/192) ([rodjek](https://github.com/rodjek))
+- Document compatibility policy and upgrade strategy [\#188](https://github.com/puppetlabs/pdk/pull/188) ([turbodog](https://github.com/turbodog))
+- \(MAINT\) Remove spinner for `bundle check` command [\#187](https://github.com/puppetlabs/pdk/pull/187) ([scotje](https://github.com/scotje))
+- \(SDK-321\) add `pdk validate help` [\#183](https://github.com/puppetlabs/pdk/pull/183) ([DavidS](https://github.com/DavidS))
+- \(SDK-317\) Ensure parent of 'pdk new module' is writable before generation [\#175](https://github.com/puppetlabs/pdk/pull/175) ([rodjek](https://github.com/rodjek))
+
+**Fixed bugs:**
+
+- \(SDK-333\) Rescue Interrupt cleanly [\#199](https://github.com/puppetlabs/pdk/pull/199) ([scotje](https://github.com/scotje))
+- \(\#137\) Nicer response when binary doesn't exist [\#149](https://github.com/puppetlabs/pdk/pull/149) ([rodjek](https://github.com/rodjek))
+
 ## [v0.5.0](https://github.com/puppetlabs/pdk/tree/v0.5.0) (2017-07-20)
+
 [Full Changelog](https://github.com/puppetlabs/pdk/compare/v0.4.4...v0.5.0)
 
 **Implemented enhancements:**
@@ -16,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - \(SDK-331\) allow additional gems to be installed [\#178](https://github.com/puppetlabs/pdk/pull/178) ([DavidS](https://github.com/DavidS))
 
 ## [v0.4.4](https://github.com/puppetlabs/pdk/tree/v0.4.4) (2017-07-18)
+
 [Full Changelog](https://github.com/puppetlabs/pdk/compare/v0.4.3...v0.4.4)
 
 **Fixed bugs:**
@@ -26,6 +47,7 @@ All notable changes to this project will be documented in this file.
 - \(SDK-319\) force usage of our ruby [\#168](https://github.com/puppetlabs/pdk/pull/168) ([DavidS](https://github.com/DavidS))
 
 ## [v0.4.3](https://github.com/puppetlabs/pdk/tree/v0.4.3) (2017-07-17)
+
 [Full Changelog](https://github.com/puppetlabs/pdk/compare/v0.4.2...v0.4.3)
 
 **Fixed bugs:**
@@ -33,6 +55,7 @@ All notable changes to this project will be documented in this file.
 - \(FIXUP\) Fix default subprocess success/failure messages on Windows [\#164](https://github.com/puppetlabs/pdk/pull/164) ([scotje](https://github.com/scotje))
 
 ## [v0.4.2](https://github.com/puppetlabs/pdk/tree/v0.4.2) (2017-07-17)
+
 [Full Changelog](https://github.com/puppetlabs/pdk/compare/v0.4.1...v0.4.2)
 
 **Fixed bugs:**
@@ -42,6 +65,7 @@ All notable changes to this project will be documented in this file.
 - Use default username when Etc.getlogin fails [\#160](https://github.com/puppetlabs/pdk/pull/160) ([austb](https://github.com/austb))
 
 ## [v0.4.1](https://github.com/puppetlabs/pdk/tree/v0.4.1) (2017-07-14)
+
 [Full Changelog](https://github.com/puppetlabs/pdk/compare/v0.4.0...v0.4.1)
 
 **Fixed bugs:**
@@ -49,6 +73,7 @@ All notable changes to this project will be documented in this file.
 - \(FIXUP\) Resolve conflation of cachedir concepts [\#153](https://github.com/puppetlabs/pdk/pull/153) ([scotje](https://github.com/scotje))
 
 ## [v0.4.0](https://github.com/puppetlabs/pdk/tree/v0.4.0) (2017-07-14)
+
 [Full Changelog](https://github.com/puppetlabs/pdk/compare/v0.3.0...v0.4.0)
 
 **Implemented enhancements:**
@@ -64,6 +89,7 @@ All notable changes to this project will be documented in this file.
 - \(SDK-298\) Handle exception raised when an invalid report format is specified on the CLI [\#125](https://github.com/puppetlabs/pdk/pull/125) ([rodjek](https://github.com/rodjek))
 
 ## [v0.3.0](https://github.com/puppetlabs/pdk/tree/v0.3.0) (2017-06-29)
+
 [Full Changelog](https://github.com/puppetlabs/pdk/compare/v0.2.0...v0.3.0)
 
 **Implemented enhancements:**
@@ -83,6 +109,7 @@ All notable changes to this project will be documented in this file.
 - \(SDK-277\) Exit cleanly if pdk commands are run outside of a module [\#100](https://github.com/puppetlabs/pdk/pull/100) ([rodjek](https://github.com/rodjek))
 
 ## [v0.2.0](https://github.com/puppetlabs/pdk/tree/v0.2.0) (2017-06-21)
+
 [Full Changelog](https://github.com/puppetlabs/pdk/compare/v0.1.0...v0.2.0)
 
 **Implemented enhancements:**
@@ -103,6 +130,7 @@ All notable changes to this project will be documented in this file.
 - \(maint\) nokogiri: avoid versions without ruby 2.1 support [\#60](https://github.com/puppetlabs/pdk/pull/60) ([DavidS](https://github.com/DavidS))
 
 ## [v0.1.0](https://github.com/puppetlabs/pdk/tree/v0.1.0) (2017-06-05)
+
 [Full Changelog](https://github.com/puppetlabs/pdk/compare/2be9329bed4715c888f273814b99f2cf37ee9341...v0.1.0)
 
 **Implemented enhancements:**
@@ -126,4 +154,4 @@ All notable changes to this project will be documented in this file.
 
 
 
-\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*
+* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'nokogiri', '1.7.2'
 
 group :development do
   gem 'activesupport', '4.2.9'
-  # section mapping merged into master, not yet released
+  # TODO: Use gem instead of git. Section mapping is merged into master, but not yet released
   gem 'github_changelog_generator', git: 'https://github.com/skywinder/github-changelog-generator.git', ref: '33f89614d47a4bca1a3ae02bdcc37edd0b012e86'
   gem 'pry-byebug', '~> 3.4'
   if RUBY_VERSION < '2.2.2'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ gem 'nokogiri', '1.7.2'
 
 group :development do
   gem 'activesupport', '4.2.9'
-  gem 'github_changelog_generator', git: 'https://github.com/DavidS/github-changelog-generator.git', ref: 'adjust-tag-section-mapping'
+  # section mapping merged into master, not yet released
+  gem 'github_changelog_generator', git: 'https://github.com/skywinder/github-changelog-generator.git', ref: '33f89614d47a4bca1a3ae02bdcc37edd0b012e86'
   gem 'pry-byebug', '~> 3.4'
   if RUBY_VERSION < '2.2.2'
     # required for github_changelog_generator

--- a/Rakefile
+++ b/Rakefile
@@ -92,6 +92,7 @@ begin
     config.header = "# Changelog\n\nAll notable changes to this project will be documented in this file.\n"
     config.include_labels = %w[enhancement bug]
     config.user = 'puppetlabs'
+    config.project = 'pdk'
   end
 rescue LoadError
   desc 'Install github_changelog_generator to get access to automatic changelog generation'


### PR DESCRIPTION
Since skywinder/github-changelog-generator#550 was merged, we can switch to the upstream repo.

Once a new version is released we can drop the git reference altogether.

This also includes a minor config change to make the rake task work, and the current output to show the minimal changes to the CHANGELOG file's format, and no content changes in the historical entries.