### PR TITLE
Dockerize pdk

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,30 @@
 FROM docker:dind
 
-ENV BUILD_PACKAGES bash curl-dev ruby-dev build-base libxml2-dev libxslt-dev libffi-dev
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV BUILD_PACKAGES git bash curl-dev ruby-dev build-base libxml2-dev libxslt-dev libffi-dev
 ENV RUBY_PACKAGES ruby ruby-io-console ruby-bundler
-ENV EXTRA_PACKAGES git bash
 
 RUN apk update && \
 	apk upgrade && \
 	apk add $BUILD_PACKAGES	&& \
 	apk add $RUBY_PACKAGES && \
-	apk add $EXTRA_PACKAGES && \
 	rm -rf /var/cache/apk/*
 
 RUN mkdir /pdk
-ENV PATH="/pdk/bin:${PATH}"
+ENV PATH /pdk/bin:$PATH
 WORKDIR pdk
 COPY . /pdk
 RUN bundle install
 RUN bundle binstubs pdk --path /pdk/bin
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+VOLUME /usr/src/app
+
+ENTRYPOINT ["pdk"]
+CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM docker:dind
+
+ENV BUILD_PACKAGES bash curl-dev ruby-dev build-base libxml2-dev libxslt-dev libffi-dev
+ENV RUBY_PACKAGES ruby ruby-io-console ruby-bundler
+ENV EXTRA_PACKAGES git bash
+
+RUN apk update && \
+	apk upgrade && \
+	apk add $BUILD_PACKAGES	&& \
+	apk add $RUBY_PACKAGES && \
+	apk add $EXTRA_PACKAGES && \
+	rm -rf /var/cache/apk/*
+
+RUN mkdir /pdk
+ENV PATH="/pdk/bin:${PATH}"
+WORKDIR pdk
+COPY . /pdk
+RUN bundle install
+RUN bundle binstubs pdk --path /pdk/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,5 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 VOLUME /usr/src/app
 
-ENTRYPOINT ["pdk"]
-CMD []
+ENTRYPOINT ["dockerd-entrypoint.sh"]
+CMD ["pdk"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,4 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 VOLUME /usr/src/app
 
-ENTRYPOINT ["dockerd-entrypoint.sh"]
 CMD ["pdk"]

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :test do
   gem 'rubocop', '= 0.49.1'
   gem 'rubocop-rspec', '= 1.15.1'
   gem 'simplecov-console'
+  gem 'dockerspec', '~> 0.5.0'
 end
 
 group :acceptance do

--- a/README.md
+++ b/README.md
@@ -30,6 +30,30 @@ Download and install the newest package matching your platform from the [downloa
 
 For complete installation information, see the [PDK documentation](https://puppet.com/docs/pdk/latest/pdk_install.html).
 
+### Dockerized pdk
+
+In addition to the native platform installation options, we've packaged pdk as a docker image, allowing you a puppet development environment that is completely dockerized. This provides a few benefits for development and testing:
+
+- no need to worry about pre-requisites for installing pdk (ruby, git, etc...)
+- ensure a standardized development environment for all contributors of your module
+- you can use the pdk image as a base for your CI/CD tools, ensuring tests will work the same on your development machine as they do on your CI platforms
+
+To utilize this installation method, make sure you have
+[docker](https://www.docker.com/community-edition#/download) installed,
+and `docker pull puppet/pdk` to download. To simulate having
+pdk natively installed, add the following alias to your
+shell's config file (`.bashrc`, `.zshrc`, etc..)
+
+```
+echo "alias pdk=\"docker run -it --rm -v \$(pwd):/usr/src/app puppet/pdk\"" >> ~/.bashrc && source ~/.bashrc
+```
+Test your dockerized installation by running:
+
+```
+$ pdk --version
+1.2.1 (heads/master)
+```
+
 ## Basic usage
 
 PDK can generate modules and classes, validate module metadata, style, and syntax, and run unit tests. This README contains very basic usage information---for complete usage information, see the [PDK documentation](https://puppet.com/docs/pdk/latest/pdk_install.html).

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pdk natively installed, add the following alias to your
 shell's config file (`.bashrc`, `.zshrc`, etc..)
 
 ```
-echo "alias pdk=\"docker run -it --rm -v \$(pwd):/usr/src/app puppet/pdk\"" >> ~/.bashrc && source ~/.bashrc
+echo "alias pdk=\"docker run -it --rm -v \$(pwd):/usr/src/app -v /var/run/docker.sock:/var/run/docker.sock puppet/pdk\"" >> ~/.bashrc && source ~/.bashrc
 ```
 Test your dockerized installation by running:
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ rake build                 # Build puppet module package
 
 Note that for PowerShell the `--` must be escaped using a backtick ( <code>`-- </code> ) or the shell parses it and strips it out of the command. See [PDK-408](https://tickets.puppet.com/browse/PDK-408) for details.
 
+The `puppet/pdk` docker image is built from `docker:dind` so that acceptance tests can be run from within the pdk image. Only the `docker` hypervisor is supported when using the docker-based installation of `pdk`.
+
 ## Module Compatibility
 
 **PDK Version Compatibility:** Modules created with PDK version validate against and run on all Puppet and Ruby version combinations currently under maintenance (see https://docs.puppet.com/puppet/latest/about_agent.html and https://puppet.com/misc/puppet-enterprise-lifecycle)


### PR DESCRIPTION
This PR adds a [docker](https://docs.docker.com) based offering of `pdk` for users, as an alternative to natively installing pdk (and all the pre-reqs that come with it). Some benefits of this are listed in the changes to the `README.md` included in this PR.