### PR TITLE
(PDK-626) Templatedir can now handle multiple directories

### DIFF
--- a/lib/pdk/generate/module.rb
+++ b/lib/pdk/generate/module.rb
@@ -70,7 +70,7 @@ module PDK
 
         template_url = opts.fetch(:'template-url', default_template_url)
 
-        PDK::Module::TemplateDir.new(template_url, metadata.data) do |templates|
+        PDK::Module::TemplateDir.new(template_url, metadata.data, true) do |templates|
           templates.render do |file_path, file_content|
             file = Pathname.new(temp_target_dir) + file_path
             file.dirname.mkpath

--- a/spec/acceptance/new_module_spec.rb
+++ b/spec/acceptance/new_module_spec.rb
@@ -22,7 +22,7 @@ describe 'Creating a new module' do
       it { is_expected.to be_file }
       its(:content_as_json) do
         is_expected.to include('name' => match(%r{-foo}),
-                               'template-ref' => match(%r{master-}),
+                               'template-ref' => match(%r{convert-}),
                                'operatingsystem_support' => include('operatingsystem' => 'Debian',
                                                                     'operatingsystemrelease' => ['8']))
       end

--- a/spec/unit/pdk/module/template_dir_spec.rb
+++ b/spec/unit/pdk/module/template_dir_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe PDK::Module::TemplateDir do
   subject(:template_dir) do
-    described_class.new(path_or_url, module_metadata) do |foo|
+    described_class.new(path_or_url, module_metadata, true) do |foo|
       # block does nothing
     end
   end
@@ -41,5 +41,137 @@ describe PDK::Module::TemplateDir do
 
   it 'has a metadata method' do
     expect(described_class.instance_methods(false)).to include(:metadata)
+  end
+
+  describe '.files_in_template(dirs)' do
+    context 'when passing in an empty directory' do
+      let(:dirs) { ['/the/file/is/here'] }
+
+      before(:each) do
+        allow(Dir).to receive(:exist?).with('/the/file/is/here').and_return true
+      end
+      it 'returns an empty list' do
+        expect(described_class.files_in_template(dirs)).to eq({})
+      end
+    end
+
+    context 'when passing in a non-existant directory' do
+      let(:dirs) { ['/the/file/is/nothere'] }
+
+      before(:each) do
+        allow(Dir).to receive(:exists?).with('/the/file/is/nothere').and_return false
+      end
+      it 'raises an error' do
+        expect { described_class.files_in_template(dirs) }.to raise_error(ArgumentError, %r{The directory '%\{dir\}' doesn't exist})
+      end
+    end
+
+    context 'when passing in a directory with a single file' do
+      let(:dirs) { ['/here/moduleroot'] }
+
+      before(:each) do
+        allow(Dir).to receive(:exist?).with('/here/moduleroot').and_return true
+        allow(File).to receive(:file?).with('/here/moduleroot/filename').and_return true
+        allow(Dir).to receive(:glob).with('/here/moduleroot/**/*', File::FNM_DOTMATCH).and_return ['/here/moduleroot/filename']
+      end
+      it 'returns the file name' do
+        expect(described_class.files_in_template(dirs)).to eq('filename' => '/here/moduleroot')
+      end
+    end
+
+    context 'when passing in a directory with more than one file' do
+      let(:dirs) { ['/here/moduleroot'] }
+
+      before(:each) do
+        allow(Dir).to receive(:exist?).with('/here/moduleroot').and_return true
+        allow(File).to receive(:file?).with('/here/moduleroot/filename').and_return true
+        allow(File).to receive(:file?).with('/here/moduleroot/filename2').and_return true
+        allow(Dir).to receive(:glob).with('/here/moduleroot/**/*', File::FNM_DOTMATCH).and_return ['/here/moduleroot/filename', '/here/moduleroot/filename2']
+      end
+      it 'returns both the file names' do
+        expect(described_class.files_in_template(dirs)).to eq('filename' => '/here/moduleroot', 'filename2' => '/here/moduleroot')
+      end
+    end
+
+    context 'when passing in more than one directory with a file' do
+      let(:path_or_url) { '/path/to/templates' }
+      let(:dirs) { ['/path/to/templates/moduleroot', '/path/to/templates/moduleroot_init'] }
+
+      before(:each) do
+        allow(Dir).to receive(:exist?).with('/path/to/templates').and_return true
+        allow(Dir).to receive(:exist?).with('/path/to/templates/moduleroot').and_return true
+        allow(Dir).to receive(:exist?).with('/path/to/templates/moduleroot_init').and_return true
+        allow(File).to receive(:file?).with('/path/to/templates/moduleroot/.').and_return true
+        allow(File).to receive(:file?).with('/path/to/templates/moduleroot/filename').and_return true
+        allow(File).to receive(:file?).with('/path/to/templates/moduleroot_init/filename2').and_return true
+        allow(Dir).to receive(:glob).with('/path/to/templates/moduleroot/**/*', File::FNM_DOTMATCH).and_return ['/path/to/templates/moduleroot/.', '/path/to/templates/moduleroot/filename']
+        allow(Dir).to receive(:glob).with('/path/to/templates/moduleroot_init/**/*', File::FNM_DOTMATCH).and_return ['/path/to/templates/moduleroot_init/filename2']
+      end
+      it 'returns the file names from both directories' do
+        expect(described_class.files_in_template(dirs)).to eq('filename' => '/path/to/templates/moduleroot',
+                                                              'filename2' => '/path/to/templates/moduleroot_init')
+      end
+    end
+  end
+
+  describe '.render(template_files)' do
+    before(:each) do
+      allow(File).to receive(:directory?).with(anything).and_return(true)
+      allow(PDK::Util).to receive(:make_tmpdir_name).with('pdk-module-template').and_return('/tmp/path')
+      allow(PDK::CLI::Exec).to receive(:git).with('clone', path_or_url, '/tmp/path').and_return(exit_code: 0)
+    end
+
+    context 'when passing in a template file' do
+      let(:template_file) { instance_double('PDK::TemplateFile', 'filename.erb') }
+      let(:template_files) { { 'filename.erb' => 'file/is/here/' } }
+
+      before(:each) do
+        allow(described_class).to receive(:config_for).with('filename').and_return true
+        allow(PDK::TemplateFile).to receive(:new).with('file/is/here/filename.erb', configs: true).and_return template_file
+        allow(template_file).to receive(:render).and_return template_file
+        allow(described_class).to receive(:render) { { 'filename.erb' => 'file/is/here/' } }
+      end
+      it 'renders the template file and returns relevant values' do
+        expect(described_class.render(template_files)).to eq('filename.erb' => 'file/is/here/')
+      end
+    end
+
+    context 'when passing in two template files in the same location' do
+      let(:template_file) { instance_double('PDK::TemplateFile', 'filename.erb') }
+      let(:template_file2) { instance_double('PDK::TemplateFile', 'filename2.erb') }
+      let(:template_files) { { 'filename.erb' => 'file/is/here/', 'filename2.erb' => 'file/is/here/' } }
+
+      before(:each) do
+        allow(described_class).to receive(:config_for).with('filename').and_return true
+        allow(PDK::TemplateFile).to receive(:new).with('file/is/here/filename.erb', configs: true).and_return template_file
+        allow(template_file).to receive(:render).and_return template_file
+        allow(described_class).to receive(:config_for).with('filename2').and_return true
+        allow(PDK::TemplateFile).to receive(:new).with('file/is/here/filename2.erb', configs: true).and_return template_file
+        allow(template_file).to receive(:render).and_return template_file2
+        allow(described_class).to receive(:render) { { 'filename.erb' => 'file/is/here/', 'filename2.erb' => 'file/is/here/' } }
+      end
+      it 'renders the template file and returns relevant values' do
+        expect(described_class.render(template_files)).to eq('filename.erb' => 'file/is/here/', 'filename2.erb' => 'file/is/here/')
+      end
+    end
+
+    context 'when passing in two template files in different directories' do
+      let(:template_file) { instance_double('PDK::TemplateFile', 'filename.erb') }
+      let(:template_file2) { instance_double('PDK::TemplateFile', 'filename2.erb') }
+      let(:template_files) { { 'filename.erb' => 'file/is/here/', 'filename2.erb' => 'file/is/here/' } }
+
+      before(:each) do
+        allow(described_class).to receive(:config_for).with('filename').and_return true
+        allow(PDK::TemplateFile).to receive(:new).with('file/is/here/filename.erb', configs: true).and_return template_file
+        allow(template_file).to receive(:render).and_return template_file
+        allow(described_class).to receive(:config_for).with('filename2').and_return true
+        allow(PDK::TemplateFile).to receive(:new).with('file/is/where/filename2.erb', configs: true).and_return template_file
+        allow(template_file2).to receive(:render).and_return template_file2
+        allow(described_class).to receive(:render) { { 'filename.erb' => 'file/is/here/', 'filename2.erb' => 'file/is/where/' } }
+      end
+      it 'renders the template file and returns relevant values' do
+        expect(described_class.render(template_files)).to eq('filename.erb' => 'file/is/here/', 'filename2.erb' => 'file/is/where/')
+      end
+    end
   end
 end


### PR DESCRIPTION
Required for the new 'convert' functionality - The aim of this update is so that files needed for convert are kept in a default directory,
while new requires additional directories that will be found in the 'moduleroot_init'.