### PR TITLE
(MAINT) Add --strict-dependencies to metadata-json-lint invocation

### DIFF
--- a/lib/pdk/validators/metadata/metadata_json_lint.rb
+++ b/lib/pdk/validators/metadata/metadata_json_lint.rb
@@ -31,6 +31,7 @@ module PDK
 
       def self.parse_options(_options, targets)
         cmd_options = ['--format', 'json']
+        cmd_options << '--strict-dependencies'
 
         cmd_options.concat(targets)
       end

--- a/spec/unit/pdk/validate/metadata_json_lint_spec.rb
+++ b/spec/unit/pdk/validate/metadata_json_lint_spec.rb
@@ -55,19 +55,15 @@ describe PDK::Validate::MetadataJSONLint do
     let(:targets) { %w[target1 target2.json] }
 
     it 'sets the output format as JSON' do
-      expect(command_args.first(2)).to eq(['--format', 'json'])
+      expect(command_args.join(' ')).to match(%r{--format json})
+    end
+
+    it 'enables strict dependency check' do
+      expect(command_args).to include('--strict-dependencies')
     end
 
     it 'appends the targets to the command arguments' do
       expect(command_args.last(targets.count)).to eq(targets)
-    end
-
-    context 'when auto-correct is enabled' do
-      let(:options) { { auto_correct: true } }
-
-      it 'has no effect' do
-        expect(command_args).to eq(['--format', 'json'].concat(targets))
-      end
     end
   end
 


### PR DESCRIPTION
metadata-json-lint 2.0.2 changed the behavior around open-ended dependencies...