### PR TITLE
(MAINT) Run package test commands in a login shell

### DIFF
--- a/package-testing/lib/pdk/pdk_helper.rb
+++ b/package-testing/lib/pdk/pdk_helper.rb
@@ -20,6 +20,6 @@ def pdk_command(host, command)
     # Pass the command to powershell and exit powershell with pdk's exit code
     "powershell -Command 'pdk #{command.tr("'", "\'")}; exit $LASTEXITCODE'"
   else
-    "pdk #{command}"
+    "/bin/bash -lc \"pdk #{command}\""
   end
 end


### PR DESCRIPTION
Beaker defaults to running commands in a non-interactive /bin/sh session
which means that /etc/profile and other shell setup files are not
sourced. This commit changes our helper method to still run 'pdk'
without an explicit path but do so inside a 'login' session of /bin/bash
so that any profile based PATH changes are in place when the command
runs.