### PR TITLE
Give beaker package tests their own Gemfile

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ AllCops:
     - vendor/**/*
     # Puppet util code follows Puppet's style, not pdk's
     - lib/puppet/**/*
+    # package testing gems
+    # TODO: Only want to exclude package-testing/vendor/**/* but that causes obsolescence errors (bug?)
+    - package-testing/**/*
 
 Layout/IndentHeredoc:
   Description: The `squiggly` style would be preferable, but is only available from ruby 2.3. We'll enable this when we can.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,10 @@ Run ruby style checks. Use `rake rubocop:auto_correct` to fix the easy ones.
 
 Run acceptance tests on the current pdk code. These tests are executed on commits and pull requests to this repo using both travis and appveyor.
 
-## acceptance:package
+# Testing packages
 
-Run acceptance tests against a package install. This task is for Puppet's packaging CI, and contributors outside of Puppet, Inc. don't need to worry about executing it. It uses [beaker](https://github.com/puppetlabs/beaker) to provision a VM, fetch and install a pdk installation package, and then run the acceptance tests on that VM.
+The package-testing/ folder contains files for testing built packages of pdk. This is for Puppet's packaging CI, and contributors outside of Puppet, Inc. don't need to worry about executing it. It uses [beaker](https://github.com/puppetlabs/beaker) to provision a VM, fetch and install a pdk installation package, and then run the acceptance tests on that VM.
+This folder has its own Gemfile and Rakefile providing an _acceptance_ rake task.
 It requires some environment variables to be set in order to specify what beaker will set up:
 
 Environment Variable | Usage

--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,3 @@ end
 group :acceptance do
   gem 'serverspec'
 end
-
-# beaker should not be installed on the SUT during package testing
-group :package_testing do
-  gem 'beaker'
-end

--- a/Rakefile
+++ b/Rakefile
@@ -43,29 +43,6 @@ RSpec::Core::RakeTask.new(:spec) do |t|
 end
 
 namespace :acceptance do
-  desc 'Run acceptance tests against a pdk package'
-  task(:package) do
-    require 'beaker-hostgenerator'
-
-    unless ENV['SHA']
-      abort 'Environment variable SHA must be set to the SHA or tag of a pdk build'
-    end
-
-    test_target = ENV['TEST_TARGET']
-    abort 'TEST_TARGET must be set to a beaker-hostgenerator string for a workstation host e.g. redhat7-64workstation.' unless test_target
-    unless ENV['BUILD_SERVER'] || test_target !~ %r{win}
-      abort 'Testing against Windows requires environment variable BUILD_SERVER '\
-            'to be set to the hostname of your build server (JIRA BKR-1109)'
-    end
-    puts "Generating beaker hosts using TEST_TARGET value #{test_target}"
-    cli = BeakerHostGenerator::CLI.new(["#{test_target}{type=foss}", '--disable-default-role'])
-    File.open('acceptance_hosts.yml', 'w') do |hosts_file|
-      hosts_file.print(cli.execute)
-    end
-
-    sh('bundle exec beaker -h acceptance_hosts.yml --options-file package-testing/config/options.rb --tests package-testing/tests/')
-  end
-
   desc 'Run acceptance tests against current code'
   RSpec::Core::RakeTask.new(:local) do |t|
     t.rspec_opts = '--tag ~package' # Exclude package specific examples

--- a/package-testing/.gitignore
+++ b/package-testing/.gitignore
@@ -1,0 +1,13 @@
+# bundler items
+/.bundle/
+/vendor/
+/Gemfile.lock
+
+# beaker output directories
+/tmp/
+/log/
+/repo-config/
+/acceptance_hosts.yml
+/junit/
+/archive/
+/sut-files.tgz

--- a/package-testing/Gemfile
+++ b/package-testing/Gemfile
@@ -1,0 +1,16 @@
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+
+def location_for(place, fake_version = nil)
+  if place =~ /^(git:[^#]*)#(.*)/
+    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  else
+    [place, { :require => false }]
+  end
+end
+
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.21')
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
+gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
+gem "rake", "~> 10.1"

--- a/package-testing/Rakefile
+++ b/package-testing/Rakefile
@@ -1,0 +1,22 @@
+desc 'Run acceptance tests against a pdk package'
+task(:acceptance) do
+  require 'beaker-hostgenerator'
+
+  unless ENV['SHA']
+    abort 'Environment variable SHA must be set to the SHA or tag of a pdk build'
+  end
+
+  test_target = ENV['TEST_TARGET']
+  abort 'TEST_TARGET must be set to a beaker-hostgenerator string for a workstation host e.g. redhat7-64workstation.' unless test_target
+  unless ENV['BUILD_SERVER'] || test_target !~ %r{win}
+    abort 'Testing against Windows requires environment variable BUILD_SERVER '\
+          'to be set to the hostname of your build server (JIRA BKR-1109)'
+  end
+  puts "Generating beaker hosts using TEST_TARGET value #{test_target}"
+  cli = BeakerHostGenerator::CLI.new(["#{test_target}{type=foss}", '--disable-default-role'])
+  File.open('acceptance_hosts.yml', 'w') do |hosts_file|
+    hosts_file.print(cli.execute)
+  end
+
+  sh('bundle exec beaker -h acceptance_hosts.yml --options-file config/options.rb --tests tests/')
+end

--- a/package-testing/config/options.rb
+++ b/package-testing/config/options.rb
@@ -1,6 +1,6 @@
 {
-  helper: 'package-testing/lib/helper.rb',
+  helper: 'lib/helper.rb',
   pre_suite: [
-    'package-testing/pre/000_install_package.rb',
+    'pre/000_install_package.rb',
   ],
 }

--- a/spec/acceptance/package_spec.rb
+++ b/spec/acceptance/package_spec.rb
@@ -1,9 +1,0 @@
-require 'spec_helper_acceptance'
-
-describe 'When pdk is installed by a package', package: true do
-  describe command('which pdk') do
-    its(:exit_status) { is_expected.to eq 0 }
-    its(:stdout) { is_expected.to match(%r{#{default_installed_bin_dir}/pdk}) }
-    its(:stderr) { is_expected.to match(%r{\A\Z}) }
-  end
-end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -59,9 +59,6 @@ end
 Specinfra.configuration.env = bundler_env.dup
 
 RSpec.configure do |c|
-  # If testing a package, set serverspec path to install dir
-  set :path, "#{default_installed_bin_dir}:$PATH" unless c.inclusion_filter.opposite.rules[:package]
-
   c.before(:suite) do
     RSpec.configuration.template_dir = Dir.mktmpdir
     output, status = Open3.capture2e('git', 'clone', '--bare', PDK::Generate::Module::DEFAULT_TEMPLATE, RSpec.configuration.template_dir)


### PR DESCRIPTION
To isolate package testing from the codebase (specifically pdk's Gemfile), package-testing should have its own Gemfile.

This PR also has a commit to remove a couple of 'package testing' leftovers from the spec/ folder