### PR TITLE
(PDK-479) new module: create examples/, and files/ directory

### DIFF
--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -150,6 +150,8 @@ module PDK
 
       def self.prepare_module_directory(target_dir)
         [
+          File.join(target_dir, 'examples'),
+          File.join(target_dir, 'files'),
           File.join(target_dir, 'manifests'),
           File.join(target_dir, 'templates'),
         ].each do |dir|

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -660,6 +660,8 @@ describe PDK::Generate::Module do
     let(:path) { 'test123' }
 
     it 'creates a skeleton directory structure' do
+      expect(FileUtils).to receive(:mkdir_p).with(File.join(path, 'examples'))
+      expect(FileUtils).to receive(:mkdir_p).with(File.join(path, 'files'))
       expect(FileUtils).to receive(:mkdir_p).with(File.join(path, 'manifests'))
       expect(FileUtils).to receive(:mkdir_p).with(File.join(path, 'templates'))
 


### PR DESCRIPTION
To give a fuller experience when looking at a new module, provide
the common directories that people need.

Given that git will happily ignore the empty directories, it's a bit
wishy-washy, but will do as a first iteration for newcomers.