### PR TITLE
(PDK-459) Improve error message when the generation target exists

### DIFF
--- a/lib/pdk/generators/puppet_object.rb
+++ b/lib/pdk/generators/puppet_object.rb
@@ -85,7 +85,7 @@ module PDK
       def run
         [target_object_path, target_spec_path].each do |target_file|
           if File.exist?(target_file)
-            raise PDK::CLI::FatalError, _("Unable to generate class; '%{file}' already exists.") % { file: target_file }
+            raise PDK::CLI::FatalError, _("Unable to generate %{object_type}; '%{file}' already exists.") % { file: target_file, object_type: object_type }
           end
         end
 


### PR DESCRIPTION
```
foo$ ~/git/pdk/bin/pdk new def bar
pdk (FATAL): Unable to generate defined_type; '/home/david/git/pdk/foo/manifests/bar.pp' already exists.
foo$ ~/git/pdk/bin/pdk new class bar
pdk (FATAL): Unable to generate class; '/home/david/git/pdk/foo/manifests/bar.pp' already exists.
foo$
```