### PR TITLE
(PDK-446) Package tests should expect pdk to already be on path

### DIFF
--- a/package-testing/lib/pdk/pdk_helper.rb
+++ b/package-testing/lib/pdk/pdk_helper.rb
@@ -15,11 +15,10 @@ def pdk_git_bin_dir(host)
 end
 
 # Common way to just invoke 'pdk' on each platform
-# TODO - SDK-330 - pdk should be on path after package install
 def pdk_command(host, command)
   if host.platform =~ %r{windows}
     "powershell pdk #{command}"
   else
-    "/opt/puppetlabs/bin/pdk #{command}"
+    "pdk #{command}"
   end
 end

--- a/package-testing/lib/pdk/pdk_helper.rb
+++ b/package-testing/lib/pdk/pdk_helper.rb
@@ -17,7 +17,8 @@ end
 # Common way to just invoke 'pdk' on each platform
 def pdk_command(host, command)
   if host.platform =~ %r{windows}
-    "powershell pdk #{command}"
+    # Pass the command to powershell and exit powershell with pdk's exit code
+    "powershell -Command 'pdk #{command.tr("'", "\'")}; exit $LASTEXITCODE'"
   else
     "pdk #{command}"
   end

--- a/package-testing/tests/add_gem_to_module.rb
+++ b/package-testing/tests/add_gem_to_module.rb
@@ -1,0 +1,30 @@
+test_name 'C100545 - Generate a module, add a gem to it, and validate it' do
+  require 'pdk/pdk_helper.rb'
+
+  module_name = 'c100545_module'
+
+  new_gem_name = 'nothing' # https://rubygems.org/gems/nothing - it does nothing!
+
+  teardown do
+    on(workstation, "rm -rf #{module_name}") if module_name
+  end
+
+  step 'Create a module' do
+    on(workstation, pdk_command(workstation, "new module #{module_name} --skip-interview"))
+  end
+
+  step "Add new gem dependency '#{new_gem_name}' to module's Gemfile" do
+    on(workstation, "echo \"gem \'#{new_gem_name}\'\" >> #{module_name}/Gemfile")
+  end
+
+  step 'Validate the module' do
+    on(workstation, "cd #{module_name} && #{pdk_command(workstation, 'validate --debug')}", accept_all_exit_codes: true) do |outcome|
+      assert_equal(0, outcome.exit_code,
+                   "Validate on a new module should return 0. stderr was: #{outcome.stderr}")
+
+      on(workstation, "test -f #{module_name}/Gemfile.lock", accept_all_exit_codes: true) do |lock_check_outcome|
+        assert_equal(0, lock_check_outcome.exit_code, 'pdk validate should have caused a Gemfile.lock file to be created')
+      end
+    end
+  end
+end

--- a/package-testing/tests/pdk_is_on_path.rb
+++ b/package-testing/tests/pdk_is_on_path.rb
@@ -1,0 +1,14 @@
+test_name 'C100022 - pdk --help' do
+  require 'pdk/pdk_helper.rb'
+
+  module_name = 'c100022_module'
+
+  teardown do
+    on(workstation, "rm -rf #{module_name}") if module_name
+  end
+
+  on(workstation, pdk_command(workstation, '--help'), accept_all_exit_codes: true) do |outcome|
+    assert_equal(0, outcome.exit_code, "pdk --help should exit with 0. stderr: #{outcome.stderr}")
+    assert_match(%r{NAME.*USAGE.*DESCRIPTION.*COMMANDS.*OPTIONS}m, outcome.stdout, 'stdout should contain basic help information for pdk')
+  end
+end


### PR DESCRIPTION
Package tests should expect 'pdk' to be on path and should not use the full path to pdk.