### PR TITLE
(PDK-674) UX Improvement for listing unit test files.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ end
 
 group :test do
   gem 'coveralls'
-  gem 'license_finder'
+  gem 'license_finder', '~> 3.0.4'
   gem 'rake', '~> 10.0'
   gem 'rspec', '~> 3.0'
   gem 'rspec-xsd'

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ group :development do
   gem 'github_changelog_generator', git: 'https://github.com/skywinder/github-changelog-generator.git', ref: '33f89614d47a4bca1a3ae02bdcc37edd0b012e86'
   gem 'pry-byebug', '~> 3.4'
   if RUBY_VERSION < '2.2.2'
+    # byebug >= 9.1.0 requires ruby 2.2.0 or newer
+    gem 'byebug', '~> 9.0.6'
     # required for github_changelog_generator
     gem 'rack', '~> 1.0'
   end

--- a/lib/pdk/cli/test/unit.rb
+++ b/lib/pdk/cli/test/unit.rb
@@ -7,10 +7,11 @@ module PDK::CLI
     usage _('unit [options]')
     summary _('Run unit tests.')
 
-    flag nil, :list, _('list all available unit tests and their descriptions')
-    flag nil, :parallel, _('run unit tests in parallel'), hidden: true
+    flag nil, :list, _('List all available unit test files.')
+    flag nil, :parallel, _('Run unit tests in parallel.'), hidden: true
+    flag :v, :verbose, _('More verbose output. Displays examples in each unit test file.')
 
-    option nil, :tests, _('a comma-separated list of tests to run'), argument: :required, default: '' do |values|
+    option nil, :tests, _('Specify a comma-separated list of unit test files to run.'), argument: :required, default: '' do |values|
       PDK::CLI::Util::OptionValidator.comma_separated_list?(values)
     end
 
@@ -27,11 +28,19 @@ module PDK::CLI
       if opts[:list]
         examples = PDK::Test::Unit.list
         if examples.empty?
-          puts _('No examples found.')
+          puts _('No unit test files with examples were found.')
         else
-          puts _('Examples:')
-          examples.each do |example|
-            puts _("%{id}\t%{description}" % { id: example[:id], description: example[:full_description] })
+          puts _('Unit Test Files:')
+          files = examples.map { |example| example[:file_path] }
+          files.uniq.each do |file|
+            puts _(file)
+
+            next unless opts[:verbose]
+
+            file_examples = examples.select { |example| example[:file_path] == file }
+            file_examples.each do |file_example|
+              puts _("\t%{id}\t%{description}" % { id: file_example[:id], description: file_example[:full_description] })
+            end
           end
         end
       else

--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -199,7 +199,7 @@ module PDK
         else
           examples = []
           rspec_json['examples'].each do |example|
-            examples << { id: example['id'], full_description: example['full_description'] }
+            examples << { file_path: example['file_path'], id: example['id'], full_description: example['full_description'] }
           end
           examples
         end

--- a/spec/acceptance/test_unit_spec.rb
+++ b/spec/acceptance/test_unit_spec.rb
@@ -7,7 +7,7 @@ describe 'Running unit tests' do
 
     describe command('pdk test unit --list') do
       its(:exit_status) { is_expected.to eq 0 }
-      its(:stdout) { is_expected.to match(%r{No examples found}) }
+      its(:stdout) { is_expected.to match(%r{No unit test files with examples were found}) }
     end
 
     describe command('pdk test unit') do
@@ -54,9 +54,7 @@ describe 'Running unit tests' do
 
     describe command('pdk test unit --list') do
       its(:exit_status) { is_expected.to eq 0 }
-      its(:stdout) { is_expected.to match(%r{Examples:.*passing_spec.rb\[1:1:1\]}m) }
-      its(:stdout) { is_expected.to match(%r{passing_spec.rb\[1:2:1\]}) }
-      its(:stdout) { is_expected.to match(%r{passing_spec.rb\[1:3:1\]}) }
+      its(:stdout) { is_expected.to match(%r{Test Files:.*passing_spec.rb}m) }
     end
 
     describe command('pdk test unit') do

--- a/spec/unit/pdk/cli/test/unit_spec.rb
+++ b/spec/unit/pdk/cli/test/unit_spec.rb
@@ -29,17 +29,53 @@ describe '`pdk test unit`' do
           expect(PDK::Test::Unit).to receive(:list).with(no_args).once.and_return([])
         end
 
-        it { expect { test_unit_cmd.run_this(args) }.to output(%r{No examples found}m).to_stdout }
+        it { expect { test_unit_cmd.run_this(args) }.to output(%r{No unit test files with examples were found}m).to_stdout }
       end
 
       context 'when some tests are found' do
-        let(:test_list) { [{ id: 'first_id', full_description: 'first_description' }, { id: 'second_id', full_description: 'second_description' }] }
+        let(:test_list) do
+          [{ file_path: '/path/to/first_test',
+             id: 'first_id',
+             full_description: 'first_description' },
+           { file_path: '/path/to/second_test',
+             id: 'second_id',
+             full_description: 'second_description' }]
+        end
 
         before(:each) do
           expect(PDK::Test::Unit).to receive(:list).with(no_args).once.and_return(test_list)
         end
 
-        it { expect { test_unit_cmd.run_this(args) }.to output(%r{Examples:\nfirst_id\tfirst_description\nsecond_id\tsecond_description}m).to_stdout }
+        it { expect { test_unit_cmd.run_this(args) }.to output(%r{Unit Test Files:\n/path/to/first_test\n/path/to/second_test}m).to_stdout }
+      end
+    end
+
+    context 'when listing tests with verbose' do
+      let(:args) { ['--list', '-v'] }
+
+      context 'when no tests are found' do
+        before(:each) do
+          expect(PDK::Test::Unit).to receive(:list).with(no_args).once.and_return([])
+        end
+
+        it { expect { test_unit_cmd.run_this(args) }.to output(%r{No unit test files with examples were found}m).to_stdout }
+      end
+
+      context 'when some tests are found' do
+        let(:test_list) do
+          [{ file_path: '/path/to/first_test',
+             id: 'first_id',
+             full_description: 'first_description' },
+           { file_path: '/path/to/second_test',
+             id: 'second_id',
+             full_description: 'second_description' }]
+        end
+
+        before(:each) do
+          expect(PDK::Test::Unit).to receive(:list).with(no_args).once.and_return(test_list)
+        end
+
+        it { expect { test_unit_cmd.run_this(args) }.to output(%r{Test Files:\n/path/to/first_test\n\tfirst_id\tfirst_description\n/path/to/second_test\n\tsecond_id\tsecond_description}m).to_stdout }
       end
     end
 

--- a/spec/unit/pdk/test/unit_spec.rb
+++ b/spec/unit/pdk/test/unit_spec.rb
@@ -203,7 +203,8 @@ describe PDK::Test::Unit do
       let(:rspec_json_output) do
         '{
           "examples": [
-            { "id": "./path/to/test[1:1:1]",
+            { "file_path": "./path/to/test",
+              "id": "./path/to/test[1:1:1]",
               "full_description": "a bunch of useful descriptive words",
               "description": "descriptive words" }
           ]
@@ -213,6 +214,7 @@ describe PDK::Test::Unit do
       it 'returns the id and full_description from the rspec output' do
         expected_result = [
           {
+            file_path: './path/to/test',
             id: './path/to/test[1:1:1]',
             full_description: 'a bunch of useful descriptive words',
           },


### PR DESCRIPTION
This PR Improves how `pdk test unit --list` outputs unit test list. It will display a list of test files that contain examples. This output should contain file paths that can then be passed into `--tests=` as a comma-separated list.

This PR also adds a `--verbose` or `-v` option to display more information about the examples in each test file.

```
[~/proj/sdk/test_modules/testmod]$ pdk test unit -h
NAME
    unit - Run unit tests.
USAGE
    pdk test unit [options]
OPTIONS
       --list                     List all available unit test files.
       --tests=<value>            Specify a comma-separated list of test
                                  files to run.
    -v --verbose                  Outputs more detail.
OPTIONS FOR TEST
    -d --debug                    Enable debug output.
    -f --format=<value>           Specify desired output format. Valid
                                  formats are 'junit', 'text'. You may also
                                  specify a file to which the formatted
                                  output is sent, for example:
                                  '--format=junit:report.xml'. This option
                                  may be specified multiple times if each
                                  option specifies a distinct target file.
    -h --help                     Show help for this command.
       --version                  Show version of pdk.
[~/proj/sdk/test_modules/testmod]$ pdk test unit --list
Test Files:
./spec/classes/testmod_spec.rb
./spec/defines/foo_spec.rb
[~/proj/sdk/test_modules/testmod]$ pdk test unit --list -v
Test Files:
./spec/classes/testmod_spec.rb
        ./spec/classes/testmod_spec.rb[1:1:1]   testmod on centos-7-x86_64
        ./spec/classes/testmod_spec.rb[1:2:1]   testmod on debian-8-x86_64
        ./spec/classes/testmod_spec.rb[1:3:1]   testmod on oraclelinux-7-x86_64
        ./spec/classes/testmod_spec.rb[1:4:1]   testmod on redhat-7-x86_64
        ./spec/classes/testmod_spec.rb[1:5:1]   testmod on scientific-7-x86_64
        ./spec/classes/testmod_spec.rb[1:6:1]   testmod on ubuntu-16.04-x86_64
        ./spec/classes/testmod_spec.rb[1:7:1]   testmod on windows-10-x64
        ./spec/classes/testmod_spec.rb[1:8:1]   testmod on windows-2008 R2-x64
        ./spec/classes/testmod_spec.rb[1:9:1]   testmod on windows-2008-x64
        ./spec/classes/testmod_spec.rb[1:10:1]  testmod on windows-2012 R2-x64
        ./spec/classes/testmod_spec.rb[1:11:1]  testmod on windows-2012-x64
./spec/defines/foo_spec.rb
        ./spec/defines/foo_spec.rb[1:1:1]       testmod::foo on centos-7-x86_64
        ./spec/defines/foo_spec.rb[1:2:1]       testmod::foo on debian-8-x86_64
        ./spec/defines/foo_spec.rb[1:3:1]       testmod::foo on oraclelinux-7-x86_64
        ./spec/defines/foo_spec.rb[1:4:1]       testmod::foo on redhat-7-x86_64
        ./spec/defines/foo_spec.rb[1:5:1]       testmod::foo on scientific-7-x86_64
        ./spec/defines/foo_spec.rb[1:6:1]       testmod::foo on ubuntu-16.04-x86_64
        ./spec/defines/foo_spec.rb[1:7:1]       testmod::foo on windows-10-x64
        ./spec/defines/foo_spec.rb[1:8:1]       testmod::foo on windows-2008 R2-x64
        ./spec/defines/foo_spec.rb[1:9:1]       testmod::foo on windows-2008-x64
        ./spec/defines/foo_spec.rb[1:10:1]      testmod::foo on windows-2012 R2-x64
        ./spec/defines/foo_spec.rb[1:11:1]      testmod::foo on windows-2012-x64
[~/proj/sdk/test_modules/testmod]$
```