### PR TITLE
(PDK-401) Do not accept targets for metadata validator

### DIFF
--- a/lib/pdk/validators/metadata_validator.rb
+++ b/lib/pdk/validators/metadata_validator.rb
@@ -18,6 +18,11 @@ module PDK
       def self.invoke(report, options = {})
         exit_code = 0
 
+        if options[:targets] && options[:targets] != []
+          PDK.logger.info(_('metadata validator only checks metadata.json. The specified files will be ignored: %{targets}') % { targets: options[:targets].join(', ') })
+          options.delete(:targets)
+        end
+
         metadata_validators.each do |validator|
           exit_code = validator.invoke(report, options)
           break if exit_code != 0

--- a/spec/unit/pdk/validate/metadata_validator_spec.rb
+++ b/spec/unit/pdk/validate/metadata_validator_spec.rb
@@ -43,4 +43,18 @@ describe PDK::Validate::MetadataValidator do
       end
     end
   end
+
+  describe '.invoke with targets' do
+    subject(:invoke_with_targets) { described_class.invoke(report, targets: %w[foo bar]) }
+
+    before(:each) do
+      allow(PDK::Validate::MetadataSyntax).to receive(:invoke).with(report, anything).and_return(0)
+      allow(PDK::Validate::MetadataJSONLint).to receive(:invoke).with(report, anything).and_return(0)
+    end
+
+    it 'informs user that targets will be ignored and continues to validate metadata.json' do
+      expect(PDK.logger).to receive(:info).with(a_string_matching(%r{ignored.*foo.*bar}))
+      expect(invoke_with_targets).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
Only check metadata.json. If the user passes targets through the CLI, inform user they are being ignored.