### PR TITLE
(PDK-594) mention the used template during `new module`

### DIFF
--- a/lib/pdk/generators/module.rb
+++ b/lib/pdk/generators/module.rb
@@ -98,7 +98,7 @@ module PDK
 
         begin
           if FileUtils.mv(temp_target_dir, target_dir)
-            PDK.logger.info(_('Module \'%{name}\' generated at path \'%{path}\'.') % { name: opts[:name], path: target_dir })
+            PDK.logger.info(_('Module \'%{name}\' generated at path \'%{path}\', from template \'%{template_url}\'.') % { name: opts[:name], path: target_dir, template_url: template_url })
             PDK.logger.info(_('In your module directory, add classes with the \'pdk new class\' command.'))
           end
         rescue Errno::EACCES => e


### PR DESCRIPTION
To raise awareness of the existance of templates, and make it clear
which template is used.