### PR TITLE
(maint) monkey patch TTY::Prompt::Reader::WinConsole to make it blocking

### DIFF
--- a/lib/pdk/cli/util/interview.rb
+++ b/lib/pdk/cli/util/interview.rb
@@ -1,4 +1,5 @@
 require 'tty-prompt'
+require 'pdk/monkey_patches'
 
 module PDK
   module CLI

--- a/lib/pdk/monkey_patches.rb
+++ b/lib/pdk/monkey_patches.rb
@@ -1,0 +1,13 @@
+require 'tty-prompt'
+
+module TTY
+  class Prompt
+    class Reader
+      class WinConsole
+        def get_char_non_blocking # rubocop:disable Style/AccessorMethodName
+          WinAPI.getch.chr
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The non-blocking keypress read in the latest version of tty-prompt is causing issues with the module interview on windows - it's not waiting for any input and just using the default value.