### PR TITLE
(MAINT) Fix fatal error in test unit --parallel

### DIFF
--- a/spec/acceptance/test_unit_spec.rb
+++ b/spec/acceptance/test_unit_spec.rb
@@ -16,6 +16,13 @@ describe 'Running unit tests' do
       its(:stderr) { is_expected.to match(%r{no examples found}i) }
       its(:stderr) { is_expected.to match(%r{evaluated 0 tests}i) }
     end
+
+    describe command('pdk test unit --parallel') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stderr) { is_expected.to match(%r{running unit tests in parallel}i) }
+      its(:stderr) { is_expected.to match(%r{no examples found}i) }
+      its(:stderr) { is_expected.to match(%r{evaluated 0 tests}i) }
+    end
   end
 
   context 'with passing tests' do


### PR DESCRIPTION
When there are no tests `pdk test unit` outputs `No examples found`, but
the parallel_tests gem aborts with an error and does not output JSON.
This catches that error situation and standardizes the output.

To reproduce simply make a new module with `pdk new module` and run `pdk test unit` and `pdk test unit --parallel`