### PR TITLE
(PDK-415) Convert user-input related problems from FATAL to ERROR

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -15,6 +15,10 @@ require 'pdk/util/version'
 module PDK::CLI
   def self.run(args)
     @base_cmd.run(args)
+  rescue PDK::CLI::ExitWithError => e
+    PDK.logger.error(e.message)
+
+    exit e.exit_code
   rescue PDK::CLI::FatalError => e
     PDK.logger.fatal(e.message) if e.message
 

--- a/lib/pdk/cli/errors.rb
+++ b/lib/pdk/cli/errors.rb
@@ -8,5 +8,14 @@ module PDK
         super(msg)
       end
     end
+
+    class ExitWithError < StandardError
+      attr_reader :exit_code
+
+      def initialize(msg, exit_code = 1)
+        @exit_code = exit_code
+        super(msg)
+      end
+    end
   end
 end

--- a/lib/pdk/cli/new/class.rb
+++ b/lib/pdk/cli/new/class.rb
@@ -20,7 +20,7 @@ module PDK::CLI
       end
 
       unless Util::OptionValidator.valid_class_name?(class_name)
-        raise PDK::CLI::FatalError, _("'%{name}' is not a valid class name") % { name: class_name }
+        raise PDK::CLI::ExitWithError, _("'%{name}' is not a valid class name") % { name: class_name }
       end
 
       PDK::Generate::PuppetClass.new(module_dir, class_name, opts).run

--- a/lib/pdk/cli/new/defined_type.rb
+++ b/lib/pdk/cli/new/defined_type.rb
@@ -18,7 +18,7 @@ module PDK::CLI
       end
 
       unless Util::OptionValidator.valid_defined_type_name?(defined_type_name)
-        raise PDK::CLI::FatalError, _("'%{name}' is not a valid defined type name") % { name: defined_type_name }
+        raise PDK::CLI::ExitWithError, _("'%{name}' is not a valid defined type name") % { name: defined_type_name }
       end
 
       PDK::Generate::DefinedType.new(module_dir, defined_type_name, opts).run

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -3,11 +3,11 @@ module PDK
     module Util
       # Ensures the calling code is being run from inside a module directory.
       #
-      # @raise [PDK::CLI::FatalError] if the current directory or parents do
+      # @raise [PDK::CLI::ExitWithError] if the current directory or parents do
       #   not contain a `metadata.json` file.
       def ensure_in_module!
         message = _('This command must be run from inside a valid module (no metadata.json found).')
-        raise PDK::CLI::FatalError, message if PDK::Util.module_root.nil?
+        raise PDK::CLI::ExitWithError, message if PDK::Util.module_root.nil?
       end
       module_function :ensure_in_module!
 

--- a/lib/pdk/cli/util/option_normalizer.rb
+++ b/lib/pdk/cli/util/option_normalizer.rb
@@ -29,7 +29,7 @@ module PDK
             begin
               OptionValidator.enum(format, PDK::Report.formats)
             rescue ArgumentError
-              raise PDK::CLI::FatalError, _("'%{name}' is not a valid report format (%{valid})") % {
+              raise PDK::CLI::ExitWithError, _("'%{name}' is not a valid report format (%{valid})") % {
                 name:  format,
                 valid: PDK::Report.formats.join(', '),
               }
@@ -53,13 +53,13 @@ module PDK
           param_type = 'String' if param_type.nil?
 
           unless PDK::CLI::Util::OptionValidator.valid_param_name?(param_name)
-            raise PDK::CLI::FatalError, _("'%{name}' is not a valid parameter name") % {
+            raise PDK::CLI::ExitWithError, _("'%{name}' is not a valid parameter name") % {
               name: param_name,
             }
           end
 
           unless PDK::CLI::Util::OptionValidator.valid_data_type?(param_type)
-            raise PDK::CLI::FatalError, _("'%{type}' is not a valid data type") % {
+            raise PDK::CLI::ExitWithError, _("'%{type}' is not a valid data type") % {
               type: param_type,
             }
           end

--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -38,12 +38,12 @@ module PDK
             "'%{module_name}' is not a valid module name.\n" \
             'Module names must begin with a lowercase letter and can only include lowercase letters, digits, and underscores.',
           ) % { module_name: opts[:name] }
-          raise PDK::CLI::FatalError, error_msg
+          raise PDK::CLI::ExitWithError, error_msg
         end
 
         target_dir = File.expand_path(opts[:target_dir])
 
-        raise PDK::CLI::FatalError, _("The destination directory '%{dir}' already exists") % { dir: target_dir } if File.exist?(target_dir)
+        raise PDK::CLI::ExitWithError, _("The destination directory '%{dir}' already exists") % { dir: target_dir } if File.exist?(target_dir)
       end
 
       def self.invoke(opts = {})

--- a/lib/pdk/generators/puppet_object.rb
+++ b/lib/pdk/generators/puppet_object.rb
@@ -78,14 +78,14 @@ module PDK
       # and create the target files from the template. This is the main entry
       # point for the class.
       #
-      # @raise [PDK::CLI::FatalError] if the target files already exist.
+      # @raise [PDK::CLI::ExitWithError] if the target files already exist.
       # @raise [PDK::CLI::FatalError] (see #render_file)
       #
       # @api public
       def run
         [target_object_path, target_spec_path].each do |target_file|
           if File.exist?(target_file)
-            raise PDK::CLI::FatalError, _("Unable to generate %{object_type}; '%{file}' already exists.") % { file: target_file, object_type: object_type }
+            raise PDK::CLI::ExitWithError, _("Unable to generate %{object_type}; '%{file}' already exists.") % { file: target_file, object_type: object_type }
           end
         end
 

--- a/spec/unit/cli/new/module_spec.rb
+++ b/spec/unit/cli/new/module_spec.rb
@@ -15,7 +15,7 @@ describe 'Running `pdk new module`' do
 
   context 'when passed an invalid module name' do
     it 'informs the user that the module name is invalid' do
-      expect(logger).to receive(:fatal).with(a_string_matching(%r{'123test'.*not.*valid module name}m))
+      expect(logger).to receive(:error).with(a_string_matching(%r{'123test'.*not.*valid module name}m))
 
       expect {
         PDK::CLI.run(%w[new module 123test])

--- a/spec/unit/pdk/cli/new/class_spec.rb
+++ b/spec/unit/pdk/cli/new/class_spec.rb
@@ -8,8 +8,8 @@ describe 'PDK::CLI new class' do
       allow(PDK::Util).to receive(:module_root).and_return(nil)
     end
 
-    it 'exits with a fatal error' do
-      expect(logger).to receive(:fatal).with(a_string_matching(%r{must be run from inside a valid module}))
+    it 'exits with an error' do
+      expect(logger).to receive(:error).with(a_string_matching(%r{must be run from inside a valid module}))
 
       expect {
         PDK::CLI.run(%w[new class test_class])
@@ -45,8 +45,8 @@ describe 'PDK::CLI new class' do
     end
 
     context 'and provided an invalid class name' do
-      it 'exits with a fatal error' do
-        expect(logger).to receive(:fatal).with(a_string_matching(%r{'test-class' is not a valid class name}))
+      it 'exits with an error' do
+        expect(logger).to receive(:error).with(a_string_matching(%r{'test-class' is not a valid class name}))
 
         expect {
           PDK::CLI.run(%w[new class test-class])

--- a/spec/unit/pdk/cli/new/defined_type_spec.rb
+++ b/spec/unit/pdk/cli/new/defined_type_spec.rb
@@ -17,9 +17,9 @@ describe 'PDK::CLI new defined_type' do
     end
   end
 
-  shared_examples 'it exits with a fatal error' do |expected_error|
-    it 'exits with a fatal error' do
-      expect(logger).to receive(:fatal).with(a_string_matching(expected_error))
+  shared_examples 'it exits with an error' do |expected_error|
+    it 'exits with an error' do
+      expect(logger).to receive(:error).with(a_string_matching(expected_error))
 
       expect {
         PDK::CLI.run(args)
@@ -33,7 +33,7 @@ describe 'PDK::CLI new defined_type' do
     let(:module_root) { nil }
     let(:args) { %w[new defined_type test_define] }
 
-    it_behaves_like 'it exits with a fatal error', %r{must be run from inside a valid module}
+    it_behaves_like 'it exits with an error', %r{must be run from inside a valid module}
   end
 
   context 'when run from inside a module' do
@@ -54,7 +54,7 @@ describe 'PDK::CLI new defined_type' do
     context 'and provided an invalid defined type name' do
       let(:args) { %w[new defined_type test-define] }
 
-      it_behaves_like 'it exits with a fatal error', %r{'test-define' is not a valid defined type name}
+      it_behaves_like 'it exits with an error', %r{'test-define' is not a valid defined type name}
     end
 
     context 'and provided a valid defined type name' do

--- a/spec/unit/pdk/cli/util/option_normalizer_spec.rb
+++ b/spec/unit/pdk/cli/util/option_normalizer_spec.rb
@@ -105,7 +105,11 @@ describe PDK::CLI::Util::OptionNormalizer do
         allow(PDK::CLI::Util::OptionValidator).to receive(:valid_param_name?).with(param_name).and_return(false)
       end
 
-      it { expect { normalised_parameter }.to raise_error(PDK::CLI::FatalError, %r{'#{param_name}' is not a valid parameter name}) }
+      it 'raises an error' do
+        expect {
+          normalised_parameter
+        }.to raise_error(PDK::CLI::ExitWithError, %r{'#{param_name}' is not a valid parameter name})
+      end
     end
 
     context 'when passed an invalid data type' do
@@ -115,7 +119,11 @@ describe PDK::CLI::Util::OptionNormalizer do
         allow(PDK::CLI::Util::OptionValidator).to receive(:valid_data_type?).with(param_type).and_return(false)
       end
 
-      it { expect { normalised_parameter }.to raise_error(PDK::CLI::FatalError, %r{'#{param_type}' is not a valid data type}) }
+      it 'raises an error' do
+        expect {
+          normalised_parameter
+        }.to raise_error(PDK::CLI::ExitWithError, %r{'#{param_type}' is not a valid data type})
+      end
     end
   end
 end

--- a/spec/unit/pdk/cli/util_spec.rb
+++ b/spec/unit/pdk/cli/util_spec.rb
@@ -6,7 +6,7 @@ describe 'PDK::CLI::Util' do
     subject(:ensure_in_module) { PDK::CLI::Util.ensure_in_module! }
 
     it 'raises an error when not in a module directory' do
-      expect { ensure_in_module }.to raise_error(PDK::CLI::FatalError)
+      expect { ensure_in_module }.to raise_error(PDK::CLI::ExitWithError)
     end
   end
 end

--- a/spec/unit/pdk/cli_spec.rb
+++ b/spec/unit/pdk/cli_spec.rb
@@ -27,7 +27,7 @@ describe PDK::CLI do
 
   context 'when provided an invalid report format' do
     it 'informs the user and exits' do
-      expect(logger).to receive(:fatal).with(a_string_matching(%r{'non_existant_format'.*valid report format}))
+      expect(logger).to receive(:error).with(a_string_matching(%r{'non_existant_format'.*valid report format}))
 
       expect {
         described_class.run(['--format', 'non_existant_format'])

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -69,7 +69,7 @@ describe PDK::Generate::Module do
 
         expect {
           described_class.invoke(name: 'foo', target_dir: target_dir)
-        }.to raise_error(PDK::CLI::FatalError, %r{destination directory '.+' already exists}i)
+        }.to raise_error(PDK::CLI::ExitWithError, %r{destination directory '.+' already exists}i)
       end
     end
 

--- a/spec/unit/pdk/generate/puppet_object_spec.rb
+++ b/spec/unit/pdk/generate/puppet_object_spec.rb
@@ -249,8 +249,8 @@ describe PDK::Generate::PuppetObject do
         allow(File).to receive(:exist?).with(target_object_path).and_return(true)
       end
 
-      it 'raises a fatal error' do
-        expect { templated_object.run }.to raise_error(PDK::CLI::FatalError, %r{'#{target_object_path}' already exists})
+      it 'raises an error' do
+        expect { templated_object.run }.to raise_error(PDK::CLI::ExitWithError, %r{'#{target_object_path}' already exists})
       end
     end
 
@@ -260,8 +260,8 @@ describe PDK::Generate::PuppetObject do
         allow(File).to receive(:exist?).with(target_spec_path).and_return(true)
       end
 
-      it 'raises a fatal error' do
-        expect { templated_object.run }.to raise_error(PDK::CLI::FatalError, %r{'#{target_spec_path}' already exists})
+      it 'raises an error' do
+        expect { templated_object.run }.to raise_error(PDK::CLI::ExitWithError, %r{'#{target_spec_path}' already exists})
       end
     end
   end


### PR DESCRIPTION
Adds a new exception type that should be raised when dealing with user input related problems (like trying to create a class that already exists).

```
asmodean :0: pdk/foo (git:pdk-415 → origin {2} ?:2!)$ ../bin/pdk new class foo
pdk (ERROR): Unable to generate class; '/home/tsharpe/code/puppet/pdk/foo/manifests/init.pp' already exists.
```

`PDK::CLI::FatalError` should still be used when catching and re-raising an exception, as those are almost always fatal errors and should be displayed as such.