### PR TITLE
(PDK-450) remove stdlib dependency

### DIFF
--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -101,9 +101,7 @@ module PDK
         defaults = {
           'name'         => "#{username}-#{opts[:name]}",
           'version'      => '0.1.0',
-          'dependencies' => [
-            { 'name' => 'puppetlabs-stdlib', 'version_requirement' => '>= 4.13.1 < 5.0.0' },
-          ],
+          'dependencies' => [],
           'requirements' => [
             { 'name' => 'puppet', 'version_requirement' => '>= 4.7.0 < 6.0.0' },
           ],

--- a/spec/acceptance/validate_metadata_spec.rb
+++ b/spec/acceptance/validate_metadata_spec.rb
@@ -8,7 +8,9 @@ describe 'Running metadata validation' do
 
     before(:all) do
       metadata = JSON.parse(File.read('metadata.json'))
-      metadata['dependencies'].first['version_requirement'] = '>= 1.0.0'
+      metadata['dependencies'] = [
+        { 'name' => 'puppetlabs-stdlib', 'version_requirement' => '>= 4.0.0' },
+      ]
       File.open('metadata.json', 'w') do |f|
         f.puts metadata.to_json
       end
@@ -47,7 +49,9 @@ describe 'Running metadata validation' do
     before(:all) do
       FileUtils.cp('metadata.json', 'broken.json')
       broken_metadata = JSON.parse(File.read('broken.json'))
-      broken_metadata['dependencies'].first['version_requirement'] = '>= 1.0.0'
+      broken_metadata['dependencies'] = [
+        { 'name' => 'puppetlabs-stdlib', 'version_requirement' => '>= 4.0.0' },
+      ]
       File.open('broken.json', 'w') do |f|
         f.puts broken_metadata.to_json
       end

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -491,14 +491,9 @@ describe PDK::Generate::Module do
         expect(metadata.data).to include('version' => a_string_starting_with('0.'))
       end
 
-      it 'includes puppetlabs-stdlib as a dependency' do
+      it 'has no dependencies' do
         expect(metadata.data).to include(
-          'dependencies' => [
-            {
-              'name'                => 'puppetlabs-stdlib',
-              'version_requirement' => a_string_matching(%r{>=?\s+\d+\.\d+\.\d+\s<=?\s\d+\.\d+\.\d+}),
-            },
-          ],
+          'dependencies' => [],
         )
       end
 


### PR DESCRIPTION
Having the stdlib dependency in there, but not in the rspec-puppet fixtures
leads to painful expectations: stdlib functions are available, but using
them in the code leads to test failures. Adding it to the fixtures would
cause the default PDK workflow to require a online connection, so this
instead removes the unforced dependency.