### PR TITLE
(PDK-420) Ensure Puppet and Puppet::Util modules are defined

### DIFF
--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -1,8 +1,8 @@
 require 'tmpdir'
 require 'tempfile'
-require 'puppet/util/windows'
 
 require 'pdk/util/version'
+require 'pdk/util/windows'
 
 module PDK
   module Util

--- a/lib/pdk/util/windows.rb
+++ b/lib/pdk/util/windows.rb
@@ -1,0 +1,6 @@
+module Puppet
+  module Util
+  end
+end
+
+require 'puppet/util/windows'

--- a/spec/acceptance/validate_all_spec.rb
+++ b/spec/acceptance/validate_all_spec.rb
@@ -104,4 +104,31 @@ class validate_all {
       end
     end
   end
+
+  context "when 'pdk' is included in the Gemfile" do
+    include_context 'in a new module', 'pdk_in_gemfile'
+
+    before(:all) do
+      File.open('Gemfile', 'a') do |f|
+        f.puts "gem 'pdk', path: '#{File.expand_path(File.join(__FILE__, '..', '..', '..'))}'"
+      end
+
+      File.open(File.join('manifests', 'init.pp'), 'w') do |f|
+        f.puts <<-EOS.gsub(%r{^ {10}}, '')
+          # pdk_in_gemfile
+          class pdk_in_gemfile { }
+        EOS
+      end
+    end
+
+    describe command('pdk validate') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stderr) { is_expected.to match(%r{Running all available validators}i) }
+      its(:stderr) { is_expected.to match(%r{Checking metadata syntax \(metadata\.json\)}i) }
+      its(:stderr) { is_expected.to match(%r{Checking metadata style \(metadata\.json\)}i) }
+      its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
+      its(:stderr) { is_expected.to match(%r{Checking Ruby code style}i) }
+      its(:stdout) { is_expected.to eq('') }
+    end
+  end
 end


### PR DESCRIPTION
Puppet 5 changed the format of the module definition in Puppet::Util::Windows
from the expanded to condensed format. The downside of this change is that it
means that the requires are now order dependent, as the condensed format does
not define the parent objects if not already defined.

This change abstracts our require of `puppet/util/windows`, allowing us to
define the `Puppet` and `Puppet::Util` modules before requiring
`puppet/util/windows`, fixing the exception caused when `pdk` and `puppet`
exist in the same gemfile.