### PR TITLE
(PDK-396) Disable spinners in debug mode

### DIFF
--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -228,7 +228,8 @@ module PDK
             @process.wait
           end
           @duration = Time.now - start_time
-          PDK.logger.debug(_('Execution complete (exit code: %{exit_code})') % { exit_code: @process.exit_code })
+          PDK.logger.debug(_("Execution of '%{command}' complete (duration: %{duration_in_seconds}s; exit code: %{exit_code})") %
+            { command: command_string, duration_in_seconds: @duration, exit_code: @process.exit_code })
         end
       end
     end

--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -99,7 +99,7 @@ module PDK
 
         def context=(new_context)
           unless [:system, :module].include?(new_context)
-            raise ArgumentError, _("Expected execution context to be :system or :module but got '%{context}'") % { context: new_contenxt }
+            raise ArgumentError, _("Expected execution context to be :system or :module but got '%{context}'") % { context: new_context }
           end
 
           @context = new_context
@@ -153,7 +153,7 @@ module PDK
             mod_root = PDK::Util.module_root
 
             unless mod_root
-              @spinner.error
+              @spinner.error if @spinner
 
               raise PDK::CLI::FatalError, _('Current working directory is not part of a module. (No metadata.json was found.)')
             end

--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -113,6 +113,7 @@ module PDK
         end
 
         def add_spinner(message, opts = {})
+          return if PDK.logger.debug?
           @success_message = opts.delete(:success)
           @failure_message = opts.delete(:failure)
 
@@ -226,6 +227,7 @@ module PDK
             @process.wait
           end
           @duration = Time.now - start_time
+          PDK.logger.debug(_('Execution complete (exit code: %{exit_code})') % { exit_code: @process.exit_code })
         end
       end
     end

--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -106,6 +106,7 @@ module PDK
         end
 
         def register_spinner(spinner, opts = {})
+          return if PDK.logger.debug?
           @success_message = opts.delete(:success)
           @failure_message = opts.delete(:failure)
 

--- a/lib/pdk/logger.rb
+++ b/lib/pdk/logger.rb
@@ -20,5 +20,9 @@ module PDK
     def enable_debug_output
       self.level = ::Logger::DEBUG
     end
+
+    def debug?
+      level == ::Logger::DEBUG
+    end
   end
 end

--- a/lib/pdk/validators/metadata/metadata_syntax.rb
+++ b/lib/pdk/validators/metadata/metadata_syntax.rb
@@ -21,6 +21,7 @@ module PDK
       end
 
       def self.create_spinner(targets = [], options = {})
+        return if PDK.logger.debug?
         options = options.merge(PDK::CLI::Util.spinner_opts_for_platform)
 
         exec_group = options[:exec_group]

--- a/spec/unit/pdk/cli/exec/command_spec.rb
+++ b/spec/unit/pdk/cli/exec/command_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe PDK::CLI::Exec::Command do
+  subject(:command) { described_class.new('/bin/echo', 'foo') }
+
+  describe '.context=' do
+    context 'when setting to an expected value' do
+      it 'accepts :system' do
+        expect { command.context = :system }.not_to raise_error
+        expect(command.context).to eq :system
+      end
+
+      it 'accepts :module' do
+        expect { command.context = :module }.not_to raise_error
+        expect(command.context).to eq :module
+      end
+
+      it 'rejects other values' do
+        expect { command.context = :foo }.to raise_error ArgumentError
+      end
+    end
+  end
+
+  describe '.add_spinner' do
+    context 'without --debug' do
+      before(:each) do
+        allow(logger).to receive(:debug?).and_return(false)
+        command.add_spinner('message')
+      end
+      it { expect(command.instance_variable_get(:@spinner)).to be_a TTY::Spinner }
+    end
+    context 'with --debug' do
+      before(:each) do
+        allow(logger).to receive(:debug?).and_return(true)
+        command.add_spinner('message')
+      end
+      it { expect(command.instance_variable_get(:@spinner)).to be_nil }
+    end
+  end
+
+  describe '.register_spinner' do
+    let(:spinner) { instance_double('spinner') }
+
+    context 'without --debug' do
+      before(:each) do
+        allow(logger).to receive(:debug?).and_return(false)
+        command.register_spinner(spinner)
+      end
+      it { expect(command.instance_variable_get(:@spinner)).to eq spinner }
+    end
+    context 'with --debug' do
+      before(:each) do
+        allow(logger).to receive(:debug?).and_return(true)
+        command.register_spinner(spinner)
+      end
+      it { expect(command.instance_variable_get(:@spinner)).to be_nil }
+    end
+  end
+
+  describe '.execute!' do
+    let(:process) { instance_double('ChildProcess.build(*@argv)') }
+    let(:io) { instance_double('ChildProcess.io') }
+
+    before(:each) do
+      expect(ChildProcess).to receive(:build).with('/bin/echo', 'foo').and_return(process)
+      allow(process).to receive(:leader=)
+      allow(io).to receive(:stdout=)
+      allow(io).to receive(:stderr=)
+      allow(process).to receive(:io).and_return(io)
+      allow(process).to receive(:wait)
+    end
+
+    context 'when running in the :system context' do
+      before(:each) do
+        command.context = :system
+        expect(process).to receive(:start).with(no_args)
+        allow(process).to receive(:exit_code).and_return 0
+      end
+
+      it { expect { command.execute! }.not_to raise_error }
+    end
+
+    context 'when running in the :module context' do
+      let(:environment) { {} }
+
+      before(:each) do
+        command.context = :module
+        expect(process).to receive(:start).with(no_args)
+        allow(PDK::Util).to receive(:module_root).with(no_args).and_return('/invalid_path')
+        allow(Dir).to receive(:chdir).with('/invalid_path').and_yield
+        allow(process).to receive(:exit_code).and_return 0
+        allow(process).to receive(:environment).and_return environment
+      end
+
+      it { expect { command.execute! }.not_to raise_error }
+    end
+  end
+end

--- a/spec/unit/pdk/cli/exec_spec.rb
+++ b/spec/unit/pdk/cli/exec_spec.rb
@@ -1,7 +1,34 @@
 require 'spec_helper'
 
-describe 'PDK::CLI::Exec' do
-  subject(:exec) { PDK::CLI::Exec }
-
-  it { is_expected.not_to be_nil }
+describe PDK::CLI::Exec do
+  describe '#try_vendored_bin' do
+    context 'when installed as gem' do
+      before(:each) { allow(PDK::Util).to receive(:package_install?).with(no_args).and_return(false) }
+      it 'returns the fallback' do
+        expect(described_class.try_vendored_bin('something', 'fallback')).to eq 'fallback'
+      end
+    end
+    context 'when installed as package' do
+      before(:each) do
+        allow(PDK::Util).to receive(:package_install?).with(no_args).and_return(true)
+        allow(PDK::Util).to receive(:pdk_package_basedir).with(no_args).and_return('/foo')
+      end
+      context 'when the file exists in the package' do
+        before(:each) do
+          expect(File).to receive(:exist?).with('/foo/private/bin/bar').and_return(true)
+        end
+        it 'returns the full path' do
+          expect(described_class.try_vendored_bin('private/bin/bar', 'fallback')).to eq '/foo/private/bin/bar'
+        end
+      end
+      context 'when the file is not in the package' do
+        before(:each) do
+          expect(File).to receive(:exist?).with('/foo/private/bin/bar').and_return(false)
+        end
+        it 'returns the full path' do
+          expect(described_class.try_vendored_bin('private/bin/bar', 'fallback')).to eq 'fallback'
+        end
+      end
+    end
+  end
 end

--- a/spec/unit/pdk/logger_spec.rb
+++ b/spec/unit/pdk/logger_spec.rb
@@ -15,14 +15,21 @@ describe PDK::Logger do
 
       pdk_logger.debug('test message')
     end
+
+    it { is_expected.to have_attributes(debug?: false) }
   end
 
   context 'with debug output enabled' do
+    before(:each) do
+      pdk_logger.enable_debug_output
+    end
+
     it 'prints debug messages to stdout' do
       expect(STDERR).to receive(:write).with(a_string_matching(%r{test debug message}))
 
-      pdk_logger.enable_debug_output
       pdk_logger.debug('test debug message')
     end
+
+    it { is_expected.to have_attributes(debug?: true) }
   end
 end


### PR DESCRIPTION
Disables the spinners if running with `--debug`. We already add a message to the debug log when starting a new process, so I've added another message to the debug log for when the process exits.