### PR TITLE
(PDK-459) Add defined type generator

### DIFF
--- a/lib/pdk/cli/new.rb
+++ b/lib/pdk/cli/new.rb
@@ -12,4 +12,5 @@ module PDK::CLI
 end
 
 require 'pdk/cli/new/class'
+require 'pdk/cli/new/defined_type'
 require 'pdk/cli/new/module'

--- a/lib/pdk/cli/new/defined_type.rb
+++ b/lib/pdk/cli/new/defined_type.rb
@@ -1,0 +1,27 @@
+module PDK::CLI
+  @new_define_cmd = @new_cmd.define_command do
+    name 'defined_type'
+    usage _('defined_type [options] <name>')
+    summary _('Create a new defined type named <name> using given options')
+
+    PDK::CLI.template_url_option(self)
+
+    run do |opts, args, _cmd|
+      PDK::CLI::Util.ensure_in_module!
+
+      defined_type_name = args[0]
+      module_dir = Dir.pwd
+
+      if defined_type_name.nil? || defined_type_name.empty?
+        puts command.help
+        exit 1
+      end
+
+      unless Util::OptionValidator.valid_defined_type_name?(defined_type_name)
+        raise PDK::CLI::FatalError, _("'%{name}' is not a valid defined type name") % { name: defined_type_name }
+      end
+
+      PDK::Generate::DefinedType.new(module_dir, defined_type_name, opts).run
+    end
+  end
+end

--- a/lib/pdk/generate.rb
+++ b/lib/pdk/generate.rb
@@ -1,4 +1,5 @@
 require 'pdk/generators/module'
+require 'pdk/generators/defined_type'
 require 'pdk/generators/puppet_class'
 require 'pdk/module/metadata'
 require 'pdk/module/templatedir'

--- a/lib/pdk/generators/defined_type.rb
+++ b/lib/pdk/generators/defined_type.rb
@@ -1,0 +1,49 @@
+require 'pdk/generators/puppet_object'
+
+module PDK
+  module Generate
+    class DefinedType < PuppetObject
+      OBJECT_TYPE = :defined_type
+
+      # Prepares the data needed to render the new defined type template.
+      #
+      # @return [Hash{Symbol => Object}] a hash of information that will be
+      # provided to the defined type and defined type spec templates during
+      # rendering.
+      def template_data
+        data = { name: object_name }
+
+        data
+      end
+
+      # Calculates the path to the .pp file that the new defined type will be
+      # written to.
+      #
+      # @return [String] the path where the new defined type will be written.
+      def target_object_path
+        @target_pp_path ||= begin
+          define_name_parts = object_name.split('::')[1..-1]
+          define_name_parts << 'init' if define_name_parts.empty?
+
+          "#{File.join(module_dir, 'manifests', *define_name_parts)}.pp"
+        end
+      end
+
+      # Calculates the path to the file where the tests for the new defined
+      # type will be written.
+      #
+      # @return [String] the path where the tests for the new defined type
+      # will be written.
+      def target_spec_path
+        @target_spec_path ||= begin
+          define_name_parts = object_name.split('::')
+
+          # drop the module name if the object name contains multiple parts
+          define_name_parts.delete_at(0) if define_name_parts.length > 1
+
+          "#{File.join(module_dir, 'spec', 'defines', *define_name_parts)}_spec.rb"
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/new_defined_type_spec.rb
+++ b/spec/acceptance/new_defined_type_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper_acceptance'
+
+describe 'pdk new defined_type', module_command: true do
+  shared_examples 'it creates a defined type' do |name|
+    describe command("pdk new defined_type #{name}") do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stderr) { is_expected.to match(%r{creating .* from template}i) }
+      its(:stderr) { is_expected.not_to match(%r{WARN|ERR}) }
+      its(:stdout) { is_expected.to match(%r{\A\Z}) }
+    end
+
+    describe file('manifests') do
+      it { is_expected.to be_directory }
+    end
+
+    context 'when running the generated spec tests' do
+      describe command('pdk test unit') do
+        its(:exit_status) { is_expected.to eq(0) }
+        its(:stderr) { is_expected.to match(%r{0 failures}) }
+        its(:stderr) { is_expected.not_to match(%r{no examples found}i) }
+      end
+    end
+  end
+
+  context 'in a fresh module' do
+    include_context 'in a new module', 'new_define'
+
+    context 'when creating a defined type with same name as the module' do
+      it_behaves_like 'it creates a defined type', 'new_define'
+
+      describe file('manifests/init.pp') do
+        it { is_expected.to be_file }
+        its(:content) { is_expected.to match(%r{define new_define}) }
+      end
+
+      describe file('spec/defines/new_define_spec.rb') do
+        it { is_expected.to be_file }
+        its(:content) { is_expected.to match(%r{describe 'new_define' do}) }
+      end
+    end
+
+    context 'when creating an ancillary defined type' do
+      it_behaves_like 'it creates a defined type', 'ancillary'
+
+      describe file('manifests/ancillary.pp') do
+        it { is_expected.to be_file }
+        its(:content) { is_expected.to match(%r{define new_define::ancillary}) }
+      end
+
+      describe file('spec/defines/ancillary_spec.rb') do
+        it { is_expected.to be_file }
+        its(:content) { is_expected.to match(%r{describe 'new_define::ancillary' do}) }
+      end
+    end
+
+    context 'when creating a deeply nested defined type' do
+      it_behaves_like 'it creates a defined type', 'new_define::foo::bar::baz'
+
+      describe file('manifests/foo/bar/baz.pp') do
+        it { is_expected.to be_file }
+        its(:content) { is_expected.to match(%r{define new_define::foo::bar::baz}) }
+      end
+
+      describe file('spec/defines/foo/bar/baz_spec.rb') do
+        it { is_expected.to be_file }
+        its(:content) { is_expected.to match(%r{describe 'new_define::foo::bar::baz' do}) }
+      end
+    end
+  end
+end

--- a/spec/unit/pdk/cli/new/defined_type_spec.rb
+++ b/spec/unit/pdk/cli/new/defined_type_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe 'PDK::CLI new defined_type' do
+  let(:help_text) { a_string_matching(%r{^USAGE\s+pdk new defined_type}m) }
+
+  before(:each) do
+    allow(PDK::Util).to receive(:module_root).and_return(module_root)
+  end
+
+  shared_examples 'it exits non-zero and prints the help text' do
+    it 'exits non-zero and prints the `pdk new defined_type` help' do
+      expect {
+        PDK::CLI.run(args)
+      }.to raise_error(SystemExit) { |error|
+        expect(error.status).not_to be_zero
+      }.and output(help_text).to_stdout
+    end
+  end
+
+  shared_examples 'it exits with a fatal error' do |expected_error|
+    it 'exits with a fatal error' do
+      expect(logger).to receive(:fatal).with(a_string_matching(expected_error))
+
+      expect {
+        PDK::CLI.run(args)
+      }.to raise_error(SystemExit) { |error|
+        expect(error.status).not_to be_zero
+      }
+    end
+  end
+
+  context 'when not run from inside a module' do
+    let(:module_root) { nil }
+    let(:args) { %w[new defined_type test_define] }
+
+    it_behaves_like 'it exits with a fatal error', %r{must be run from inside a valid module}
+  end
+
+  context 'when run from inside a module' do
+    let(:module_root) { '/path/to/test/module' }
+
+    context 'and not provided with a name for the new defined type' do
+      let(:args) { %w[new defined_type] }
+
+      it_behaves_like 'it exits non-zero and prints the help text'
+    end
+
+    context 'and provided an empty string as the defined type name' do
+      let(:args) { ['new', 'defined_type', ''] }
+
+      it_behaves_like 'it exits non-zero and prints the help text'
+    end
+
+    context 'and provided an invalid defined type name' do
+      let(:args) { %w[new defined_type test-define] }
+
+      it_behaves_like 'it exits with a fatal error', %r{'test-define' is not a valid defined type name}
+    end
+
+    context 'and provided a valid defined type name' do
+      let(:generator) { PDK::Generate::DefinedType }
+      let(:generator_double) { instance_double(generator) }
+      let(:generator_opts) { instance_of(Hash) }
+
+      before(:each) do
+        allow(generator).to receive(:new).with(anything, 'test_define', generator_opts).and_return(generator_double)
+      end
+
+      it 'generates the defined type' do
+        expect(generator_double).to receive(:run)
+
+        PDK::CLI.run(%w[new defined_type test_define])
+      end
+
+      context 'and a custom template URL' do
+        let(:generator_opts) { { :'template-url' => 'https://custom/template' } }
+
+        it 'generates the defined type from the custom template' do
+          expect(generator_double).to receive(:run)
+
+          PDK::CLI.run(%w[new defined_type test_define --template-url https://custom/template])
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/pdk/generate/defined_type_spec.rb
+++ b/spec/unit/pdk/generate/defined_type_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+describe PDK::Generate::DefinedType do
+  subject(:generator) { described_class.new(module_dir, given_name, options) }
+
+  subject(:target_object_path) { generator.target_object_path }
+
+  subject(:target_spec_path) { generator.target_spec_path }
+
+  subject(:template_data) { generator.template_data }
+
+  let(:module_name) { 'test_module' }
+  let(:module_dir) { '/tmp/test_module' }
+  let(:options) { {} }
+  let(:expected_name) { given_name }
+
+  before(:each) do
+    test_metadata = instance_double(PDK::Module::Metadata, data: { 'name' => module_name })
+    allow(PDK::Module::Metadata).to receive(:from_file).with(File.join(module_dir, 'metadata.json')).and_return(test_metadata)
+  end
+
+  shared_examples 'it generates the template data' do
+    it 'includes the defined type name in the template data' do
+      expect(template_data).to eq(name: expected_name)
+    end
+  end
+
+  shared_examples 'it generates a spec file' do
+    it 'writes the spec file into spec/defines/' do
+      expect(target_spec_path).to eq(expected_spec_path)
+    end
+  end
+
+  context 'when the defined type name is the same as the module name' do
+    let(:given_name) { module_name }
+    let(:expected_object_path) { File.join(module_dir, 'manifests', 'init.pp') }
+    let(:expected_spec_path) { File.join(module_dir, 'spec', 'defines', "#{expected_name}_spec.rb") }
+
+    it_behaves_like 'it generates the template data'
+    it_behaves_like 'it generates a spec file'
+
+    it 'writes the defined type to manifests/init.pp' do
+      expect(target_object_path).to eq(expected_object_path)
+    end
+  end
+
+  context 'when the defined type name is in the module namespace' do
+    let(:given_name) { "#{module_name}::test_define" }
+    let(:expected_object_path) { File.join(module_dir, 'manifests', 'test_define.pp') }
+    let(:expected_spec_path) { File.join(module_dir, 'spec', 'defines', 'test_define_spec.rb') }
+
+    it_behaves_like 'it generates the template data'
+    it_behaves_like 'it generates a spec file'
+
+    it 'writes the defined type to manifests/test_define.pp' do
+      expect(target_object_path).to eq(expected_object_path)
+    end
+  end
+
+  context 'when the defined type is deeply nested in the module namespace' do
+    let(:given_name) { "#{module_name}::something::else::test_define" }
+    let(:expected_object_path) { File.join(module_dir, 'manifests', 'something', 'else', 'test_define.pp') }
+    let(:expected_spec_path) { File.join(module_dir, 'spec', 'defines', 'something', 'else', 'test_define_spec.rb') }
+
+    it_behaves_like 'it generates the template data'
+    it_behaves_like 'it generates a spec file'
+
+    it 'writes the defined type to manifests/something/else/test_define.pp' do
+      expect(target_object_path).to eq(expected_object_path)
+    end
+  end
+
+  context 'when the defined type name is outside the module namespace' do
+    let(:given_name) { 'test_define' }
+    let(:expected_name) { [module_name, given_name].join('::') }
+    let(:expected_object_path) { File.join(module_dir, 'manifests', 'test_define.pp') }
+    let(:expected_spec_path) { File.join(module_dir, 'spec', 'defines', 'test_define_spec.rb') }
+
+    it 'prepends the module name to the defined type name' do
+      expect(generator.object_name).to eq(expected_name)
+    end
+
+    it_behaves_like 'it generates the template data'
+    it_behaves_like 'it generates a spec file'
+
+    it 'writes the defined type to manifests/test_define.pp' do
+      expect(target_object_path).to eq(expected_object_path)
+    end
+  end
+end


### PR DESCRIPTION
```
NAME
    defined_type - Create a new defined type named <name> using given options

USAGE
    pdk new defined_type [options] <name>

OPTIONS
       --template-url=<value>      Specifies the URL to the template to use
                                   when creating new modules or classes.
                                   (default:
                                   https://github.com/puppetlabs/pdk-module-template)

OPTIONS FOR NEW
    -d --debug                     Enable debug output.
    -f --format=<value>            Specify desired output format. Valid
                                   formats are 'junit', 'text'. You may also
                                   specify a file to which the formatted
                                   output is sent, for example:
                                   '--format=junit:report.xml'. This option
                                   may be specified multiple times if each
                                   option specifies a distinct target file.
    -h --help                      Show help for this command.
       --version                   Show version of pdk.
```