### PR TITLE
(PDK-502) Add git mingw paths to PATH

### DIFF
--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -25,6 +25,20 @@ module PDK
         @git_dir ||= File.join('private', 'git', Gem.win_platform? ? 'cmd' : 'bin')
       end
 
+      def self.git_paths
+        @paths ||= begin
+          paths = [File.join(PDK::Util.pdk_package_basedir, git_bindir)]
+
+          if Gem.win_platform?
+            paths << File.join(PDK::Util.pdk_package_basedir, 'private', 'git', 'mingw64', 'bin')
+            paths << File.join(PDK::Util.pdk_package_basedir, 'private', 'git', 'mingw64', 'libexec', 'git-core')
+            paths << File.join(PDK::Util.pdk_package_basedir, 'private', 'git', 'usr', 'bin')
+          end
+
+          paths
+        end
+      end
+
       def self.git_bin
         git_bin = Gem.win_platform? ? 'git.exe' : 'git'
         vendored_bin_path = File.join(git_bindir, git_bin)
@@ -154,9 +168,9 @@ module PDK
               File.join(@process.environment['GEM_HOME'], 'bin'),
               File.join(@process.environment['GEM_PATH'], 'bin'),
               package_binpath,
-              PDK::Util.package_install? ? PDK::CLI::Exec.git_bindir : nil,
               ENV['PATH'],
-            ].compact.join(File::PATH_SEPARATOR)
+              PDK::Util.package_install? ? PDK::CLI::Exec.git_paths : nil,
+            ].compact.flatten.join(File::PATH_SEPARATOR)
 
             mod_root = PDK::Util.module_root
 


### PR DESCRIPTION
Git on Windows doesn't seem to automatically find its component binaries, so we need to add them to the path in order for the vendored git to work properly.