### PR TITLE
(PDK-406) Add GEM_HOME and GEM_PATH bin dirs to PATH when executing

### DIFF
--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -148,7 +148,12 @@ module PDK
             end
 
             # Make sure invocation of Ruby prefers our private installation.
-            @process.environment['PATH'] = [RbConfig::CONFIG['bindir'], ENV['PATH']].compact.join(File::PATH_SEPARATOR)
+            @process.environment['PATH'] = [
+              RbConfig::CONFIG['bindir'],
+              File.join(@process.environment['GEM_HOME'], 'bin'),
+              File.join(@process.environment['GEM_PATH'], 'bin'),
+              ENV['PATH'],
+            ].compact.join(File::PATH_SEPARATOR)
 
             mod_root = PDK::Util.module_root
 


### PR DESCRIPTION
This is to handle cases where there is not a `.bundle/config` in a module telling bundler what paths to add to `PATH` when running `bundle exec`.