### PR TITLE
(PDK-388, PDK-392) New module generation improvements.

### DIFF
--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -44,7 +44,7 @@ module PDK
 
         template_url = opts.fetch(:'template-url', PDK.answers['template-url'] || DEFAULT_TEMPLATE)
 
-        PDK::Module::TemplateDir.new(template_url) do |templates|
+        PDK::Module::TemplateDir.new(template_url, metadata.data) do |templates|
           templates.render do |file_path, file_content|
             file = Pathname.new(temp_target_dir) + file_path
             file.dirname.mkpath

--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -96,6 +96,9 @@ module PDK
           'dependencies' => [
             { 'name' => 'puppetlabs-stdlib', 'version_requirement' => '>= 4.13.1 < 5.0.0' },
           ],
+          'requirements' => [
+            { 'name' => 'puppet', 'version_requirement' => '>= 4.7.0 < 6.0.0' },
+          ],
         }
         defaults['author'] = PDK.answers['author'] unless PDK.answers['author'].nil?
         defaults['license'] = PDK.answers['license'] unless PDK.answers['license'].nil?

--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -34,6 +34,7 @@ module PDK
             'operatingsystemrelease' => ['2012 R2'],
           },
         ],
+        'requirements'  => Set.new.freeze,
       }.freeze
 
       def initialize(params = {})

--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -34,7 +34,7 @@ module PDK
             'operatingsystemrelease' => ['2012 R2'],
           },
         ],
-        'requirements'  => Set.new.freeze,
+        'requirements' => Set.new.freeze,
       }.freeze
 
       def initialize(params = {})

--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -15,6 +15,8 @@ module PDK
       #
       # @param path_or_url [String] The path to a directory to use as the
       # template or a URL to a git repository.
+      # @param module_metadata [Hash] A Hash containing the module metadata.
+      # Defaults to an empty Hash.
       # @yieldparam self [PDK::Module::TemplateDir] The initialised object with
       # the template available on disk.
       #
@@ -34,7 +36,7 @@ module PDK
       # @raise [ArgumentError] (see #validate_module_template!)
       #
       # @api public
-      def initialize(path_or_url)
+      def initialize(path_or_url, module_metadata = {})
         if File.directory?(path_or_url)
           @path = path_or_url
         else
@@ -60,6 +62,8 @@ module PDK
         @moduleroot_dir = File.join(@path, 'moduleroot')
         @object_dir = File.join(@path, 'object_templates')
         validate_module_template!
+
+        @module_metadata = module_metadata
 
         yield self
       ensure
@@ -231,6 +235,7 @@ module PDK
         end
 
         file_config = @config.fetch(:global, {})
+        file_config['module_metadata'] = @module_metadata
         file_config.merge(@config.fetch(dest_path, {})) unless dest_path.nil?
       end
     end

--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -236,7 +236,8 @@ module PDK
 
         file_config = @config.fetch(:global, {})
         file_config['module_metadata'] = @module_metadata
-        file_config.merge(@config.fetch(dest_path, {})) unless dest_path.nil?
+        file_config.merge!(@config.fetch(dest_path, {})) unless dest_path.nil?
+        file_config
       end
     end
   end

--- a/spec/acceptance/new_module_spec.rb
+++ b/spec/acceptance/new_module_spec.rb
@@ -27,5 +27,15 @@ describe 'Creating a new module' do
                                                                     'operatingsystemrelease' => ['8']))
       end
     end
+
+    describe file('foo/README.md') do
+      it { is_expected.to be_file }
+      it { is_expected.to contain(%r{# foo}i) }
+    end
+
+    describe file('foo/CHANGELOG.md') do
+      it { is_expected.to be_file }
+      it { is_expected.to contain(%r{## Release 0.1.0}i) }
+    end
   end
 end

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -29,7 +29,7 @@ shared_context 'mock template dir' do
   let(:test_template_file) { StringIO.new }
 
   before(:each) do
-    allow(PDK::Module::TemplateDir).to receive(:new).with(anything).and_yield(test_template_dir)
+    allow(PDK::Module::TemplateDir).to receive(:new).with(anything, anything).and_yield(test_template_dir)
 
     dir_double = instance_double(Pathname, mkpath: true)
     allow(dir_double).to receive(:+).with(anything).and_return(test_template_file)
@@ -155,13 +155,13 @@ describe PDK::Generate::Module do
 
       context 'when a template-url is supplied on the command line' do
         it 'uses that template to generate the module' do
-          expect(PDK::Module::TemplateDir).to receive(:new).with('cli-template').and_yield(test_template_dir)
+          expect(PDK::Module::TemplateDir).to receive(:new).with('cli-template', anything).and_yield(test_template_dir)
           described_class.invoke(invoke_opts.merge(:'template-url' => 'cli-template'))
         end
 
         it 'takes precedence over the template-url answer' do
           PDK.answers.update!('template-url' => 'answer-template')
-          expect(PDK::Module::TemplateDir).to receive(:new).with('cli-template').and_yield(test_template_dir)
+          expect(PDK::Module::TemplateDir).to receive(:new).with('cli-template', anything).and_yield(test_template_dir)
           described_class.invoke(invoke_opts.merge(:'template-url' => 'cli-template'))
         end
 
@@ -176,7 +176,7 @@ describe PDK::Generate::Module do
         context 'and a template-url answer exists' do
           it 'uses the template-url from the answer file to generate the module' do
             PDK.answers.update!('template-url' => 'answer-template')
-            expect(PDK::Module::TemplateDir).to receive(:new).with('answer-template').and_yield(test_template_dir)
+            expect(PDK::Module::TemplateDir).to receive(:new).with('answer-template', anything).and_yield(test_template_dir)
 
             described_class.invoke(invoke_opts)
           end
@@ -184,7 +184,7 @@ describe PDK::Generate::Module do
 
         context 'and no template-url answer exists' do
           it 'uses the default template to generate the module' do
-            expect(PDK::Module::TemplateDir).to receive(:new).with(PDK::Generate::Module::DEFAULT_TEMPLATE).and_yield(test_template_dir)
+            expect(PDK::Module::TemplateDir).to receive(:new).with(PDK::Generate::Module::DEFAULT_TEMPLATE, anything).and_yield(test_template_dir)
 
             described_class.invoke(invoke_opts)
           end

--- a/spec/unit/pdk/module/template_dir_spec.rb
+++ b/spec/unit/pdk/module/template_dir_spec.rb
@@ -1,6 +1,44 @@
 require 'spec_helper'
 
 describe PDK::Module::TemplateDir do
+  subject(:template_dir) do
+    described_class.new(path_or_url, module_metadata) do |foo|
+      # block does nothing
+    end
+  end
+
+  let(:path_or_url) { '/path/to/templates' }
+
+  let(:module_metadata) do
+    {
+      'name' => 'foo-bar',
+      'version' => '0.1.0',
+    }
+  end
+
+  let(:config_defaults) do
+    <<-EOS
+      ---
+      foo:
+        attr:
+          - val: 1
+    EOS
+  end
+
+  context 'with a valid template path' do
+    it 'returns config hash with module metadata' do
+      allow(File).to receive(:directory?).with(anything).and_return(true)
+      allow(PDK::Util).to receive(:make_tmpdir_name).with('pdk-module-template').and_return('/tmp/path')
+      allow(PDK::CLI::Exec).to receive(:git).with('clone', path_or_url, '/tmp/path').and_return(exit_code: 0)
+      allow(File).to receive(:file?).with(anything).and_return(File.join(path_or_url, 'config_defaults.yml')).and_return(true)
+      allow(File).to receive(:read).with(File.join(path_or_url, 'config_defaults.yml')).and_return(config_defaults)
+      allow(Dir).to receive(:rmdir).with('/tmp/path').and_return(0)
+
+      allow(described_class).to receive(:new).with(path_or_url, module_metadata).and_yield(template_dir)
+      expect(template_dir.object_config).to include('module_metadata' => module_metadata)
+    end
+  end
+
   it 'has a metadata method' do
     expect(described_class.instance_methods(false)).to include(:metadata)
   end


### PR DESCRIPTION
-Adds a puppet requirement to metadata.json
-Adds generating a skeleton README.md when generating new module
-Adds generating a skeleton CHANGELOG.md when generating new module

Requires https://github.com/puppetlabs/pdk-module-template/pull/24