### PR TITLE
(MAINT) Improve moduleroot error message

### DIFF
--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -178,7 +178,7 @@ module PDK
         end
 
         unless File.directory?(@moduleroot_dir) # rubocop:disable Style/GuardClause
-          raise ArgumentError, _("The template at '%{path}' does not contain a moduleroot directory") % { path: @path }
+          raise ArgumentError, _("The template at '%{path}' does not contain a 'moduleroot/' directory") % { path: @path }
         end
       end
 


### PR DESCRIPTION
By adding quoting and a slash, the directory name becomes easily
recognisable as such.