### PR TITLE
(PDK-369) Improve error context for pdk test unit failures

### DIFF
--- a/spec/unit/pdk/report/event_spec.rb
+++ b/spec/unit/pdk/report/event_spec.rb
@@ -386,6 +386,50 @@ describe PDK::Report::Event do
           expect(text_event).to match(%r{testfile\.rb:123:456})
         end
       end
+
+      context 'it includes a snippet of the file for rspec events' do
+        let(:data) do
+          {
+            line:    4,
+            source:  'rspec',
+            message: 'test message',
+            severity: 'failure',
+            test:     'spec description',
+            state:    :failure,
+          }
+        end
+
+        let(:file_content) do
+          [
+            'line 1',
+            'line 2',
+            'line 3',
+            'line 4',
+            'line 5',
+          ].join("\n")
+        end
+
+        let(:expected_text) do
+          <<-END.gsub(%r{^ {12}}, '')
+            failure: rspec: testfile.rb:4: test message
+              spec description
+              Failure/Error:
+              line 2
+              line 3
+              line 4
+              line 5
+
+          END
+        end
+
+        before(:each) do
+          allow(File).to receive(:read).with('testfile.rb').and_return(file_content)
+        end
+
+        it 'renders the event with context' do
+          expect(text_event).to eq(expected_text)
+        end
+      end
     end
 
     context 'and a severity is provided' do


### PR DESCRIPTION
Adds the spec description to the output for rspec events, as well as up to 5 lines of context of the failing spec (up to 2 on either side of the failing line).

Example:
```
asmodean :0: pdk/foo (git:sdk-369 {2} U:1 ?:2!)$ ../bin/pdk test unit
[✔] Preparing to run the unit tests.
[✖] Running unit tests.
  Evaluated 5 tests in 0.206083208 seconds: 5 failures, 0 pending.
[✔] Cleaning up after running unit tests.
failed: rspec: ./spec/classes/foo_spec.rb:8: expected that the catalogue would not compile but it does
  foo on windows-2012-x64 should not compile into a catalogue without dependency cycles
  Failure/Error:
        let(:facts) { os_facts }
  
        it { is_expected.not_to compile }
      end
    end

failed: rspec: ./spec/classes/foo_spec.rb:8: expected that the catalogue would not compile but it does
  foo on debian-8-x86_64 should not compile into a catalogue without dependency cycles
  Failure/Error:
        let(:facts) { os_facts }
  
        it { is_expected.not_to compile }
      end
    end

failed: rspec: ./spec/classes/foo_spec.rb:8: expected that the catalogue would not compile but it does
  foo on windows-2012 R2-x64 should not compile into a catalogue without dependency cycles
  Failure/Error:
        let(:facts) { os_facts }
  
        it { is_expected.not_to compile }
      end
    end

failed: rspec: ./spec/classes/foo_spec.rb:8: expected that the catalogue would not compile but it does
  foo on ubuntu-16.04-x86_64 should not compile into a catalogue without dependency cycles
  Failure/Error:
        let(:facts) { os_facts }
  
        it { is_expected.not_to compile }
      end
    end

failed: rspec: ./spec/classes/foo_spec.rb:8: expected that the catalogue would not compile but it does
  foo on redhat-7-x86_64 should not compile into a catalogue without dependency cycles
  Failure/Error:
        let(:facts) { os_facts }
  
        it { is_expected.not_to compile }
      end
    end
```