### PR TITLE
(maint) Allow bundler to install gems in parallel

### DIFF
--- a/lib/pdk/util/bundler.rb
+++ b/lib/pdk/util/bundler.rb
@@ -103,7 +103,7 @@ module PDK
         end
 
         def install!
-          argv = ['install', "--gemfile=#{gemfile}"]
+          argv = ['install', "--gemfile=#{gemfile}", '-j4']
           argv << "--path=#{bundle_cachedir}" if PDK::Util.gem_install?
 
           command = bundle_command(*argv).tap do |c|


### PR DESCRIPTION
Set jobs=2 when PDK calls bundle install to allow bundler to install gems in parallel.

It could be set higher than 2 but that might require testing to check it has no issues and even saves any time on workstations with less processing resource.