### PR TITLE
(PDK-370) Adds a 'pdk module generate' redirect to 'pdk new module'.

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -2,6 +2,7 @@ require 'cri'
 
 require 'pdk/cli/errors'
 require 'pdk/cli/util'
+require 'pdk/cli/util/command_redirector'
 require 'pdk/cli/util/option_normalizer'
 require 'pdk/cli/util/option_validator'
 require 'pdk/cli/exec_group'
@@ -34,6 +35,10 @@ module PDK::CLI
 
   def self.template_url_option(dsl)
     dsl.option nil, 'template-url', _('Specifies the URL to the template to use when creating new modules or classes.'), argument: :required, default: PDK::Generate::Module.default_template_url
+  end
+
+  def self.skip_interview_option(dsl)
+    dsl.option nil, 'skip-interview', _('When specified, skips interactive querying of metadata.')
   end
 
   @base_cmd = Cri::Command.define do
@@ -77,6 +82,7 @@ module PDK::CLI
   require 'pdk/cli/new'
   require 'pdk/cli/test'
   require 'pdk/cli/validate'
+  require 'pdk/cli/module'
 
   @base_cmd.add_command Cri::Command.new_basic_help
 end

--- a/lib/pdk/cli/bundle.rb
+++ b/lib/pdk/cli/bundle.rb
@@ -3,9 +3,11 @@ module PDK::CLI
   @bundle_cmd = @base_cmd.define_command do
     name 'bundle'
     usage _('bundle -- [bundler_options]')
-    summary _('escape hatch to bundler')
+    summary _('(Experimental) Command pass-through to bundler')
     description _('[experimental] For advanced users, pdk bundle runs arbitrary commands in the bundler environment that pdk manages.' \
       'Careless use of this command can lead to errors that pdk can\'t help recover from.')
+
+    be_hidden
 
     run do |_opts, args, _cmd|
       PDK::CLI::Util.ensure_in_module!

--- a/lib/pdk/cli/module.rb
+++ b/lib/pdk/cli/module.rb
@@ -1,0 +1,14 @@
+module PDK::CLI
+  @module_cmd = @base_cmd.define_command do
+    name 'module'
+    usage _('module [options]')
+    summary _('Perform administrative tasks on your module.')
+    description _('Perform tasks on the module project.')
+    default_subcommand 'help'
+    be_hidden
+  end
+
+  @module_cmd.add_command Cri::Command.new_basic_help
+end
+
+require 'pdk/cli/module/generate'

--- a/lib/pdk/cli/module/generate.rb
+++ b/lib/pdk/cli/module/generate.rb
@@ -1,0 +1,40 @@
+require 'tty-prompt'
+
+module PDK::CLI
+  @module_generate_cmd = @module_cmd.define_command do
+    name 'generate'
+    usage _('generate [options] <module_name>')
+    summary _('This command is now \'pdk new module\'.')
+    be_hidden
+
+    PDK::CLI.template_url_option(self)
+    PDK::CLI.skip_interview_option(self)
+
+    run do |opts, args, _cmd|
+      require 'pdk/generators/module'
+
+      module_name = args[0]
+
+      if module_name.nil? || module_name.empty?
+        puts command.help
+        exit 1
+      end
+
+      PDK.logger.info(_('New modules are created using the ‘pdk new module’ command.'))
+      prompt = TTY::Prompt.new(help_color: :cyan)
+      redirect = PDK::CLI::Util::CommandRedirector.new(prompt)
+      redirect.target_command('pdk new module')
+      answer = redirect.run
+
+      if answer
+        opts[:name] = module_name
+        opts[:target_dir] = module_name
+
+        PDK.logger.info(_('Creating new module: %{modname}') % { modname: module_name })
+        PDK::Generate::Module.invoke(opts)
+      else
+        exit 1
+      end
+    end
+  end
+end

--- a/lib/pdk/cli/new/module.rb
+++ b/lib/pdk/cli/new/module.rb
@@ -1,4 +1,3 @@
-
 module PDK::CLI
   @new_module_cmd = @new_cmd.define_command do
     name 'module'
@@ -6,11 +5,10 @@ module PDK::CLI
     summary _('Create a new module named <module_name> using given options')
 
     PDK::CLI.template_url_option(self)
+    PDK::CLI.skip_interview_option(self)
 
     option nil, 'license', _('Specifies the license this module is written under. ' \
       "This should be a identifier from https://spdx.org/licenses/. Common values are 'Apache-2.0', 'MIT', or 'proprietary'."), argument: :required
-
-    flag nil, 'skip-interview', _('When specified, skips interactive querying of metadata.')
 
     run do |opts, args, _cmd|
       require 'pdk/generators/module'
@@ -21,14 +19,6 @@ module PDK::CLI
       if module_name.nil? || module_name.empty?
         puts command.help
         exit 1
-      end
-
-      unless Util::OptionValidator.valid_module_name?(module_name)
-        error_msg = _(
-          "'%{module_name}' is not a valid module name.\n" \
-          'Module names must begin with a lowercase letter and can only include lowercase letters, digits, and underscores.',
-        ) % { module_name: module_name }
-        raise PDK::CLI::FatalError, error_msg
       end
 
       opts[:name] = module_name

--- a/lib/pdk/cli/util/command_redirector.rb
+++ b/lib/pdk/cli/util/command_redirector.rb
@@ -1,0 +1,26 @@
+require 'tty-prompt'
+
+module PDK
+  module CLI
+    module Util
+      class CommandRedirector < TTY::Prompt::AnswersCollector
+        attr_accessor :command
+
+        def pastel
+          @pastel ||= Pastel.new
+        end
+
+        def target_command(cmd)
+          @command = cmd
+        end
+
+        def run
+          @prompt.puts _('Did you mean \'%{command}\'?') % { command: pastel.bold(@command) }
+          @prompt.yes?('-->')
+        rescue TTY::Prompt::Reader::InputInterrupt
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -9,6 +9,7 @@ require 'pdk/module/metadata'
 require 'pdk/module/templatedir'
 require 'pdk/cli/exec'
 require 'pdk/cli/util/interview'
+require 'pdk/cli/util/option_validator'
 require 'pdk/util'
 require 'pdk/util/version'
 
@@ -31,13 +32,24 @@ module PDK
         end
       end
 
-      def self.invoke(opts = {})
-        target_dir = File.expand_path(opts[:target_dir])
-
-        if File.exist?(target_dir)
-          raise PDK::CLI::FatalError, _("The destination directory '%{dir}' already exists") % { dir: target_dir }
+      def self.validate_options(opts)
+        unless PDK::CLI::Util::OptionValidator.valid_module_name?(opts[:name])
+          error_msg = _(
+            "'%{module_name}' is not a valid module name.\n" \
+            'Module names must begin with a lowercase letter and can only include lowercase letters, digits, and underscores.',
+          ) % { module_name: opts[:name] }
+          raise PDK::CLI::FatalError, error_msg
         end
 
+        target_dir = File.expand_path(opts[:target_dir])
+
+        raise PDK::CLI::FatalError, _("The destination directory '%{dir}' already exists") % { dir: target_dir } if File.exist?(target_dir)
+      end
+
+      def self.invoke(opts = {})
+        validate_options(opts)
+
+        target_dir = File.expand_path(opts[:target_dir])
         parent_dir = File.dirname(target_dir)
 
         begin

--- a/spec/unit/cli/module/generate_spec.rb
+++ b/spec/unit/cli/module/generate_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe 'Running pdk module generate' do
+  subject { PDK::CLI.instance_variable_get(:@new_module_cmd) }
+
+  let(:module_name) { 'foo' }
+
+  describe 'when not passed a module name' do
+    it do
+      expect {
+        PDK::CLI.run(%w[module generate])
+      }.to raise_error(SystemExit) { |error|
+        expect(error.status).to eq(1)
+      }.and output(a_string_matching(%r{^USAGE\s+pdk module generate}m)).to_stdout
+    end
+  end
+
+  context 'with a yes at the prompt' do
+    before(:each) do
+      redirector = instance_double('PDK::CLI::Util::CommandRedirector')
+      allow(redirector).to receive(:target_command)
+      allow(redirector).to receive(:run).and_return(true)
+      expect(logger).to receive(:info).with(%r{New modules are created using the ‘pdk new module’ command}i)
+      expect(PDK::CLI::Util::CommandRedirector).to receive(:new).and_return(redirector)
+    end
+
+    it 'to call to new module generator' do
+      expect(logger).to receive(:info).with(%r{Creating new module:}i)
+      expect(PDK::Generate::Module).to receive(:invoke)
+      PDK::CLI.run(['module', 'generate', module_name])
+    end
+  end
+
+  # context 'with a no at the prompt' do
+  #  before(:each) do
+  #    redirector = instance_double('PDK::CLI::Util::CommandRedirector')
+  #    allow(redirector).to receive(:target_command)
+  #    allow(redirector).to receive(:run).and_return(false)
+  #    expect(logger).to receive(:info).with(%r{New modules are created using the ‘pdk new module’ command}i)
+  #    expect(PDK::CLI::Util::CommandRedirector).to receive(:new).and_return(redirector)
+  #  end
+
+  #  it 'to not call new module generator' do
+  #    expect(logger).not_to receive(:info).with(%r{Creating new module:}i)
+  #    expect(PDK::Generate::Module).not_to receive(:invoke)
+  #    PDK::CLI.run(['module', 'generate', module_name])
+  #  end
+  # end
+end

--- a/spec/unit/cli/module_spec.rb
+++ b/spec/unit/cli/module_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'Running `pdk module`' do
+  subject { PDK::CLI.instance_variable_get(:@module_cmd) }
+
+  context 'when no arguments or options are provided' do
+    it do
+      expect {
+        PDK::CLI.run(['module'])
+      }.to output(%r{^USAGE\s+pdk module}m).to_stdout
+    end
+  end
+end

--- a/spec/unit/cli/new/module_spec.rb
+++ b/spec/unit/cli/new/module_spec.rb
@@ -29,7 +29,6 @@ describe 'Running `pdk new module`' do
     let(:module_name) { 'test123' }
 
     it 'validates the module name' do
-      expect(PDK::CLI::Util::OptionValidator).to receive(:valid_module_name?).with(module_name).and_call_original
       expect(PDK::Generate::Module).to receive(:invoke).with(hash_including(name: module_name))
       expect(logger).to receive(:info).with("Creating new module: #{module_name}")
       PDK::CLI.run(['new', 'module', module_name])

--- a/spec/unit/pdk/cli/util/command_redirector_spec.rb
+++ b/spec/unit/pdk/cli/util/command_redirector_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe PDK::CLI::Util::CommandRedirector do
+  subject(:command_redirector) do
+    described_class.new(prompt, {})
+  end
+
+  let(:prompt) { instance_double('TTY::Prompt') }
+
+  let(:command) { 'foo' }
+
+  it 'initially has no target command' do
+    expect(command_redirector.command).to eq(nil)
+  end
+
+  it 'sets the target' do
+    command_redirector.target_command(command)
+    expect(command_redirector.command).to eq(command)
+  end
+
+  it 'prints a query when run' do
+    command_redirector.target_command('foo')
+    expect(prompt).to receive(:puts).with(a_string_matching(%r{Did you mean.*foo.*?}i))
+    expect(prompt).to receive(:yes?).with('-->')
+    command_redirector.run
+  end
+end

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -68,7 +68,7 @@ describe PDK::Generate::Module do
         expect(logger).not_to receive(:info).with(a_string_matching(%r{In your new module directory, add classes with the 'pdk new class' command}i))
 
         expect {
-          described_class.invoke(target_dir: target_dir)
+          described_class.invoke(name: 'foo', target_dir: target_dir)
         }.to raise_error(PDK::CLI::FatalError, %r{destination directory '.+' already exists}i)
       end
     end

--- a/spec/unit/pdk/validate/puppet_lint_spec.rb
+++ b/spec/unit/pdk/validate/puppet_lint_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-shared_examples_for 'it sets the common options' do
+shared_examples_for 'it sets the common puppet-lint options' do
   it 'sets the output format as JSON' do
     expect(command_args.first).to eq('--json')
   end
@@ -37,7 +37,7 @@ describe PDK::Validate::PuppetLint do
     context 'when auto-correct is enabled' do
       let(:options) { { auto_correct: true } }
 
-      it_behaves_like 'it sets the common options'
+      it_behaves_like 'it sets the common puppet-lint options'
 
       it 'includes the --fix flag' do
         expect(command_args).to include('--fix')
@@ -45,7 +45,7 @@ describe PDK::Validate::PuppetLint do
     end
 
     context 'when auto-correct is disabled' do
-      it_behaves_like 'it sets the common options'
+      it_behaves_like 'it sets the common puppet-lint options'
 
       it 'does not include the --fix flag' do
         expect(command_args).not_to include('--fix')

--- a/spec/unit/pdk/validate/rubocop_spec.rb
+++ b/spec/unit/pdk/validate/rubocop_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'rubocop'
 require 'ostruct'
 
-shared_examples_for 'it sets the common options' do
+shared_examples_for 'it sets the common rubocop options' do
   it 'sets the output format as JSON' do
     expect(command_args.first(2)).to eq(['--format', 'json'])
   end
@@ -85,7 +85,7 @@ describe PDK::Validate::Rubocop do
     context 'when auto-correct is enabled' do
       let(:options) { { auto_correct: true } }
 
-      it_behaves_like 'it sets the common options'
+      it_behaves_like 'it sets the common rubocop options'
 
       it 'includes the --auto-correct flag' do
         expect(command_args).to include('--auto-correct')
@@ -93,7 +93,7 @@ describe PDK::Validate::Rubocop do
     end
 
     context 'when auto-correct is disabled' do
-      it_behaves_like 'it sets the common options'
+      it_behaves_like 'it sets the common rubocop options'
 
       it 'does not include the --auto-correct flag' do
         expect(command_args).not_to include('--auto-correct')


### PR DESCRIPTION
This new CLI option is meant to mirror the 'puppet module generate' command for experienced module developers used to the old method of generating a module skeleton. This CLI option redirects to 'pdk new module' after an initial prompt confirming the user's intent.