### PR TITLE
(PDK-373) Make test unit --list consistent with test unit

### DIFF
--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -32,14 +32,7 @@ module PDK
 
         result = command.execute!
 
-        json_result = nil
-        json_result = [] if options.key?(:parallel)
-
-        if options.key?(:parallel)
-          json_result.push(PDK::Util.find_valid_json_in(result[:stdout]))
-        else
-          json_result = PDK::Util.find_valid_json_in(result[:stdout])
-        end
+        json_result = PDK::Util.find_valid_json_in(result[:stdout], !options.key?(:parallel))
 
         raise PDK::CLI::FatalError, _('Unit test output did not contain a valid JSON result: %{output}') % { output: result[:stdout] } if json_result.nil? || json_result.empty?
 

--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -32,7 +32,7 @@ module PDK
 
         result = command.execute!
 
-        json_result = PDK::Util.find_valid_json_in(result[:stdout], !options.key?(:parallel))
+        json_result = PDK::Util.find_valid_json_in(result[:stdout], break_on_first: !options.key?(:parallel))
 
         raise PDK::CLI::FatalError, _('Unit test output did not contain a valid JSON result: %{output}') % { output: result[:stdout] } if json_result.nil? || json_result.empty?
 

--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -32,22 +32,13 @@ module PDK
 
         result = command.execute!
 
-        # TODO: cleanup rspec and/or beaker output
-        # Iterate through possible JSON documents until we find one that is valid.
         json_result = nil
         json_result = [] if options.key?(:parallel)
 
-        result[:stdout].scan(%r{\{(?:[^{}]|(?:\g<0>))*\}}x) do |str|
-          begin
-            if options.key?(:parallel)
-              json_result.push(JSON.parse(str))
-            else
-              json_result = JSON.parse(str)
-              break
-            end
-          rescue JSON::ParserError
-            next
-          end
+        if options.key?(:parallel)
+          json_result.push(PDK::Util.find_valid_json_in(result[:stdout]))
+        else
+          json_result = PDK::Util.find_valid_json_in(result[:stdout])
         end
 
         raise PDK::CLI::FatalError, _('Unit test output did not contain a valid JSON result: %{output}') % { output: result[:stdout] } if json_result.nil? || json_result.empty?
@@ -148,29 +139,28 @@ module PDK
       # @return array of { :id, :full_description }
       def self.list
         PDK::Util::Bundler.ensure_bundle!
-        PDK::Util::Bundler.ensure_binstubs!('rspec-core')
+        PDK::Util::Bundler.ensure_binstubs!('rake')
 
-        command_argv = [File.join(PDK::Util.module_root, 'bin', 'rspec'), '--dry-run', '--format', 'json']
+        command_argv = [File.join(PDK::Util.module_root, 'bin', 'rake'), 'spec_list_json']
         command_argv.unshift('ruby') if Gem.win_platform?
         list_command = PDK::CLI::Exec::Command.new(*command_argv)
         list_command.context = :module
         output = list_command.execute!
 
-        rspec_json_output = JSON.parse(output[:stdout])
-        if rspec_json_output['examples'].empty?
-          rspec_message = rspec_json_output['messages'][0]
+        rspec_json = PDK::Util.find_valid_json_in(output[:stdout])
+        raise PDK::CLI::FatalError, _('Failed to find valid JSON in output from rspec: %{output}' % { output: output[:stdout] }) unless rspec_json
+        if rspec_json['examples'].empty?
+          rspec_message = rspec_json['messages'][0]
           return [] if rspec_message == 'No examples found.'
 
           raise PDK::CLI::FatalError, _('Unable to enumerate examples. rspec reported: %{message}' % { message: rspec_message })
         else
           examples = []
-          rspec_json_output['examples'].each do |example|
+          rspec_json['examples'].each do |example|
             examples << { id: example['id'], full_description: example['full_description'] }
           end
           examples
         end
-      rescue JSON::ParserError => e
-        raise PDK::CLI::FatalError, _('Failed to parse output from rspec: %{message}' % { message: e.message })
       end
     end
   end

--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -100,5 +100,27 @@ module PDK
       end
     end
     module_function :module_root
+
+    # Iterate through possible JSON documents until we find one that is valid.
+    #
+    # @param text the text in which to find a JSON document
+    #
+    # @return substring of text that is valid JSON, or nil if no valid
+    #   JSON found in the text
+    def find_valid_json_in(text)
+      json_result = nil
+
+      text.scan(%r{\{(?:[^{}]|(?:\g<0>))*\}}x) do |str|
+        begin
+          json_result = JSON.parse(str)
+          break
+        rescue JSON::ParserError
+          next
+        end
+      end
+
+      json_result
+    end
+    module_function :find_valid_json_in
   end
 end

--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -104,21 +104,27 @@ module PDK
     # Iterate through possible JSON documents until we find one that is valid.
     #
     # @param text the text in which to find a JSON document
+    # @param break_on_first [Boolean] Whether or not to break after valid JSON is found, defaults to true
     #
-    # @return substring of text that is valid JSON, or nil if no valid
+    # @return [Hash, Array<Hash>, nil] subset of text as Hash of first valid JSON found, array of all valid JSON found, or nil if no valid
     #   JSON found in the text
-    def find_valid_json_in(text)
-      json_result = nil
+    def find_valid_json_in(text, break_on_first = true)
+      json_result = break_on_first ? nil : []
 
       text.scan(%r{\{(?:[^{}]|(?:\g<0>))*\}}x) do |str|
         begin
-          json_result = JSON.parse(str)
-          break
+          if break_on_first
+            json_result = JSON.parse(str)
+            break
+          else
+            json_result.push(JSON.parse(str))
+          end
         rescue JSON::ParserError
           next
         end
       end
 
+      return nil if json_result.nil? || json_result.empty?
       json_result
     end
     module_function :find_valid_json_in

--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -103,12 +103,15 @@ module PDK
 
     # Iterate through possible JSON documents until we find one that is valid.
     #
-    # @param text the text in which to find a JSON document
-    # @param break_on_first [Boolean] Whether or not to break after valid JSON is found, defaults to true
+    # @param [String] text the text in which to find a JSON document
+    # @param [Hash] opts options
+    # @option opts [Boolean] :break_on_first Whether or not to break after valid JSON is found, defaults to true
     #
     # @return [Hash, Array<Hash>, nil] subset of text as Hash of first valid JSON found, array of all valid JSON found, or nil if no valid
     #   JSON found in the text
-    def find_valid_json_in(text, break_on_first = true)
+    def find_valid_json_in(text, opts = {})
+      break_on_first = opts.key?(:break_on_first) ? opts[:break_on_first] : true
+
       json_result = break_on_first ? nil : []
 
       text.scan(%r{\{(?:[^{}]|(?:\g<0>))*\}}x) do |str|

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -239,4 +239,35 @@ describe PDK::Util do
       it { is_expected.to be_nil }
     end
   end
+
+  # TODO: These expect a string rather than actual JSON. Primarily they expect the non-JSON string to be removed
+  describe '.find_valid_json_in' do
+    it 'returns JSON from start of a string' do
+      text = '{"version":"3.6.0", "examples":[]}bar'
+      json = '{"version"=>"3.6.0", "examples"=>[]}'
+      expect(described_class.find_valid_json_in(text).to_s).to eq(json)
+    end
+
+    it 'returns JSON from the end of a string' do
+      text = 'foo{"version":"3.6.0", "examples":[]}'
+      json = '{"version"=>"3.6.0", "examples"=>[]}'
+      expect(described_class.find_valid_json_in(text).to_s).to eq(json)
+    end
+
+    it 'returns JSON from the middle of a string' do
+      text = 'foo{"version":"3.6.0", "examples":[]}bar'
+      json = '{"version"=>"3.6.0", "examples"=>[]}'
+      expect(described_class.find_valid_json_in(text).to_s).to eq(json)
+    end
+
+    it 'returns nil for invalid JSON in a string' do
+      text = 'foo{"version"":"3.6.0", "examples":[]}bar'
+      expect(described_class.find_valid_json_in(text)).to be_nil
+    end
+
+    it 'returns nil for no JSON in a string' do
+      text = 'foosomethingbar'
+      expect(described_class.find_valid_json_in(text)).to be_nil
+    end
+  end
 end

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -244,30 +244,53 @@ describe PDK::Util do
   describe '.find_valid_json_in' do
     it 'returns JSON from start of a string' do
       text = '{"version":"3.6.0", "examples":[]}bar'
-      json = '{"version"=>"3.6.0", "examples"=>[]}'
-      expect(described_class.find_valid_json_in(text).to_s).to eq(json)
+      expected = { 'version' => '3.6.0', 'examples' => [] }
+
+      expect(described_class.find_valid_json_in(text)).to eq(expected)
     end
 
     it 'returns JSON from the end of a string' do
       text = 'foo{"version":"3.6.0", "examples":[]}'
-      json = '{"version"=>"3.6.0", "examples"=>[]}'
-      expect(described_class.find_valid_json_in(text).to_s).to eq(json)
+      expected = { 'version' => '3.6.0', 'examples' => [] }
+
+      expect(described_class.find_valid_json_in(text)).to eq(expected)
     end
 
     it 'returns JSON from the middle of a string' do
       text = 'foo{"version":"3.6.0", "examples":[]}bar'
-      json = '{"version"=>"3.6.0", "examples"=>[]}'
-      expect(described_class.find_valid_json_in(text).to_s).to eq(json)
+      expected = { 'version' => '3.6.0', 'examples' => [] }
+
+      expect(described_class.find_valid_json_in(text)).to eq(expected)
     end
 
     it 'returns nil for invalid JSON in a string' do
       text = 'foo{"version"":"3.6.0", "examples":[]}bar'
+
       expect(described_class.find_valid_json_in(text)).to be_nil
     end
 
     it 'returns nil for no JSON in a string' do
       text = 'foosomethingbar'
+
       expect(described_class.find_valid_json_in(text)).to be_nil
+    end
+
+    it 'returns first JSON document from string with multiple valid docs' do
+      text = '{"version": "3.6.0", "examples": []}{"version": "4.6.0", "examples": []}'
+      expected = { 'version' => '3.6.0', 'examples' => [] }
+
+      expect(described_class.find_valid_json_in(text)).to eq(expected)
+    end
+
+    context 'when break_on_first option is set to false' do
+      let(:opts) { { break_on_first: false } }
+
+      it 'returns array of JSON documents from string with multiple valid docs' do
+        text = '{"version": "3.6.0", "examples": []}{"version": "4.6.0", "examples": []}'
+        expected = [{ 'version' => '3.6.0', 'examples' => [] }, { 'version' => '4.6.0', 'examples' => [] }]
+
+        expect(described_class.find_valid_json_in(text, opts)).to contain_exactly(*expected)
+      end
     end
   end
 end


### PR DESCRIPTION
`pdk test unit` was using a pattern defined in puppetlabs_spec_helper while `pdk test unit --list` was using no pattern.
This commit updates the --list option to use a puppetlabs_spec_helper rake task so it uses the same pattern.