### PR TITLE
(SDK-325) Validate all should run all validators

### DIFF
--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -82,8 +82,8 @@ module PDK::CLI
       PDK::Util::Bundler.ensure_bundle!
 
       validators.each do |validator|
-        exit_code = validator.invoke(report, options)
-        break if exit_code != 0
+        validator_exit_code = validator.invoke(report, options)
+        exit_code = validator_exit_code if validator_exit_code != 0
       end
 
       report_formats.each do |format|

--- a/spec/acceptance/validate_all_spec.rb
+++ b/spec/acceptance/validate_all_spec.rb
@@ -31,4 +31,70 @@ class validate_all { }
       its(:stderr) { is_expected.to match(%r{Checking Ruby code style}i) }
     end
   end
+
+  context 'with a puppet syntax failure should still run all validators' do
+    include_context 'in a new module', 'validate_all'
+
+    init_pp = File.join('manifests', 'init.pp')
+
+    before(:all) do
+      File.open(init_pp, 'w') do |f|
+        f.puts <<-EOS
+# foo
+class validate_all {
+  Fails here because of gibberish
+}
+        EOS
+      end
+    end
+
+    describe command('pdk validate') do
+      its(:exit_status) { is_expected.not_to eq(0) }
+      its(:stderr) { is_expected.to match(%r{Running all available validators}i) }
+      its(:stderr) { is_expected.to match(%r{Checking metadata \(metadata\.json\)}i) }
+      its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
+      its(:stdout) { is_expected.to match(%r{Error: This Name has no effect}i) }
+      its(:stdout) { is_expected.to match(%r{Error: This Type-Name has no effect}i) }
+      its(:stdout) { is_expected.to match(%r{Error: Language validation logged 2 errors. Giving up}i) }
+      its(:stderr) { is_expected.not_to match(%r{Checking Puppet manifest style}i) }
+      its(:stderr) { is_expected.to match(%r{Checking Ruby code style}i) }
+    end
+
+    describe command('pdk validate --format junit') do
+      its(:exit_status) { is_expected.not_to eq(0) }
+      its(:stderr) { is_expected.to match(%r{Running all available validators}i) }
+      its(:stderr) { is_expected.to match(%r{Checking metadata \(metadata\.json\)}i) }
+      its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
+      its(:stderr) { is_expected.not_to match(%r{Checking Puppet manifest style}i) }
+      its(:stderr) { is_expected.to match(%r{Checking Ruby code style}i) }
+      its(:stdout) { is_expected.to pass_validation(junit_xsd) }
+
+      its(:stdout) do
+        is_expected.to have_junit_testsuite('puppet-syntax').with_attributes(
+          'failures' => eq(3),
+          'tests'    => eq(3),
+        )
+      end
+
+      its(:stdout) do
+        is_expected.to have_junit_testcase.in_testsuite('puppet-syntax').with_attributes(
+          'classname' => 'puppet-syntax',
+          'name'      => a_string_starting_with(init_pp),
+        ).that_failed(
+          'type'    => 'Error',
+          'message' => a_string_matching(%r{This Name has no effect}i),
+        )
+      end
+
+      its(:stdout) do
+        is_expected.to have_junit_testcase.in_testsuite('puppet-syntax').with_attributes(
+          'classname' => 'puppet-syntax',
+          'name'      => a_string_starting_with(init_pp),
+        ).that_failed(
+          'type'    => 'Error',
+          'message' => a_string_matching(%r{This Type-Name has no effect}i),
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
'pdk validate' should run all top-level validators even if one
of the validators produces an error.