### PR TITLE
(PDK-461) Make Version.git_ref more forgiving

### DIFF
--- a/lib/pdk/util/version.rb
+++ b/lib/pdk/util/version.rb
@@ -23,9 +23,12 @@ module PDK
       end
 
       def self.git_ref
-        ref_result = PDK::CLI::Exec.git('--git-dir', File.join(File.expand_path('../../..', File.dirname(__FILE__)), '.git'), 'describe', '--all', '--long')
+        source_git_dir = File.join(File.expand_path('../../..', File.dirname(__FILE__)), '.git')
 
-        ref_result[:stdout].strip if ref_result[:exit_code].zero?
+        return nil unless File.directory?(source_git_dir)
+
+        ref_result = PDK::CLI::Exec.git('--git-dir', source_git_dir, 'describe', '--all', '--long')
+        return ref_result[:stdout].strip if ref_result[:exit_code].zero?
       end
 
       def self.version_file

--- a/spec/unit/pdk/util/version_spec.rb
+++ b/spec/unit/pdk/util/version_spec.rb
@@ -6,4 +6,44 @@ describe PDK::Util::Version do
 
     it { is_expected.not_to be_nil }
   end
+
+  context 'when running from a checkout' do
+    before(:each) do
+      allow(PDK::Util).to receive(:find_upwards).and_return('/tmp/package/PDK_VERSION')
+      allow(File).to receive(:exist?).with('/tmp/package/PDK_VERSION').and_return(false)
+      allow(File).to receive(:directory?).with(%r{.git\Z}).and_return(true)
+
+      result = instance_double('exec_git_describe_result')
+      allow(result).to receive(:[]).with(:stdout).and_return('git_hash')
+      allow(result).to receive(:[]).with(:exit_code).and_return(0)
+
+      allow(PDK::CLI::Exec).to receive(:git).with('--git-dir', %r{.git\Z}, 'describe', '--all', '--long').and_return(result)
+    end
+
+    describe '#git_ref' do
+      it { expect(described_class.git_ref).to eq 'git_hash' }
+    end
+
+    describe '#pkg_sha' do
+      it { expect(described_class.pkg_sha).to be_nil }
+    end
+  end
+
+  context 'when running from a package' do
+    before(:each) do
+      allow(PDK::Util).to receive(:find_upwards).and_return('/tmp/package/PDK_VERSION')
+      allow(File).to receive(:exist?).with('/tmp/package/PDK_VERSION').and_return(true)
+      allow(File).to receive(:read).with('/tmp/package/PDK_VERSION').and_return('0.1.2.3.4.pkg_hash')
+      allow(File).to receive(:directory?).with(%r{.git\Z}).and_return(false)
+      allow(PDK::CLI::Exec).to receive(:git).never
+    end
+
+    describe '#git_ref' do
+      it { expect(described_class.git_ref).to be_nil }
+    end
+
+    describe '#pkg_sha' do
+      it { expect(described_class.pkg_sha).to eq 'pkg_hash' }
+    end
+  end
 end


### PR DESCRIPTION
When there is no target `.git` directory, no need to call git at all.

Also adds more tests to cover everything.