### PR TITLE
(maint) Downgrade Bundler on TravisCI to 1.15.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: false
 language: ruby
 bundler_args: "--without development"
+before_install:
+  - gem -v
+  - gem update --system 2.6.14
+  - gem install bundler --version 1.16.0 --force
 script:
   - cat Gemfile.lock
   - bundle list


### PR DESCRIPTION
Travis updated bundler in their build environments to 1.16.0, but we specify Bundler ~> 1.15 as a dependency and this discrepancy causes Bad Things (tm) to happen.