### PR TITLE
(PDK-624) Add UpdateManager class to handle making changes to module files

### DIFF
--- a/lib/pdk/module/update_manager.rb
+++ b/lib/pdk/module/update_manager.rb
@@ -1,0 +1,190 @@
+require 'set'
+require 'diff/lcs'
+require 'diff/lcs/hunk'
+require 'English'
+require 'fileutils'
+
+module PDK
+  module Module
+    class UpdateManager
+      # Initialises a blank UpdateManager object, which is used to store and
+      # process file additions/removals/modifications.
+      def initialize
+        @modified_files = Set.new
+        @added_files = Set.new
+        @removed_files = Set.new
+        @diff_cache = {}
+      end
+
+      # Store a pending modification to an existing file.
+      #
+      # @param path [String] The path to the file to be modified.
+      # @param content [String] The new content of the file.
+      def modify_file(path, content)
+        @modified_files << { path: path, content: content }
+      end
+
+      # Store a pending file addition.
+      #
+      # @param path [String] The path where the file will be created.
+      # @param content [String] The content of the new file.
+      def add_file(path, content)
+        @added_files << { path: path, content: content }
+      end
+
+      # Store a pending file removal.
+      #
+      # @param path [String] The path to the file to be removed.
+      def remove_file(path)
+        @removed_files << path
+      end
+
+      # Generate a summary of the changes that will be applied to the module.
+      #
+      # @raise (see #calculate_diffs)
+      # @return [Hash{Symbol => Set,Hash}] the summary of the pending changes.
+      def changes
+        calculate_diffs
+
+        {
+          added:    @added_files,
+          removed:  @removed_files,
+          modified: @diff_cache.reject { |_, value| value.nil? },
+        }
+      end
+
+      # Check if there are any pending changes to apply to the module.
+      #
+      # @raise (see #changes)
+      # @return [Boolean] true if there are changes to apply to the module.
+      def changes?
+        !changes[:added].empty? ||
+          !changes[:removed].empty? ||
+          changes[:modified].any? { |_, value| !value.nil? }
+      end
+
+      # Apply any pending changes stored in the UpdateManager to the module.
+      #
+      # @raise (see #calculate_diffs)
+      # @raise (see #write_file)
+      # @raise (see #unlink_file)
+      def sync_changes!
+        calculate_diffs
+
+        files_to_write = @added_files
+        files_to_write += @modified_files.reject { |file| @diff_cache[file[:path]].nil? }
+
+        files_to_write.each do |file|
+          write_file(file[:path], file[:content])
+        end
+
+        @removed_files.each do |file|
+          unlink_file(file)
+        end
+      end
+
+      private
+
+      # Loop through all the files to be modified and cache of unified diff of
+      # the changes to be made to each file.
+      #
+      # @raise [PDK::CLI::ExitWithError] if a file being modified isn't
+      #   readable.
+      def calculate_diffs
+        @modified_files.each do |file|
+          next if @diff_cache.key?(file[:path])
+
+          unless File.readable?(file[:path])
+            raise PDK::CLI::ExitWithError, _("Unable to open '%{path}' for reading") % { path: file[:path] }
+          end
+
+          old_content = File.read(file[:path])
+          file_diff = unified_diff(file[:path], old_content, file[:content])
+          @diff_cache[file[:path]] = file_diff
+        end
+      end
+
+      # Write or overwrite a file with the specified content.
+      #
+      # @param path [String] The path to be written to.
+      # @param content [String] The data to be written to the file.
+      #
+      # @raise [PDK::CLI::ExitWithError] if the file is not writeable.
+      def write_file(path, content)
+        File.open(path, 'w') { |f| f.puts content }
+      rescue Errno::EACCES
+        raise PDK::CLI::ExitWithError, _("You do not have permission to write to '%{path}'") % { path: path }
+      end
+
+      # Remove a file from disk.
+      #
+      # Like FileUtils.rm_f, this method will not fail if the file does not
+      # exist. Unlink FileUtils.rm_f, this method will not blindly swallow all
+      # exceptions.
+      #
+      # @param path [String] The path to the file to be removed.
+      #
+      # @raise [PDK::CLI::ExitWithError] if the file could not be removed.
+      def unlink_file(path)
+        FileUtils.rm(path) if File.file?(path)
+      rescue => e
+        raise PDK::CLI::ExitWithError, _("Unable to remove '%{path}': %{message}") % {
+          path:    path,
+          message: e.message,
+        }
+      end
+
+      # Generate a unified diff of the changes to be made to a file.
+      #
+      # @param path [String] The path to the file being diffed (only used to
+      #   generate the diff header).
+      # @param old_content [String] The current content of the file.
+      # @param new_content [String] The new content of the file if the pending
+      #   change is applied.
+      # @param lines_of_context [Integer] The maximum number of lines of
+      #   context to include around the changed lines in the diff output
+      #   (default: 3).
+      #
+      # @return [String] The unified diff of the pending changes to the file.
+      def unified_diff(path, old_content, new_content, lines_of_context = 3)
+        output = []
+
+        old_lines = old_content.split($INPUT_RECORD_SEPARATOR).map(&:chomp)
+        new_lines = new_content.split($INPUT_RECORD_SEPARATOR).map(&:chomp)
+
+        diffs = Diff::LCS.diff(old_lines, new_lines)
+
+        return nil if diffs.empty?
+
+        file_mtime = File.stat(path).mtime.localtime.strftime('%Y-%m-%d %H:%M:%S.%N %z')
+        now = Time.now.localtime.strftime('%Y-%m-%d %H:%M:%S.%N %z')
+
+        output << "--- #{path}\t#{file_mtime}"
+        output << "+++ #{path}.pdknew\t#{now}"
+
+        oldhunk = hunk = nil
+        file_length_difference = 0
+
+        diffs.each do |piece|
+          begin
+            hunk = Diff::LCS::Hunk.new(old_lines, new_lines, piece, lines_of_context, file_length_difference)
+            file_length_difference = hunk.file_length_difference
+
+            next unless oldhunk
+
+            # If the hunk overlaps with the oldhunk, merge them.
+            next if lines_of_context > 0 && hunk.merge(oldhunk)
+
+            output << oldhunk.diff(:unified)
+          ensure
+            oldhunk = hunk
+          end
+        end
+
+        output << oldhunk.diff(:unified)
+
+        output.join($INPUT_RECORD_SEPARATOR)
+      end
+    end
+  end
+end

--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'json_pure', '~> 2.1.0'
   spec.add_runtime_dependency 'json-schema', '2.8.0'
   spec.add_runtime_dependency 'tty-which', '0.3.0'
+  spec.add_runtime_dependency 'diff-lcs', '1.3'
 
   # Used in the pdk-module-template
   spec.add_runtime_dependency 'deep_merge', '~> 1.1'

--- a/spec/unit/pdk/module/update_manager_spec.rb
+++ b/spec/unit/pdk/module/update_manager_spec.rb
@@ -1,0 +1,227 @@
+require 'spec_helper'
+require 'pdk/module/update_manager'
+
+describe PDK::Module::UpdateManager do
+  subject(:update_manager) { described_class.new }
+
+  let(:dummy_file) { File.join(Dir.pwd, 'test_file') }
+
+  describe '#initialize' do
+    it 'has no pending changes by default' do
+      expect(update_manager.changes?).to be_falsey
+    end
+  end
+
+  describe '#add_file' do
+    let(:content) { "some content\n" }
+
+    before(:each) do
+      update_manager.add_file(dummy_file, content)
+    end
+
+    it 'creates a pending change' do
+      expect(update_manager.changes?).to be_truthy
+    end
+
+    it 'creates a file added change' do
+      expect(update_manager.changes).to include(added: [{ path: dummy_file, content: content }])
+    end
+
+    context 'when syncing the changes' do
+      let(:dummy_file_io) { StringIO.new }
+
+      before(:each) do
+        allow(File).to receive(:open).with(any_args).and_call_original
+        allow(File).to receive(:open).with(dummy_file, 'w').and_yield(dummy_file_io)
+        update_manager.sync_changes!
+        dummy_file_io.rewind
+      end
+
+      it 'writes the file to disk' do
+        expect(dummy_file_io.read).to eq(content)
+      end
+
+      context 'but if the file can not be written to' do
+        before(:each) do
+          allow(File).to receive(:open).with(dummy_file, 'w').and_raise(Errno::EACCES)
+        end
+
+        it 'exits with an error' do
+          expect {
+            update_manager.sync_changes!
+          }.to raise_error(PDK::CLI::ExitWithError, %r{You do not have permission to write to '#{Regexp.escape(dummy_file)}'})
+        end
+      end
+    end
+  end
+
+  describe '#remove_file' do
+    before(:each) do
+      update_manager.remove_file(dummy_file)
+    end
+
+    it 'creates a pending change' do
+      expect(update_manager.changes?).to be_truthy
+    end
+
+    it 'creates a file removed change' do
+      expect(update_manager.changes).to include(removed: [dummy_file])
+    end
+
+    context 'when syncing the changes' do
+      context 'and the file exists' do
+        before(:each) do
+          allow(File).to receive(:file?).with(dummy_file).and_return(true)
+        end
+
+        it 'removes the file' do
+          expect(FileUtils).to receive(:rm).with(dummy_file)
+
+          update_manager.sync_changes!
+        end
+
+        context 'but it fails to remove the file' do
+          before(:each) do
+            allow(FileUtils).to receive(:rm).with(dummy_file).and_raise(StandardError, 'an unknown error')
+          end
+
+          it 'exits with an error' do
+            expect {
+              update_manager.sync_changes!
+            }.to raise_error(PDK::CLI::ExitWithError, %r{Unable to remove '#{Regexp.escape(dummy_file)}': an unknown error})
+          end
+        end
+      end
+
+      context 'and the file does not exist' do
+        before(:each) do
+          allow(File).to receive(:file?).with(dummy_file).and_return(false)
+        end
+
+        it 'does not attempt to remove the file' do
+          expect(FileUtils).not_to receive(:rm).with(dummy_file)
+
+          update_manager.sync_changes!
+        end
+      end
+    end
+  end
+
+  describe '#modify_file' do
+    let(:original_content) do
+      <<-EOS.gsub(%r{^ {8}}, '')
+        line 1
+        line 2
+        line 3
+      EOS
+    end
+
+    let(:new_content) do
+      <<-EOS.gsub(%r{^ {8}}, '')
+        line 4
+        line 2
+        line 3
+        line 1
+      EOS
+    end
+
+    before(:each) do
+      allow(File).to receive(:readable?).with(dummy_file).and_return(true)
+      allow(File).to receive(:read).with(dummy_file).and_return(original_content)
+      allow(File).to receive(:stat).with(dummy_file).and_return(instance_double(File::Stat, mtime: Time.now - 60))
+    end
+
+    context 'when the file can not be opened for reading' do
+      before(:each) do
+        allow(File).to receive(:readable?).with(dummy_file).and_return(false)
+        update_manager.modify_file(dummy_file, new_content)
+      end
+
+      it 'exits with an error' do
+        expect {
+          update_manager.changes
+        }.to raise_error(PDK::CLI::ExitWithError, %r{Unable to open '#{Regexp.escape(dummy_file)}' for reading})
+      end
+    end
+
+    context 'when the new file content differs from the original content' do
+      let(:expected_diff) do
+        <<-EOS.chomp.gsub(%r{^ {10}}, '')
+          @@ -1,4 +1,5 @@
+          -line 1
+          +line 4
+           line 2
+           line 3
+          +line 1
+        EOS
+      end
+
+      before(:each) do
+        update_manager.modify_file(dummy_file, new_content)
+      end
+
+      it 'creates a pending change' do
+        expect(update_manager.changes?).to be_truthy
+      end
+
+      it 'creates a file modified change' do
+        expect(update_manager.changes).to include(modified: { dummy_file => anything })
+      end
+
+      it 'creates a diff of the changes' do
+        diff_lines = update_manager.changes[:modified][dummy_file].split("\n")
+        expect(diff_lines[0]).to match(%r{\A--- #{Regexp.escape(dummy_file)}.+})
+        expect(diff_lines[1]).to match(%r{\A\+\+\+ #{Regexp.escape(dummy_file)}\.pdknew.+})
+        expect(diff_lines[2..-1].join("\n")).to eq(expected_diff)
+      end
+
+      context 'when syncing the changes' do
+        let(:dummy_file_io) { StringIO.new }
+
+        before(:each) do
+          allow(File).to receive(:open).with(any_args).and_call_original
+          allow(File).to receive(:open).with(dummy_file, 'w').and_yield(dummy_file_io)
+          update_manager.sync_changes!
+          dummy_file_io.rewind
+        end
+
+        it 'writes the modified file to disk' do
+          expect(dummy_file_io.read).to eq(new_content)
+        end
+
+        context 'but if the file can not be written to' do
+          before(:each) do
+            allow(File).to receive(:open).with(dummy_file, 'w').and_raise(Errno::EACCES)
+          end
+
+          it 'exits with an error' do
+            expect {
+              update_manager.sync_changes!
+            }.to raise_error(PDK::CLI::ExitWithError, %r{You do not have permission to write to '#{Regexp.escape(dummy_file)}'})
+          end
+        end
+      end
+    end
+
+    context 'when the new file content matches the original content' do
+      before(:each) do
+        update_manager.modify_file(dummy_file, original_content)
+      end
+
+      it 'does not create a pending change' do
+        expect(update_manager.changes?).to be_falsey
+      end
+
+      it 'does not create a file modified change' do
+        expect(update_manager.changes).to include(modified: {})
+      end
+
+      context 'when syncing the changes' do
+        it 'does not modify the file' do
+          expect(File).not_to receive(:open).with(dummy_file, 'w')
+          update_manager.sync_changes!
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Abstracts away the file modification logic into its own class. This will allow
easy reuse for the future `pdk update` as well as a simple interface for
storing the pending changes in memory rather than on disk (less cleanup
required in the event of an interrupt). The presentation/reporting of the changes
has been separated from the logic that makes the changes, so that we can easily
tweak and modify the output as this feature develops.

---

An example where my metadata.json was missing the license field.
```
asmodean :0: pdk/foo (git:master → origin {2} U:3 ?:2!)$ ../bin/pdk convert
pdk (INFO): This is a potentially destructive action. Please ensure that you have committed it to a version control system or have a backup before continuing.
Do you want to continue converting this module? Yes
--- metadata.json	2017-11-22 14:19:03.616567876 +1100
+++ metadata.json.pdknew	2017-11-22 14:20:21.076163844 +1100
@@ -2,6 +2,7 @@
   "name": "rodjek-test",
   "author": "rodjek",
   "summary": "",
+  "license": "Apache-2.0",
   "source": "",
   "dependencies": [
 
Do you want to continue and make these changes to your module? Yes
asmodean :0: pdk/foo (git:master → origin {2} U:3 ?:2!)$ cat metadata.json 
{
  "name": "rodjek-test",
  "author": "rodjek",
  "summary": "",
  "license": "Apache-2.0",
  "source": "",
  "dependencies": [

  ],
  "operatingsystem_support": [
    {
      "operatingsystem": "Debian",
      "operatingsystemrelease": [
        "8"
      ]
    },
    {
      "operatingsystem": "RedHat",
      "operatingsystemrelease": [
        "7.0"
      ]
    },
    {
      "operatingsystem": "Ubuntu",
      "operatingsystemrelease": [
        "16.04"
      ]
    },
    {
      "operatingsystem": "windows",
      "operatingsystemrelease": [
        "2012 R2"
      ]
    }
  ],
  "requirements": [

  ]
}
```