### PR TITLE
Enable rubocop for package-testing folder

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,11 +7,12 @@ AllCops:
     # binstubs, and other utilities
     - bin/**/*
     - vendor/**/*
+    - vendor/**/.*
     # Puppet util code follows Puppet's style, not pdk's
     - lib/puppet/**/*
     # package testing gems
-    # TODO: Only want to exclude package-testing/vendor/**/* but that causes obsolescence errors (bug?)
-    - package-testing/**/*
+    - package-testing/vendor/**/*
+    - package-testing/vendor/**/.*
 
 Layout/IndentHeredoc:
   Description: The `squiggly` style would be preferable, but is only available from ruby 2.3. We'll enable this when we can.

--- a/package-testing/Gemfile
+++ b/package-testing/Gemfile
@@ -1,16 +1,16 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 def location_for(place, fake_version = nil)
-  if place =~ /^(git:[^#]*)#(.*)/
-    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
-  elsif place =~ /^file:\/\/(.*)/
-    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  if place =~ %r{^(git:[^#]*)#(.*)}
+    [fake_version, { git: Regexp.last_match(1), branch: Regexp.last_match(2), require: false }].compact
+  elsif place =~ %r{^file:\/\/(.*)}
+    ['>= 0', { path: File.expand_path(Regexp.last_match(1)), require: false }]
   else
-    [place, { :require => false }]
+    [place, { require: false }]
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.21')
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
-gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
-gem "rake", "~> 10.1"
+gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.21')
+gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.2')
+gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '~> 0.3')
+gem 'rake', '~> 10.1'

--- a/package-testing/Rakefile
+++ b/package-testing/Rakefile
@@ -3,23 +3,22 @@ task(:acceptance) do
   require 'beaker-hostgenerator'
 
   unless ENV['SHA'] || ENV['LOCAL_PKG']
-    abort "SHA or LOCAL_PKG must be set:\n" +
-      "  SHA: git sha or tag of a pdk package build available on the server\n" +
-      "  LOCAL_PKG: path to a locally built package to use for testing"
+    abort 'SHA or LOCAL_PKG must be set:\n' \
+      '  SHA: git sha or tag of a pdk package build available on the server\n' \
+      '  LOCAL_PKG: path to a locally built package to use for testing'
     EOS
   end
 
   if ENV['SHA'] && ENV['LOCAL_PKG']
-    abort "Both SHA and LOCAL_PKG are set, these vars are mutually exclusive. Set only one or the other."
+    abort 'Both SHA and LOCAL_PKG are set, these vars are mutually exclusive. Set only one or the other.'
   end
 
   if ENV['LOCAL_PKG'] && !File.exist?(ENV['LOCAL_PKG'])
     abort "LOCAL_PKG is set to '#{ENV['LOCAL_PKG']}' but that file does not exist."
   end
 
-  unless test_target = ENV['TEST_TARGET']
-    abort 'TEST_TARGET must be set to a beaker-hostgenerator string for a workstation host e.g. "redhat7-64workstation."'
-  end
+  test_target = ENV['TEST_TARGET']
+  abort 'TEST_TARGET must be set to a beaker-hostgenerator string for a workstation host e.g. "redhat7-64workstation."' unless test_target
 
   # TODO: Is there a reason not to just default BUILD_SERVER to
   # builds.delivery.puppetlabs.net instead of requiring it?

--- a/package-testing/config/options.rb
+++ b/package-testing/config/options.rb
@@ -3,7 +3,7 @@
   pre_suite: [
     'pre/000_install_package.rb',
   ],
-  :ssh => {
-    :keys => ["~/.ssh/id_rsa-acceptance"],
+  ssh: {
+    keys: ['~/.ssh/id_rsa-acceptance'],
   },
 }


### PR DESCRIPTION
Currently rubocop does not cover the package-testing folder due to what was thought to be a bug: https://github.com/bbatsov/rubocop/issues/4640

From that bug report; it appears that our rubocop config should have additional wildcard patterns to exclude hidden files.

This PR adds those patterns, and then fixes all the rubocop issues in the package-testing folder.