### PR TITLE
(PDK-385) Support package testing on OSX

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,8 @@ Environment Variable | Usage
 *--or--* |
 **LOCAL_PKG** | Full path to a locally built package that you want to test.
 **TEST_TARGET** | A beaker-hostgenerator string for the OS of the VM you want to test on e.g. _redhat7-64workstation._ or _windows2012r2-64workstation._ (The period character after workstation is required by beaker-hostgenerator).
-**BUILD_SERVER** | (Only required if testing a SHA on a Windows VM). The hostname of the build server that hosts packages. A Puppet JIRA ticket ([BKR-1109](https://tickets.puppetlabs.com/browse/BKR-1109)) has been filed to update beaker so this would never be required.
+**BUILD_SERVER** | (Defaults to 'builds.delivery.puppetlabs.net' if not set) (Only required if testing a SHA on a Windows VM). The hostname of the build server that hosts packages. A Puppet JIRA ticket ([BKR-1109](https://tickets.puppetlabs.com/browse/BKR-1109)) has been filed to update beaker so this would never be required.
+**SUITE_VERSION** | (If not set, will be automatically determined if possible) The build tag/version string used when installing packages on certain platforms - e.g. if the package you built is `pdk-0.5.0.0.21.gb84d40e-1.osx10.12.dmg` then **SUITE_VERSION** would be `0.5.0.0.21.gb84d40e`
 
 # Release Process
 

--- a/package-testing/Gemfile
+++ b/package-testing/Gemfile
@@ -14,3 +14,7 @@ gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.21')
 gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.2')
 gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '~> 0.3')
 gem 'rake', '~> 10.1'
+
+group :development do
+  gem 'pry-byebug', '~> 3.4'
+end

--- a/package-testing/Rakefile
+++ b/package-testing/Rakefile
@@ -1,12 +1,14 @@
+require 'json'
+require 'open-uri'
+
 desc 'Run acceptance tests against a pdk package'
 task(:acceptance) do
   require 'beaker-hostgenerator'
 
   unless ENV['SHA'] || ENV['LOCAL_PKG']
-    abort 'SHA or LOCAL_PKG must be set:\n' \
-      '  SHA: git sha or tag of a pdk package build available on the server\n' \
+    abort "SHA or LOCAL_PKG must be set:\n" \
+      "  SHA: git sha or tag of a pdk package build available on the server\n" \
       '  LOCAL_PKG: path to a locally built package to use for testing'
-    EOS
   end
 
   if ENV['SHA'] && ENV['LOCAL_PKG']
@@ -20,11 +22,33 @@ task(:acceptance) do
   test_target = ENV['TEST_TARGET']
   abort 'TEST_TARGET must be set to a beaker-hostgenerator string for a workstation host e.g. "redhat7-64workstation."' unless test_target
 
-  # TODO: Is there a reason not to just default BUILD_SERVER to
-  # builds.delivery.puppetlabs.net instead of requiring it?
-  unless (!ENV['SHA'] || ENV['BUILD_SERVER']) || test_target !~ %r{win}
-    abort 'Testing against Windows requires environment variable BUILD_SERVER '\
-          'to be set to the hostname of your build server (JIRA BKR-1109)'
+  # to use this beaker suite outside of Puppet Inc, set BUILD_SERVER to the hostname of a build server that uses the directory hierarchy beaker assumes
+  ENV['BUILD_SERVER'] ||= 'builds.delivery.puppetlabs.net'
+
+  # If testing on OSX or Windows, SUITE_VERSION should be set to the build's version string (it forms part of the installer file naming)
+  # If it's not set, it's possible to fall back to finding it on BUILD_SERVER if SHA is available
+  # or in the package filename if LOCAL_PKG is being used.
+  unless ENV['SUITE_VERSION'] || test_target !~ %r{osx|win}
+    if ENV['LOCAL_PKG']
+      $stderr.puts "SUITE_VERSION has not been set. Trying to determine it from the filename: '#{ENV['LOCAL_PKG']}'"
+
+      ENV['SUITE_VERSION'] = %r{^pdk[-_](\d+\.\d+\.\d+\.\d+(\.\d+\.g[a-f\d]+)?)}.match(File.basename(ENV['LOCAL_PKG']))[1]
+
+      unless ENV['SUITE_VERSION']
+        abort "Could not find a valid SUITE_VERSION in the filename: '#{ENV['LOCAL_PKG']}'"
+      end
+    else
+      metadata_url = "http://#{ENV['BUILD_SERVER']}/pdk/#{ENV['SHA']}/artifacts/#{ENV['SHA']}.build_metadata.json"
+      $stderr.puts "SUITE_VERSION has not been set. Fetching it from build metadata for '#{ENV['SHA']}' at '#{metadata_url}'"
+
+      begin
+        ENV['SUITE_VERSION'] = JSON.parse(open(metadata_url).read)['version']
+      rescue StandardError => e
+        abort("Could not get build metadata from build server. Tried to request '#{metadata_url}' and got: #{e.message}")
+      end
+    end
+
+    $stderr.puts "Resolved SUITE_VERSION to '#{ENV['SUITE_VERSION']}'"
   end
 
   puts "Generating beaker hosts using TEST_TARGET value #{test_target}"

--- a/package-testing/pre/000_install_package.rb
+++ b/package-testing/pre/000_install_package.rb
@@ -7,12 +7,23 @@ test_name 'Install pdk package on workstation host' do
       scp_to(workstation, ENV['LOCAL_PKG'], pkg)
     end
 
-    if workstation['platform'] =~ %r{windows}
-      pkg ||= "http://#{ENV['BUILD_SERVER']}/pdk/#{ENV['SHA']}/repos/windows/pdk-x64.msi"
-
-      # BKR-1109 requests a neater way to install an MSI
+    case workstation['platform']
+    # TODO: BKR-1109 requests a supported way to install packages on Windows and OSX
+    when %r{windows}
+      pkg ||= "http://#{ENV['BUILD_SERVER']}/pdk/#{ENV['SHA']}/artifacts/windows/pdk-#{ENV['SUITE_VERSION']}-x64.msi"
       generic_install_msi_on(workstation, pkg)
+    when %r{osx}
+      version, arch = workstation['platform'].split('-')[1, 2]
+      pkg ||= "http://#{ENV['BUILD_SERVER']}/pdk/#{ENV['SHA']}/artifacts/apple/#{version}/PC1/#{arch}/pdk-#{ENV['SUITE_VERSION']}-1.osx#{version}.dmg"
+
+      # The beaker helper for dmg needs to know the /Volumes folder name the dmg will mount to, and the pkg filename contained within that folder
+      package_volume_name = "pdk-#{ENV['SUITE_VERSION']}"
+      package_filename = "#{package_volume_name}-1-installer.pkg"
+
+      logger.info("About to install '#{package_filename}' from '#{pkg}' on '#{workstation.hostname}'")
+      workstation.generic_install_dmg(pkg, package_volume_name, package_filename)
     else
+      # For most platforms, beaker will install the dev repo from the build server then 'install_package('pdk')' can simply be used
       pkg ||= 'pdk'
 
       if ENV['SHA']


### PR DESCRIPTION
Add package install for OSX (beaker does not have a helper for this, yet. See https://tickets.puppetlabs.com/browse/BKR-1109 for having a single helper for all platforms implemented).

I'm unhappy with the amount of code here when beaker and vanagon should provide a 2-liner method to get a .dmg from the build server and install it on the workstation host.

Tested against a number of builds (including per-commit builds and tag builds). Also tested that this works with the LOCAL_PKG option to point to a local .dmg file instead of one on the build server