### PR TITLE
(PDK-643) Do not display spinners when not running interactively

### DIFF
--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -90,7 +90,7 @@ module PDK
         end
 
         def register_spinner(spinner, opts = {})
-          return if PDK.logger.debug?
+          return unless display_spinner?
           @success_message = opts.delete(:success)
           @failure_message = opts.delete(:failure)
 
@@ -98,11 +98,19 @@ module PDK
         end
 
         def add_spinner(message, opts = {})
-          return if PDK.logger.debug?
+          return unless display_spinner?
           @success_message = opts.delete(:success)
           @failure_message = opts.delete(:failure)
 
           @spinner = TTY::Spinner.new("[:spinner] #{message}", opts.merge(PDK::CLI::Util.spinner_opts_for_platform))
+        end
+
+        def display_spinner?
+          return false if PDK.logger.debug?
+          return (ENV['PDK_FRONTEND'] != 'NONINTERACTIVE') if ENV['PDK_FRONTEND']
+          return false unless $stderr.isatty
+
+          true
         end
 
         def execute!

--- a/spec/acceptance/report_spec.rb
+++ b/spec/acceptance/report_spec.rb
@@ -16,41 +16,52 @@ class foo { }
       end
     end
 
-    # Tests writing reports to a file
-    describe command('pdk validate puppet manifests/init.pp --format=text:report.txt') do
-      its(:exit_status) { is_expected.to eq(0) }
-      its(:stdout) { is_expected.to match(%r{\A\Z}) }
-      its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
-      its(:stderr) { is_expected.to match(%r{Checking Puppet manifest style}i) }
+    context 'when run interactively' do
+      include_context 'with a fake TTY'
+      # Tests writing reports to a file
+      describe command('pdk validate puppet manifests/init.pp --format=text:report.txt') do
+        its(:exit_status) { is_expected.to eq(0) }
+        its(:stdout) { is_expected.to match(%r{\A\Z}) }
+        its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
+        its(:stderr) { is_expected.to match(%r{Checking Puppet manifest style}i) }
 
-      describe file('report.txt') do
-        it { is_expected.to exist }
-        its(:content) { is_expected.to match %r{^warning:.*#{Regexp.escape(init_pp)}.*class not documented} }
+        describe file('report.txt') do
+          it { is_expected.to exist }
+          its(:content) { is_expected.to match %r{^warning:.*#{Regexp.escape(init_pp)}.*class not documented} }
+        end
+      end
+
+      # Tests writing reports to stdout doesn't actually write a file named stdout
+      describe command('pdk validate puppet manifests/init.pp --format=text:stdout') do
+        its(:exit_status) { is_expected.to eq(0) }
+        its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
+        its(:stderr) { is_expected.to match(%r{Checking Puppet manifest style}i) }
+        its(:stdout) { is_expected.to match(%r{^warning:.*#{Regexp.escape(init_pp)}.*class not documented}) }
+
+        describe file('stdout') do
+          it { is_expected.not_to exist }
+        end
+      end
+
+      # Tests writing reports to stderr doesn't actually write a file named stderr
+      describe command('pdk validate puppet manifests/init.pp --format=text:stderr') do
+        its(:exit_status) { is_expected.to eq(0) }
+        its(:stdout) { is_expected.to match(%r{\A\Z}) }
+        its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
+        its(:stderr) { is_expected.to match(%r{Checking Puppet manifest style}i) }
+        its(:stderr) { is_expected.to match(%r{^warning:.*#{Regexp.escape(init_pp)}.*class not documented}) }
+
+        describe file('stderr') do
+          it { is_expected.not_to exist }
+        end
       end
     end
 
-    # Tests writing reports to stdout doesn't actually write a file named stdout
-    describe command('pdk validate puppet manifests/init.pp --format=text:stdout') do
-      its(:exit_status) { is_expected.to eq(0) }
-      its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
-      its(:stderr) { is_expected.to match(%r{Checking Puppet manifest style}i) }
-      its(:stdout) { is_expected.to match(%r{^warning:.*#{Regexp.escape(init_pp)}.*class not documented}) }
-
-      describe file('stdout') do
-        it { is_expected.not_to exist }
-      end
-    end
-
-    # Tests writing reports to stderr doesn't actually write a file named stderr
-    describe command('pdk validate puppet manifests/init.pp --format=text:stderr') do
-      its(:exit_status) { is_expected.to eq(0) }
-      its(:stdout) { is_expected.to match(%r{\A\Z}) }
-      its(:stderr) { is_expected.to match(%r{Checking Puppet manifest syntax}i) }
-      its(:stderr) { is_expected.to match(%r{Checking Puppet manifest style}i) }
-      its(:stderr) { is_expected.to match(%r{^warning:.*#{Regexp.escape(init_pp)}.*class not documented}) }
-
-      describe file('stderr') do
-        it { is_expected.not_to exist }
+    context 'when not run interactively' do
+      describe command('pdk validate puppet manifests/init.pp') do
+        its(:exit_status) { is_expected.to eq(0) }
+        its(:stderr) { is_expected.to match(%r{\A\Z}) }
+        its(:stdout) { is_expected.to match(%r{^warning:.*#{Regexp.escape(init_pp)}.*class not documented}) }
       end
     end
   end

--- a/spec/acceptance/support/with_a_fake_tty.rb
+++ b/spec/acceptance/support/with_a_fake_tty.rb
@@ -1,0 +1,7 @@
+RSpec.shared_context 'with a fake TTY' do
+  around(:each) do |example|
+    ENV['PDK_FRONTEND'] = 'INTERACTIVE'
+    example.run
+    ENV.delete('PDK_FRONTEND')
+  end
+end

--- a/spec/acceptance/test_unit_spec.rb
+++ b/spec/acceptance/test_unit_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper_acceptance'
 require 'fileutils'
 
 describe 'Running unit tests' do
+  include_context 'with a fake TTY'
+
   context 'with a fresh module' do
     include_context 'in a new module', 'unit_test_module_new'
 

--- a/spec/acceptance/validate_all_spec.rb
+++ b/spec/acceptance/validate_all_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper_acceptance'
 describe 'Running all validations' do
   let(:junit_xsd) { File.join(RSpec.configuration.fixtures_path, 'JUnit.xsd') }
 
+  include_context 'with a fake TTY'
+
   context 'with a fresh module' do
     include_context 'in a new module', 'validate_all'
 

--- a/spec/acceptance/validate_metadata_spec.rb
+++ b/spec/acceptance/validate_metadata_spec.rb
@@ -6,6 +6,8 @@ describe 'Running metadata validation' do
   let(:module_style_spinner) { %r{checking module metadata style}i }
   let(:task_style_spinner) { %r{checking task metadata style}i }
 
+  include_context 'with a fake TTY'
+
   context 'with a metadata violation' do
     include_context 'in a new module', 'metadata_violation_module'
 

--- a/spec/acceptance/validate_puppet_spec.rb
+++ b/spec/acceptance/validate_puppet_spec.rb
@@ -7,6 +7,8 @@ describe 'pdk validate puppet', module_command: true do
   let(:lint_spinner_text) { %r{checking puppet manifest style}i }
   let(:empty_string) { %r{\A\Z} }
 
+  include_context 'with a fake TTY'
+
   init_pp = File.join('manifests', 'init.pp')
   example_pp = File.join('manifests', 'example.pp')
 

--- a/spec/acceptance/validate_ruby_spec.rb
+++ b/spec/acceptance/validate_ruby_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper_acceptance'
 describe 'pdk validate ruby', module_command: true do
   let(:junit_xsd) { File.join(RSpec.configuration.fixtures_path, 'JUnit.xsd') }
 
+  include_context 'with a fake TTY'
+
   context 'with a style violation' do
     include_context 'in a new module', 'foo'
 

--- a/spec/unit/pdk/cli/exec/command_spec.rb
+++ b/spec/unit/pdk/cli/exec/command_spec.rb
@@ -25,15 +25,27 @@ describe PDK::CLI::Exec::Command do
     context 'without --debug' do
       before(:each) do
         allow(logger).to receive(:debug?).and_return(false)
+        allow($stderr).to receive(:isatty).and_return(true)
         command.add_spinner('message')
       end
+
       it { expect(command.instance_variable_get(:@spinner)).to be_a TTY::Spinner }
     end
+
     context 'with --debug' do
       before(:each) do
         allow(logger).to receive(:debug?).and_return(true)
         command.add_spinner('message')
       end
+      it { expect(command.instance_variable_get(:@spinner)).to be_nil }
+    end
+
+    context 'when run non-interactive' do
+      before(:each) do
+        allow($stderr).to receive(:isatty).and_return(false)
+        command.add_spinner('message')
+      end
+
       it { expect(command.instance_variable_get(:@spinner)).to be_nil }
     end
   end
@@ -44,15 +56,26 @@ describe PDK::CLI::Exec::Command do
     context 'without --debug' do
       before(:each) do
         allow(logger).to receive(:debug?).and_return(false)
+        allow($stderr).to receive(:isatty).and_return(true)
         command.register_spinner(spinner)
       end
       it { expect(command.instance_variable_get(:@spinner)).to eq spinner }
     end
+
     context 'with --debug' do
       before(:each) do
         allow(logger).to receive(:debug?).and_return(true)
         command.register_spinner(spinner)
       end
+      it { expect(command.instance_variable_get(:@spinner)).to be_nil }
+    end
+
+    context 'when run non-interactive' do
+      before(:each) do
+        allow($stderr).to receive(:isatty).and_return(false)
+        command.register_spinner(spinner)
+      end
+
       it { expect(command.instance_variable_get(:@spinner)).to be_nil }
     end
   end


### PR DESCRIPTION
Determines if the process is being run interactively by checking if stderr is a TTY and only create the spinners when the PDK is run interactively.

Acceptance tests for this proved to be troublesome as the specinfra exec backend doesn't support creating a PTY. I created a new backend for specinfra but it turns out that Windows doesn't support PTYs anyway, so that had to be thrown away and I've instead gone for an environment variable (h/t to DEBIAN_FRONTEND) to override the TTY check during tests.