### PR TITLE
(PDK-397) Log output of bundler commands at appropriate levels

### DIFF
--- a/lib/pdk/util/bundler.rb
+++ b/lib/pdk/util/bundler.rb
@@ -82,8 +82,7 @@ module PDK
           result = bundle_command(*argv).execute!
 
           unless result[:exit_code].zero?
-            $stderr.puts result[:stdout]
-            $stderr.puts result[:stderr]
+            PDK.logger.debug(result.values_at(:stdout, :stderr).join("\n"))
           end
 
           result[:exit_code].zero?
@@ -97,8 +96,7 @@ module PDK
           result = command.execute!
 
           unless result[:exit_code].zero?
-            $stderr.puts result[:stdout]
-            $stderr.puts result[:stderr]
+            PDK.logger.fatal(result.values_at(:stdout, :stderr).join("\n"))
           end
 
           result[:exit_code].zero?
@@ -115,8 +113,7 @@ module PDK
           result = command.execute!
 
           unless result[:exit_code].zero?
-            $stderr.puts result[:stdout]
-            $stderr.puts result[:stderr]
+            PDK.logger.fatal(result.values_at(:stdout, :stderr).join("\n"))
           end
 
           result[:exit_code].zero?
@@ -131,9 +128,7 @@ module PDK
           result = command.execute!
 
           unless result[:exit_code].zero?
-            PDK.logger.error(_('Failed to generate binstubs for %{gems}') % { gems: gems.join(' ') })
-            $stderr.puts result[:stdout]
-            $stderr.puts result[:stderr]
+            PDK.logger.fatal(_("Failed to generate binstubs for '%{gems}':\n%{output}") % { gems: gems.join(' '), output: result.values_at(:stdout, :stderr).join("\n") })
           end
 
           result[:exit_code].zero?

--- a/spec/unit/pdk/util/bundler_spec.rb
+++ b/spec/unit/pdk/util/bundler_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe PDK::Util::Bundler do
       end
 
       it 'raises a fatal error' do
-        expect(logger).to receive(:error).with(a_string_matching(%r{failed to generate binstubs}i))
+        expect(logger).to receive(:fatal).with(a_string_matching(%r{failed to generate binstubs}i))
 
         expect {
           described_class.ensure_binstubs!(*gems)


### PR DESCRIPTION
Output of `bundle check` should go to DEBUG but non-zero exit status for the rest of the bundler commands represent fatal errors.