### PR TITLE
Add --relative cli argument for autoload layout testing in puppet-lint

### DIFF
--- a/lib/pdk/validators/puppet/puppet_lint.rb
+++ b/lib/pdk/validators/puppet/puppet_lint.rb
@@ -23,7 +23,7 @@ module PDK
       end
 
       def self.parse_options(options, targets)
-        cmd_options = ['--json']
+        cmd_options = ['--json', '--relative']
 
         cmd_options << '--fix' if options[:auto_correct]
 

--- a/spec/unit/pdk/validate/puppet_lint_spec.rb
+++ b/spec/unit/pdk/validate/puppet_lint_spec.rb
@@ -5,6 +5,10 @@ shared_examples_for 'it sets the common puppet-lint options' do
     expect(command_args.first).to eq('--json')
   end
 
+  it 'sets the autoload layout plugin to ignore the top-most directory' do
+    expect(command_args[1]).to eq('--relative')
+  end
+
   it 'appends the targets to the command arguments' do
     expect(command_args.last(targets.count)).to eq(targets)
   end


### PR DESCRIPTION
When validating a module via `pdk validate`, puppet-lint fails validation for its autoloader_layout check if the module directory is not the exact module name, i.e. if validating an ntp module, puppet-lint passes `/path/ntp` but fails `/path/puppetlabs-ntp`.

This passes the `--relative` argument to puppet-lint to ignore the top-most directory of the module and pass in both of the previous examples. Hopefully this should help with module conversion.

More info: https://github.com/rodjek/puppet-lint/issues/245
and https://github.com/rodjek/puppet-lint/pull/252