### PR TITLE
(MAINT) Add ability to test locally built package with beaker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,14 +32,16 @@ Run acceptance tests on the current pdk code. These tests are executed on commit
 # Testing packages
 
 The package-testing/ folder contains files for testing built packages of pdk. This is for Puppet's packaging CI, and contributors outside of Puppet, Inc. don't need to worry about executing it. It uses [beaker](https://github.com/puppetlabs/beaker) to provision a VM, fetch and install a pdk installation package, and then run the acceptance tests on that VM.
-This folder has its own Gemfile and Rakefile providing an _acceptance_ rake task.
-It requires some environment variables to be set in order to specify what beaker will set up:
+
+This folder has its own Gemfile and Rakefile providing an _acceptance_ rake task. It requires some environment variables to be set in order to specify what beaker will set up:
 
 Environment Variable | Usage
 ---------------------|------
 **SHA** | The SHA or tag of a package build i.e. the folder name on the build server that packages will be found in.
+*--or--* |
+**LOCAL_PKG** | Full path to a locally built package that you want to test.
 **TEST_TARGET** | A beaker-hostgenerator string for the OS of the VM you want to test on e.g. _redhat7-64workstation._ or _windows2012r2-64workstation._ (The period character after workstation is required by beaker-hostgenerator).
-**BUILD_SERVER** | (Only required if the tests will run on a Windows VM). The hostname of the build server that hosts packages. A Puppet JIRA ticket ([BKR-1109](https://tickets.puppetlabs.com/browse/BKR-1109)) has been filed to update beaker so this would never be required.
+**BUILD_SERVER** | (Only required if testing a SHA on a Windows VM). The hostname of the build server that hosts packages. A Puppet JIRA ticket ([BKR-1109](https://tickets.puppetlabs.com/browse/BKR-1109)) has been filed to update beaker so this would never be required.
 
 # Release Process
 

--- a/package-testing/Rakefile
+++ b/package-testing/Rakefile
@@ -13,6 +13,10 @@ task(:acceptance) do
     abort "Both SHA and LOCAL_PKG are set, these vars are mutually exclusive. Set only one or the other."
   end
 
+  if ENV['LOCAL_PKG'] && !File.exist?(ENV['LOCAL_PKG'])
+    abort "LOCAL_PKG is set to '#{ENV['LOCAL_PKG']}' but that file does not exist."
+  end
+
   unless test_target = ENV['TEST_TARGET']
     abort 'TEST_TARGET must be set to a beaker-hostgenerator string for a workstation host e.g. "redhat7-64workstation."'
   end

--- a/package-testing/Rakefile
+++ b/package-testing/Rakefile
@@ -9,11 +9,17 @@ task(:acceptance) do
     EOS
   end
 
+  if ENV['SHA'] && ENV['LOCAL_PKG']
+    abort "Both SHA and LOCAL_PKG are set, these vars are mutually exclusive. Set only one or the other."
+  end
+
   unless test_target = ENV['TEST_TARGET']
     abort 'TEST_TARGET must be set to a beaker-hostgenerator string for a workstation host e.g. "redhat7-64workstation."'
   end
 
-  unless ENV['BUILD_SERVER'] || test_target !~ %r{win}
+  # TODO: Is there a reason not to just default BUILD_SERVER to
+  # builds.delivery.puppetlabs.net instead of requiring it?
+  unless (!ENV['SHA'] || ENV['BUILD_SERVER']) || test_target !~ %r{win}
     abort 'Testing against Windows requires environment variable BUILD_SERVER '\
           'to be set to the hostname of your build server (JIRA BKR-1109)'
   end

--- a/package-testing/Rakefile
+++ b/package-testing/Rakefile
@@ -2,18 +2,26 @@ desc 'Run acceptance tests against a pdk package'
 task(:acceptance) do
   require 'beaker-hostgenerator'
 
-  unless ENV['SHA']
-    abort 'Environment variable SHA must be set to the SHA or tag of a pdk build'
+  unless ENV['SHA'] || ENV['LOCAL_PKG']
+    abort "SHA or LOCAL_PKG must be set:\n" +
+      "  SHA: git sha or tag of a pdk package build available on the server\n" +
+      "  LOCAL_PKG: path to a locally built package to use for testing"
+    EOS
   end
 
-  test_target = ENV['TEST_TARGET']
-  abort 'TEST_TARGET must be set to a beaker-hostgenerator string for a workstation host e.g. redhat7-64workstation.' unless test_target
+  unless test_target = ENV['TEST_TARGET']
+    abort 'TEST_TARGET must be set to a beaker-hostgenerator string for a workstation host e.g. "redhat7-64workstation."'
+  end
+
   unless ENV['BUILD_SERVER'] || test_target !~ %r{win}
     abort 'Testing against Windows requires environment variable BUILD_SERVER '\
           'to be set to the hostname of your build server (JIRA BKR-1109)'
   end
+
   puts "Generating beaker hosts using TEST_TARGET value #{test_target}"
+
   cli = BeakerHostGenerator::CLI.new(["#{test_target}{type=foss}", '--disable-default-role'])
+
   File.open('acceptance_hosts.yml', 'w') do |hosts_file|
     hosts_file.print(cli.execute)
   end

--- a/package-testing/pre/000_install_package.rb
+++ b/package-testing/pre/000_install_package.rb
@@ -6,6 +6,10 @@ test_name 'Install pdk package on workstation host' do
       # BKR-1109 requests a neater way to install an MSI
       msi_url = "http://#{ENV['BUILD_SERVER']}/pdk/#{ENV['SHA']}/repos/windows/pdk-x64.msi"
       generic_install_msi_on(workstation, msi_url)
+    elsif ENV['LOCAL_PKG']
+      pkg_fullname = File.basename(ENV['LOCAL_PKG'])
+      scp_to(workstation, ENV['LOCAL_PKG'], "/root/#{pkg_fullname}")
+      workstation.install_package(pkg_fullname)
     else
       install_puppetlabs_dev_repo(workstation, 'pdk', ENV['SHA'], 'repo-config')
       workstation.install_package('pdk')

--- a/package-testing/pre/000_install_package.rb
+++ b/package-testing/pre/000_install_package.rb
@@ -2,17 +2,24 @@ test_name 'Install pdk package on workstation host' do
   workstation = find_at_most_one('workstation')
 
   step 'Install pdk package' do
+    if ENV['LOCAL_PKG']
+      pkg = File.basename(ENV['LOCAL_PKG'])
+      scp_to(workstation, ENV['LOCAL_PKG'], pkg)
+    end
+
     if workstation['platform'] =~ %r{windows}
+      pkg ||= "http://#{ENV['BUILD_SERVER']}/pdk/#{ENV['SHA']}/repos/windows/pdk-x64.msi"
+
       # BKR-1109 requests a neater way to install an MSI
-      msi_url = "http://#{ENV['BUILD_SERVER']}/pdk/#{ENV['SHA']}/repos/windows/pdk-x64.msi"
-      generic_install_msi_on(workstation, msi_url)
-    elsif ENV['LOCAL_PKG']
-      pkg_fullname = File.basename(ENV['LOCAL_PKG'])
-      scp_to(workstation, ENV['LOCAL_PKG'], "/root/#{pkg_fullname}")
-      workstation.install_package(pkg_fullname)
+      generic_install_msi_on(workstation, pkg)
     else
-      install_puppetlabs_dev_repo(workstation, 'pdk', ENV['SHA'], 'repo-config')
-      workstation.install_package('pdk')
+      pkg ||= 'pdk'
+
+      if ENV['SHA']
+        install_puppetlabs_dev_repo(workstation, 'pdk', ENV['SHA'], 'repo-config')
+      end
+
+      workstation.install_package(pkg)
     end
   end
 end


### PR DESCRIPTION
This change lets you run the package-based acceptance tests but on a package you have built locally instead of requiring it to be on the builds server.

For example:

```
LOCAL_PKG=/path/to/package/pdk-0.5.0.0.11.g612fd91-1.el7.x86_64.rpm TEST_TARGET=redhat7-64workstation. bundle exec rake acceptance
```

I found this greatly reduced my cycle times for testing acceptance test changes that also required code changes.

Thoughts? Is there a more standard way to do this?