### PR TITLE
(PDK-407) Validate module interview confirmation answer

### DIFF
--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -220,7 +220,11 @@ module PDK
         puts '-' * 40
         puts
 
-        unless prompt.yes?(_('About to generate this module; continue?'))
+        continue = prompt.yes?(_('About to generate this module; continue?')) do |q|
+          q.validate(proc { |value| [true, false].include?(value) || value =~ %r{\A(?:yes|y|no|n)\Z}i }, 'Please answer yes or no')
+        end
+
+        unless continue
           PDK.logger.info _('Module not generated.')
           exit 0
         end

--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -221,7 +221,7 @@ module PDK
         puts
 
         continue = prompt.yes?(_('About to generate this module; continue?')) do |q|
-          q.validate(proc { |value| [true, false].include?(value) || value =~ %r{\A(?:yes|y|no|n)\Z}i }, 'Please answer yes or no')
+          q.validate(proc { |value| [true, false].include?(value) || value =~ %r{\A(?:yes|y|no|n)\Z}i }, 'Please answer "yes" or "no"')
         end
 
         unless continue

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -405,6 +405,41 @@ describe PDK::Generate::Module do
         }
       end
     end
+
+    context 'when the user does not confirm with yes or no' do
+      include_context 'allow summary to be printed to stdout'
+
+      let(:responses) do
+        [
+          'foo',
+          '2.2.0',
+          'William Hopper',
+          'Apache-2.0',
+          'A simple module to do some stuff.',
+          'github.com/whopper/bar',
+          'forge.puppet.com/whopper/bar',
+          'tickets.foo.com/whopper/bar',
+          'test', # incorrect confirmation
+          'yes',  # reattempted confirmation
+        ]
+      end
+
+      it 'reattempts the confirmation' do
+        allow($stdout).to receive(:puts).and_call_original
+        expect { interview_metadata }.not_to raise_error
+
+        expect(interview_metadata).to include(
+          'name'         => 'foo-bar',
+          'version'      => '2.2.0',
+          'author'       => 'William Hopper',
+          'license'      => 'Apache-2.0',
+          'summary'      => 'A simple module to do some stuff.',
+          'source'       => 'github.com/whopper/bar',
+          'project_page' => 'forge.puppet.com/whopper/bar',
+          'issues_url'   => 'tickets.foo.com/whopper/bar',
+        )
+      end
+    end
   end
 
   describe '.prepare_metadata' do


### PR DESCRIPTION
Suprisingly, the library doesn't do this by default. By providing our own
validation block, we can make it retry when it receives an invalid response
rather than throwing an exception.