### PR TITLE
(PDK-555) Handle windows style (backslash separated) paths

### DIFF
--- a/lib/pdk/validators/base_validator.rb
+++ b/lib/pdk/validators/base_validator.rb
@@ -36,6 +36,7 @@ module PDK
                     options[:targets]
                   end
 
+        targets.map! { |r| r.gsub(File::ALT_SEPARATOR, File::SEPARATOR) } if File::ALT_SEPARATOR
         skipped = []
         invalid = []
         matched = targets.map { |target|


### PR DESCRIPTION
`Dir.glob` [doesn't support backslash separated paths](https://ruby-doc.org/core-2.2.0/Dir.html#method-c-glob) due to backslashes being used to escape characters, so we convert the ALT_SEPARATORs to SEPARATORs in user supplied paths before using them.