### PR TITLE
(PDK-401, PDK-402, PDK-403, PDK-404) Update validators to handle targets better

### DIFF
--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -93,7 +93,7 @@ module PDK::CLI
         exit_code = exec_group.exit_code
       else
         validators.each do |validator|
-          validator_exit_code = validator.invoke(report, options)
+          validator_exit_code = validator.invoke(report, options.dup)
           exit_code = validator_exit_code if validator_exit_code != 0
         end
       end

--- a/lib/pdk/report/event.rb
+++ b/lib/pdk/report/event.rb
@@ -96,7 +96,7 @@ module PDK
         location = nil if location.empty?
 
         # TODO: maybe add trace
-        [location, severity, message].compact.join(': ')
+        [severity, source, location, message].compact.join(': ')
       end
 
       # Renders the event as a JUnit XML testcase.
@@ -170,7 +170,9 @@ module PDK
 
         if path.absolute?
           module_root = Pathname.new(PDK::Util.module_root)
-          path.relative_path_from(module_root).to_path
+          path = path.relative_path_from(module_root).to_path
+          path << '/' if path == '.'
+          path
         else
           path.to_path
         end

--- a/lib/pdk/validators/metadata/metadata_syntax.rb
+++ b/lib/pdk/validators/metadata/metadata_syntax.rb
@@ -42,7 +42,10 @@ module PDK
       end
 
       def self.invoke(report, options = {})
-        targets = parse_targets(options)
+        targets, skipped, invalid = parse_targets(options)
+
+        process_skipped(report, skipped)
+        process_invalid(report, invalid)
 
         return 0 if targets.empty?
 
@@ -57,18 +60,6 @@ module PDK
         JSON.parser = JSON::Pure::Parser
 
         targets.each do |target|
-          unless File.file?(target)
-            report.add_event(
-              file:     target,
-              source:   name,
-              state:    :failure,
-              severity: 'error',
-              message:  _('not a file'),
-            )
-            return_val = 1
-            next
-          end
-
           unless File.readable?(target)
             report.add_event(
               file: target,

--- a/lib/pdk/validators/metadata_validator.rb
+++ b/lib/pdk/validators/metadata_validator.rb
@@ -18,11 +18,6 @@ module PDK
       def self.invoke(report, options = {})
         exit_code = 0
 
-        if options[:targets] && options[:targets] != []
-          PDK.logger.info(_('metadata validator only checks metadata.json. The specified files will be ignored: %{targets}') % { targets: options[:targets].join(', ') })
-          options.delete(:targets)
-        end
-
         metadata_validators.each do |validator|
           exit_code = validator.invoke(report, options)
           break if exit_code != 0

--- a/lib/pdk/validators/metadata_validator.rb
+++ b/lib/pdk/validators/metadata_validator.rb
@@ -18,6 +18,11 @@ module PDK
       def self.invoke(report, options = {})
         exit_code = 0
 
+        if options[:targets] && options[:targets] != []
+          PDK.logger.info(_('metadata validator only checks metadata.json. The specified files will be ignored: %{targets}') % { targets: options[:targets].join(', ') })
+          options.delete(:targets)
+        end
+
         metadata_validators.each do |validator|
           exit_code = validator.invoke(report, options)
           break if exit_code != 0

--- a/lib/pdk/validators/puppet/puppet_lint.rb
+++ b/lib/pdk/validators/puppet/puppet_lint.rb
@@ -19,7 +19,7 @@ module PDK
       end
 
       def self.spinner_text(_targets = nil)
-        _('Checking Puppet manifest style')
+        _('Checking Puppet manifest style (%{pattern})') % { pattern: pattern }
       end
 
       def self.parse_options(options, targets)

--- a/lib/pdk/validators/puppet/puppet_syntax.rb
+++ b/lib/pdk/validators/puppet/puppet_syntax.rb
@@ -18,7 +18,7 @@ module PDK
       end
 
       def self.spinner_text(_targets = nil)
-        _('Checking Puppet manifest syntax')
+        _('Checking Puppet manifest syntax (%{pattern})') % { pattern: pattern }
       end
 
       def self.parse_options(_options, targets)

--- a/lib/pdk/validators/ruby/rubocop.rb
+++ b/lib/pdk/validators/ruby/rubocop.rb
@@ -16,8 +16,12 @@ module PDK
         'rubocop'
       end
 
+      def self.pattern
+        '**/**.rb'
+      end
+
       def self.spinner_text(_targets = nil)
-        _('Checking Ruby code style')
+        _('Checking Ruby code style (%{pattern})') % { pattern: pattern }
       end
 
       def self.parse_options(options, targets)

--- a/spec/acceptance/report_spec.rb
+++ b/spec/acceptance/report_spec.rb
@@ -25,7 +25,7 @@ class foo { }
 
       describe file('report.txt') do
         it { is_expected.to exist }
-        its(:content) { is_expected.to match %r{^#{Regexp.escape(init_pp)}.*warning.*class not documented} }
+        its(:content) { is_expected.to match %r{^warning:.*#{Regexp.escape(init_pp)}.*class not documented} }
       end
     end
 
@@ -34,7 +34,7 @@ class foo { }
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
       its(:stderr) { is_expected.to match(%r{Checking Puppet manifest style}i) }
-      its(:stdout) { is_expected.to match(%r{^#{Regexp.escape(init_pp)}.*warning.*class not documented}) }
+      its(:stdout) { is_expected.to match(%r{^warning:.*#{Regexp.escape(init_pp)}.*class not documented}) }
 
       describe file('stdout') do
         it { is_expected.not_to exist }
@@ -47,7 +47,7 @@ class foo { }
       its(:stdout) { is_expected.to match(%r{\A\Z}) }
       its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
       its(:stderr) { is_expected.to match(%r{Checking Puppet manifest style}i) }
-      its(:stderr) { is_expected.to match(%r{^#{Regexp.escape(init_pp)}.*warning.*class not documented}) }
+      its(:stderr) { is_expected.to match(%r{^warning:.*#{Regexp.escape(init_pp)}.*class not documented}) }
 
       describe file('stderr') do
         it { is_expected.not_to exist }

--- a/spec/acceptance/validate_all_spec.rb
+++ b/spec/acceptance/validate_all_spec.rb
@@ -60,9 +60,9 @@ class validate_all {
       its(:stderr) { is_expected.to match(%r{Checking metadata syntax \(metadata\.json\)}i) }
       its(:stderr) { is_expected.to match(%r{Checking metadata style \(metadata\.json\)}i) }
       its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
-      its(:stdout) { is_expected.to match(%r{Error: This Name has no effect}i) }
-      its(:stdout) { is_expected.to match(%r{Error: This Type-Name has no effect}i) }
-      its(:stdout) { is_expected.to match(%r{Error: Language validation logged 2 errors. Giving up}i) }
+      its(:stdout) { is_expected.to match(%r{Error:.*This Name has no effect}i) }
+      its(:stdout) { is_expected.to match(%r{Error:.*This Type-Name has no effect}i) }
+      its(:stdout) { is_expected.to match(%r{Error:.*Language validation logged 2 errors. Giving up}i) }
       its(:stderr) { is_expected.to match(%r{Checking Ruby code style}i) }
     end
 

--- a/spec/acceptance/validate_metadata_spec.rb
+++ b/spec/acceptance/validate_metadata_spec.rb
@@ -16,7 +16,7 @@ describe 'Running metadata validation' do
 
     describe command('pdk validate metadata') do
       its(:exit_status) { is_expected.not_to eq(0) }
-      its(:stdout) { is_expected.to match(%r{^metadata\.json:.+warning.+open ended dependency}) }
+      its(:stdout) { is_expected.to match(%r{^warning:.*metadata\.json:.+open ended dependency}) }
       its(:stderr) { is_expected.to match(spinner_text) }
     end
 
@@ -72,17 +72,17 @@ describe 'Running metadata validation' do
 
     describe command('pdk validate metadata --format junit broken.json') do
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stderr) { is_expected.to match(spinner_text) }
-      its(:stderr) { is_expected.to match(%r{will be ignored.*broken.json}) }
+      its(:stderr) { is_expected.not_to match(spinner_text) }
 
       its(:stdout) do
-        is_expected.to have_xpath('/testsuites/testsuite[@name="metadata-json-lint"]/testcase').with_attributes(
-          'name' => 'metadata.json',
+        is_expected.to have_xpath('/testsuites/testsuite[@name="metadata-json-lint"]').with_attributes(
+          'tests' => '1',
+          'skipped' => '1',
         )
       end
 
       its(:stdout) do
-        is_expected.not_to have_xpath('/testsuites/testsuite[@name="metadata-json-lint"]/testcase').with_attributes(
+        is_expected.to have_xpath('/testsuites/testsuite[@name="metadata-json-lint"]/testcase').with_attributes(
           'name' => 'broken.json',
         )
       end
@@ -99,25 +99,18 @@ describe 'Running metadata validation' do
       end
 
       describe command('pdk validate metadata --format junit broken.json') do
-        its(:exit_status) { is_expected.not_to eq(0) }
-        its(:stderr) { is_expected.to match(spinner_text) }
-        its(:stderr) { is_expected.to match(%r{will be ignored.*broken.json}) }
+        its(:exit_status) { is_expected.to eq(0) }
+        its(:stderr) { is_expected.not_to match(spinner_text) }
 
         its(:stdout) do
           is_expected.to have_junit_testsuite('metadata-json-lint').with_attributes(
-            'failures' => eq(1),
-            'tests'    => eq(1),
+            'skipped' => eq(1),
+            'tests' => eq(1),
           )
         end
 
         its(:stdout) do
           is_expected.to have_xpath('/testsuites/testsuite[@name="metadata-json-lint"]/testcase').with_attributes(
-            'name' => 'metadata.json',
-          )
-        end
-
-        its(:stdout) do
-          is_expected.not_to have_xpath('/testsuites/testsuite[@name="metadata-json-lint"]/testcase').with_attributes(
             'name' => 'broken.json',
           )
         end

--- a/spec/acceptance/validate_puppet_spec.rb
+++ b/spec/acceptance/validate_puppet_spec.rb
@@ -16,7 +16,7 @@ describe 'pdk validate puppet', module_command: true do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.not_to match(syntax_spinner_text) }
       its(:stderr) { is_expected.not_to match(lint_spinner_text) }
-      its(:stdout) { is_expected.to match(empty_string) }
+      its(:stdout) { is_expected.to match(%r{Target does not contain any files to validate}) }
     end
 
     describe command('pdk validate puppet --format junit') do
@@ -25,8 +25,8 @@ describe 'pdk validate puppet', module_command: true do
       its(:stderr) { is_expected.not_to match(lint_spinner_text) }
 
       its(:stdout) { is_expected.to pass_validation(junit_xsd) }
-      its(:stdout) { is_expected.not_to have_junit_testsuite('puppet-syntax') }
-      its(:stdout) { is_expected.not_to have_junit_testsuite('puppet-lint') }
+      its(:stdout) { is_expected.to have_junit_testcase.in_testsuite('puppet-syntax').that_was_skipped }
+      its(:stdout) { is_expected.to have_junit_testcase.in_testsuite('puppet-lint').that_was_skipped }
     end
   end
 
@@ -82,8 +82,8 @@ class foo {
       its(:stderr) { is_expected.to match(syntax_spinner_text) }
       its(:stderr) { is_expected.to match(lint_spinner_text) }
 
-      its(:stdout) { is_expected.to match(%r{Warning: Unrecognized escape sequence \'\\\[\'}i) }
-      its(:stdout) { is_expected.to match(%r{Warning: Unrecognized escape sequence \'\\\]\'}i) }
+      its(:stdout) { is_expected.to match(%r{Warning:.*Unrecognized escape sequence \'\\\[\'}i) }
+      its(:stdout) { is_expected.to match(%r{Warning:.*Unrecognized escape sequence \'\\\]\'}i) }
     end
 
     describe command('pdk validate puppet --format junit') do
@@ -149,7 +149,7 @@ class foo {
 
     describe command('pdk validate puppet') do
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stdout) { is_expected.to match(%r{^#{Regexp.escape(init_pp)}.+class not documented}i) }
+      its(:stdout) { is_expected.to match(%r{^warning:.*#{Regexp.escape(init_pp)}.+class not documented}i) }
       its(:stderr) { is_expected.to match(syntax_spinner_text) }
       its(:stderr) { is_expected.to match(lint_spinner_text) }
     end
@@ -211,9 +211,9 @@ class foo {
       its(:stderr) { is_expected.to match(syntax_spinner_text) }
       its(:stderr) { is_expected.not_to match(lint_spinner_text) }
 
-      its(:stdout) { is_expected.to match(%r{Error: This Name has no effect}i) }
-      its(:stdout) { is_expected.to match(%r{Error: This Type-Name has no effect}i) }
-      its(:stdout) { is_expected.to match(%r{Error: Language validation logged 2 errors. Giving up}i) }
+      its(:stdout) { is_expected.to match(%r{Error:.*This Name has no effect}i) }
+      its(:stdout) { is_expected.to match(%r{Error:.*This Type-Name has no effect}i) }
+      its(:stdout) { is_expected.to match(%r{Error:.*Language validation logged 2 errors. Giving up}i) }
     end
 
     describe command('pdk validate puppet --format junit') do
@@ -356,8 +356,8 @@ class foo {
         its(:exit_status) { is_expected.not_to eq(0) }
         its(:stderr) { is_expected.to match(syntax_spinner_text) }
         its(:stderr) { is_expected.to match(lint_spinner_text) }
-        its(:stdout) { is_expected.to match(%r{^#{Regexp.escape(another_problem_pp)}}) }
-        its(:stdout) { is_expected.not_to match(%r{^#{Regexp.escape(example_pp)}}) }
+        its(:stdout) { is_expected.to match(%r{#{Regexp.escape(another_problem_pp)}}) }
+        its(:stdout) { is_expected.not_to match(%r{#{Regexp.escape(example_pp)}}) }
       end
 
       describe command("pdk validate puppet --format junit #{another_problem_dir}") do
@@ -401,12 +401,12 @@ class foo {
 
     describe command('pdk validate puppet') do
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stdout) { is_expected.to match(%r{^#{Regexp.escape(example_pp)}.*warning.*double quoted string}) }
+      its(:stdout) { is_expected.to match(%r{^warning:.*#{Regexp.escape(example_pp)}.*double quoted string}) }
     end
 
     describe command('pdk validate puppet --auto-correct') do
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stdout) { is_expected.to match(%r{^#{Regexp.escape(example_pp)}.*corrected.*double quoted string}) }
+      its(:stdout) { is_expected.to match(%r{^corrected:.*#{Regexp.escape(example_pp)}.*double quoted string}) }
     end
 
     describe command('pdk validate puppet') do

--- a/spec/acceptance/validate_ruby_spec.rb
+++ b/spec/acceptance/validate_ruby_spec.rb
@@ -87,12 +87,12 @@ describe 'pdk validate ruby', module_command: true do
 
     describe command('pdk validate ruby') do
       its(:exit_status) { is_expected.not_to eq(0) }
-      its(:stdout) { is_expected.to match(%r{^test\.rb.*space inside (\{|\}) missing}i) }
+      its(:stdout) { is_expected.to match(%r{test\.rb.*space inside (\{|\}) missing}i) }
     end
 
     describe command('pdk validate ruby --auto-correct') do
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stdout) { is_expected.to match(%r{^test\.rb.*corrected.*space inside (\{|\}) missing}i) }
+      its(:stdout) { is_expected.to match(%r{^corrected:.*test\.rb.*space inside (\{|\}) missing}i) }
     end
 
     describe command('pdk validate ruby') do

--- a/spec/support/it_accepts_metadata_json_targets.rb
+++ b/spec/support/it_accepts_metadata_json_targets.rb
@@ -17,28 +17,31 @@ RSpec.shared_examples_for 'it accepts metadata.json targets' do
         let(:globbed_files) { [module_metadata_json] }
 
         it 'returns the path to metadata.json in the module' do
-          expect(parsed_targets).to eq(globbed_files)
+          expect(parsed_targets.first).to eq(globbed_files)
         end
       end
 
       context 'and the module does not contain a metadata.json file' do
         it 'returns no targets' do
-          expect(parsed_targets).to eq([])
+          expect(parsed_targets.first).to eq([])
         end
       end
     end
 
-    context 'when given specific target files' do
+    context 'when given a target that will not match the validator\s pattern' do
       let(:targets) { ['target1', 'target2.json'] }
 
       before(:each) do
         targets.each do |target|
           allow(File).to receive(:directory?).with(target).and_return(false)
+          allow(File).to receive(:file?).with(target).and_return(true)
         end
       end
 
-      it 'returns the targets' do
-        expect(parsed_targets).to eq(targets)
+      it 'skips the targets' do
+        expect(parsed_targets[0]).to eq([])
+        expect(parsed_targets[1]).to eq(['target1', 'target2.json'])
+        expect(parsed_targets[2]).to eq([])
       end
     end
 
@@ -56,13 +59,13 @@ RSpec.shared_examples_for 'it accepts metadata.json targets' do
         let(:globbed_files) { [File.join(targets.first, 'metadata.json')] }
 
         it 'returns the path to the metadata.json file in the target directory' do
-          expect(parsed_targets).to eq(globbed_files)
+          expect(parsed_targets.first).to eq(globbed_files)
         end
       end
 
       context 'and the directory does not contain a metadata.json file' do
         it 'returns no targets' do
-          expect(parsed_targets).to eq([])
+          expect(parsed_targets.first).to eq([])
         end
       end
     end

--- a/spec/support/it_accepts_pp_targets.rb
+++ b/spec/support/it_accepts_pp_targets.rb
@@ -21,13 +21,13 @@ RSpec.shared_examples_for 'it accepts .pp targets' do
         end
 
         it 'returns the paths to all the .pp files in the module' do
-          expect(parsed_targets).to eq(globbed_files)
+          expect(parsed_targets.first).to eq(globbed_files)
         end
       end
 
       context 'and the module contains no .pp files' do
         it 'returns no targets' do
-          expect(parsed_targets).to eq([])
+          expect(parsed_targets.first).to eq([])
         end
       end
     end
@@ -38,11 +38,12 @@ RSpec.shared_examples_for 'it accepts .pp targets' do
       before(:each) do
         targets.each do |target|
           allow(File).to receive(:directory?).with(target).and_return(false)
+          allow(File).to receive(:file?).with(target).and_return(true)
         end
       end
 
       it 'returns the targets' do
-        expect(parsed_targets).to eq(targets)
+        expect(parsed_targets.first).to eq(targets)
       end
     end
 
@@ -58,13 +59,13 @@ RSpec.shared_examples_for 'it accepts .pp targets' do
         let(:globbed_files) { [File.join(targets.first, 'test.pp')] }
 
         it 'returns the paths to the .pp files in the directory' do
-          expect(parsed_targets).to eq(globbed_files)
+          expect(parsed_targets.first).to eq(globbed_files)
         end
       end
 
       context 'and the directory contains no .pp files' do
         it 'returns no targets' do
-          expect(parsed_targets).to eq([])
+          expect(parsed_targets.first).to eq([])
         end
       end
     end

--- a/spec/unit/pdk/report/event_spec.rb
+++ b/spec/unit/pdk/report/event_spec.rb
@@ -359,8 +359,8 @@ describe PDK::Report::Event do
   end
 
   context 'when generating text output' do
-    it 'contains the file name at the start of the string' do
-      expect(text_event).to match(%r{\Atestfile\.rb})
+    it 'contains the file name in the string' do
+      expect(text_event).to match(%r{testfile\.rb})
     end
 
     context 'and a line number is provided' do
@@ -371,7 +371,7 @@ describe PDK::Report::Event do
       end
 
       it 'appends the line number to the file name' do
-        expect(text_event).to match(%r{\Atestfile\.rb:123})
+        expect(text_event).to match(%r{testfile\.rb:123})
       end
 
       context 'and a column number is provided' do
@@ -383,7 +383,7 @@ describe PDK::Report::Event do
         end
 
         it 'appends the column number to the line number' do
-          expect(text_event).to match(%r{\Atestfile\.rb:123:456})
+          expect(text_event).to match(%r{testfile\.rb:123:456})
         end
       end
     end
@@ -395,8 +395,20 @@ describe PDK::Report::Event do
         }
       end
 
-      it 'includes the message after the file name' do
-        expect(text_event).to match(%r{\Atestfile\.rb: ok\Z})
+      it 'includes the severity at the front' do
+        expect(text_event).to match(%r{\Aok:})
+      end
+    end
+
+    context 'and a validator is provided' do
+      let(:data) do
+        {
+          source: 'my-validator',
+        }
+      end
+
+      it 'includes the validator' do
+        expect(text_event).to match(%r{my-validator})
       end
     end
 
@@ -408,7 +420,7 @@ describe PDK::Report::Event do
       end
 
       it 'includes the message at the end of the string' do
-        expect(text_event).to match(%r{\Atestfile\.rb: test message\Z})
+        expect(text_event).to match(%r{testfile\.rb: test message\Z})
       end
 
       context 'and a severity is provided' do
@@ -419,8 +431,8 @@ describe PDK::Report::Event do
           }
         end
 
-        it 'includes the severity before the message' do
-          expect(text_event).to match(%r{\Atestfile\.rb: critical: test message\Z})
+        it 'includes the severity before the file' do
+          expect(text_event).to match(%r{\Acritical: test-validator: testfile\.rb: test message\Z})
         end
       end
     end

--- a/spec/unit/pdk/validate/base_validator_spec.rb
+++ b/spec/unit/pdk/validate/base_validator_spec.rb
@@ -8,4 +8,106 @@ describe PDK::Validate::BaseValidator do
       expect(validator.methods).to include(:invoke)
     end
   end
+
+  describe '.parse_targets' do
+    subject(:target_files) { described_class.parse_targets(targets: targets) }
+
+    let(:module_root) { File.join('path', 'to', 'test', 'module') }
+    let(:pattern) { '**/**.pp' }
+
+    before(:each) do
+      allow(described_class).to receive(:pattern).and_return(pattern)
+      allow(PDK::Util).to receive(:module_root).and_return(module_root)
+    end
+
+    context 'when given no targets' do
+      let(:targets) { [] }
+      let(:glob_pattern) { File.join(module_root, described_class.pattern) }
+      let(:globbed_files) do
+        [
+          File.join(module_root, 'manifests', 'init.pp'),
+        ]
+      end
+
+      before(:each) do
+        allow(File).to receive(:directory?).and_return(true)
+        allow(Dir).to receive(:glob).with(glob_pattern).and_return(globbed_files)
+      end
+
+      it 'returns the module root' do
+        expect(target_files[0]).to eq(globbed_files)
+      end
+    end
+
+    context 'when given specific targets' do
+      let(:targets) { ['target1.pp', 'target2/'] }
+
+      let(:globbed_target2) do
+        [
+          File.join('target2', 'target.pp'),
+        ]
+      end
+
+      before(:each) do
+        allow(Dir).to receive(:glob).with(File.join('target2', described_class.pattern)).and_return(globbed_target2)
+        allow(File).to receive(:directory?).with('target1.pp').and_return(false)
+        allow(File).to receive(:directory?).with('target2/').and_return(true)
+        allow(File).to receive(:file?).with('target1.pp').and_return(true)
+      end
+
+      it 'returns the targets' do
+        expect(target_files[0]).to eq(['target1.pp'].concat(globbed_target2))
+        expect(target_files[1]).to be_empty
+        expect(target_files[2]).to be_empty
+      end
+    end
+
+    context 'when given specific target with no matching files' do
+      let(:targets) { ['target3/'] }
+
+      let(:globbed_target2) do
+        []
+      end
+
+      before(:each) do
+        allow(Dir).to receive(:glob).with(File.join('target3', described_class.pattern)).and_return(globbed_target2)
+        allow(File).to receive(:directory?).with('target3/').and_return(true)
+      end
+
+      it 'returns the skipped' do
+        expect(target_files[0]).to be_empty
+        expect(target_files[1]).to eq(['target3/'].concat(globbed_target2))
+        expect(target_files[2]).to be_empty
+      end
+    end
+
+    context 'when given specific target that are not found' do
+      let(:targets) { ['nonexistent.pp'] }
+
+      before(:each) do
+        allow(File).to receive(:directory?).with('nonexistent.pp').and_return(false)
+        allow(File).to receive(:file?).with('nonexistent.pp').and_return(false)
+      end
+
+      it 'returns the invalid' do
+        expect(target_files[0]).to be_empty
+        expect(target_files[1]).to be_empty
+        expect(target_files[2]).to eq(['nonexistent.pp'])
+      end
+    end
+
+    context 'when there is no pattern' do
+      let(:targets) { ['random'] }
+
+      before(:each) do
+        allow(described_class).to receive(:respond_to?).with(:pattern).and_return(false)
+      end
+
+      it 'returns the target as-is' do
+        expect(target_files[0]).to eq(['random'])
+        expect(target_files[1]).to be_empty
+        expect(target_files[2]).to be_empty
+      end
+    end
+  end
 end

--- a/spec/unit/pdk/validate/metadata_json_lint_spec.rb
+++ b/spec/unit/pdk/validate/metadata_json_lint_spec.rb
@@ -179,14 +179,15 @@ describe PDK::Validate::MetadataJSONLint do
       allow(PDK::Util::Bundler).to receive(:ensure_binstubs!).with(described_class.cmd)
       targets.each do |target|
         allow(File).to receive(:directory?).with(target).and_return(false)
+        allow(File).to receive(:file?).with(target).and_return(true)
       end
     end
 
-    it 'invokes metadata-json-lint once per target' do
-      targets.each do |target|
-        cmd_args = expected_args.dup.flatten << target
-        expect(PDK::CLI::Exec::Command).to receive(:new).with(*cmd_args).and_return(command_double)
-      end
+    it 'invokes metadata-json-lint only once on valid target' do
+      valid_cmd_args = expected_args.dup.flatten << 'metadata.json'
+      invalid_cmd_args = expected_args.dup.flatten << 'test.json'
+      expect(PDK::CLI::Exec::Command).to receive(:new).with(*valid_cmd_args).and_return(command_double)
+      expect(PDK::CLI::Exec::Command).not_to receive(:new).with(*invalid_cmd_args)
 
       described_class.invoke(PDK::Report.new, targets: targets)
     end

--- a/spec/unit/pdk/validate/metadata_syntax_spec.rb
+++ b/spec/unit/pdk/validate/metadata_syntax_spec.rb
@@ -27,34 +27,21 @@ describe PDK::Validate::MetadataSyntax do
 
     context 'when no valid targets are provided' do
       it 'does not attempt to validate files' do
-        expect(report).not_to receive(:add_event)
-        expect(return_value).to eq(0)
-      end
-    end
-
-    context 'when a target is provided that is not a file' do
-      let(:targets) do
-        [
-          { name: 'not_file', file: false },
-        ]
-      end
-
-      it 'adds a failure event to the report' do
         expect(report).to receive(:add_event).with(
-          file:     targets.first[:name],
+          file:     module_root,
           source:   'metadata-syntax',
-          state:    :failure,
-          severity: 'error',
-          message:  'not a file',
+          state:    :skipped,
+          severity: :info,
+          message:  a_string_matching(%r{\ATarget does not contain any}),
         )
-        expect(return_value).to eq(1)
+        expect(return_value).to eq(0)
       end
     end
 
     context 'when a target is provided that is an unreadable file' do
       let(:targets) do
         [
-          { name: 'not_readable', readable: false },
+          { name: 'metadata.json', readable: false },
         ]
       end
 
@@ -73,7 +60,7 @@ describe PDK::Validate::MetadataSyntax do
     context 'when a target is provided that contains valid JSON' do
       let(:targets) do
         [
-          { name: 'valid_file', content: '{"test": "value"}' },
+          { name: 'metadata.json', content: '{"test": "value"}' },
         ]
       end
 
@@ -91,7 +78,7 @@ describe PDK::Validate::MetadataSyntax do
     context 'when a target is provided that contains invalid JSON' do
       let(:targets) do
         [
-          { name: 'invalid_file', content: '{"test"": "value"}' },
+          { name: 'metadata.json', content: '{"test"": "value"}' },
         ]
       end
 
@@ -110,26 +97,26 @@ describe PDK::Validate::MetadataSyntax do
     context 'when targets are provided that contain valid and invalid JSON' do
       let(:targets) do
         [
-          { name: 'invalid_file', content: '{"test": "value",}' },
-          { name: 'valid_file', content: '{"test": "value"}' },
+          { name: 'invalid/metadata.json', content: '{"test": "value",}' },
+          { name: 'metadata.json', content: '{"test": "value"}' },
         ]
       end
 
-      it 'adds events for all targets to the report' do
+      it 'adds events for all valid and skipped targets to the report' do
         expect(report).to receive(:add_event).with(
-          file:     'invalid_file',
+          file:     'invalid/metadata.json',
           source:   'metadata-syntax',
-          state:    :failure,
-          severity: 'error',
-          message:  a_string_matching(%r{\Aexpected next name}),
+          state:    :skipped,
+          severity: :info,
+          message:  a_string_matching(%r{\ATarget does not contain any}),
         )
         expect(report).to receive(:add_event).with(
-          file:     'valid_file',
+          file:     'metadata.json',
           source:   'metadata-syntax',
           state:    :passed,
           severity: 'ok',
         )
-        expect(return_value).to eq(1)
+        expect(return_value).to eq(0)
       end
     end
   end

--- a/spec/unit/pdk/validate/metadata_validator_spec.rb
+++ b/spec/unit/pdk/validate/metadata_validator_spec.rb
@@ -43,4 +43,18 @@ describe PDK::Validate::MetadataValidator do
       end
     end
   end
+
+  describe '.invoke with targets' do
+    subject(:invoke_with_targets) { described_class.invoke(report, targets: %w[foo bar]) }
+
+    before(:each) do
+      allow(PDK::Validate::MetadataSyntax).to receive(:invoke).with(report, anything).and_return(0)
+      allow(PDK::Validate::MetadataJSONLint).to receive(:invoke).with(report, anything).and_return(0)
+    end
+
+    it 'informs user that targets will be ignored and continues to validate metadata.json' do
+      expect(PDK.logger).to receive(:info).with(a_string_matching(%r{ignored.*foo.*bar}))
+      expect(invoke_with_targets).to eq(0)
+    end
+  end
 end

--- a/spec/unit/pdk/validate/metadata_validator_spec.rb
+++ b/spec/unit/pdk/validate/metadata_validator_spec.rb
@@ -48,13 +48,12 @@ describe PDK::Validate::MetadataValidator do
     subject(:invoke_with_targets) { described_class.invoke(report, targets: %w[foo bar]) }
 
     before(:each) do
-      allow(PDK::Validate::MetadataSyntax).to receive(:invoke).with(report, anything).and_return(0)
-      allow(PDK::Validate::MetadataJSONLint).to receive(:invoke).with(report, anything).and_return(0)
+      allow(PDK::Validate::MetadataSyntax).to receive(:invoke).with(report, anything).and_return(1)
+      allow(PDK::Validate::MetadataJSONLint).to receive(:invoke).with(report, anything).and_return(1)
     end
 
-    it 'informs user that targets will be ignored and continues to validate metadata.json' do
-      expect(PDK.logger).to receive(:info).with(a_string_matching(%r{ignored.*foo.*bar}))
-      expect(invoke_with_targets).to eq(0)
+    it 'informs user that explicit targets were invalid' do
+      expect(invoke_with_targets).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Updates validators to handle targets consistently and disallows input of
explicit targets that are incompatible with the validator's defined
filter pattern. Also updates the spinner text to be informative about what
kind of files the validator is validating against.

Relates to #239 