### PR TITLE
(maint) Update PDK::Test::Unit.parallel_with_no_tests? for PSH #216 changes

### DIFF
--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -31,8 +31,8 @@ module PDK
 
       def self.parallel_with_no_tests?(ran_in_parallel, json_result, result)
         ran_in_parallel && json_result.empty? &&
-          !result[:exit_code].zero? &&
-          result[:stderr].strip =~ %r{Pass files or folders to run$}
+          ((!result[:exit_code].zero? && result[:stderr].strip =~ %r{Pass files or folders to run$}) ||
+           result[:stderr].strip =~ %r{No files for parallel_spec to run against$})
       end
 
       def self.print_failure(result, exception)

--- a/spec/unit/pdk/test/unit_spec.rb
+++ b/spec/unit/pdk/test/unit_spec.rb
@@ -17,14 +17,40 @@ describe PDK::Test::Unit do
   end
 
   describe '.parallel_with_no_tests?' do
-    context 'when not parallel' do
-      it 'is false' do
-        result = {
-          stderr: 'Pass files or folders to run',
-          exit_code: 1,
-        }
+    subject { described_class.parallel_with_no_tests?(ran_in_parallel, json_result, cmd_result) }
 
-        expect(described_class.parallel_with_no_tests?(false, ['json_result'], result)).to be(false)
+    let(:json_result) { [] }
+    let(:cmd_result) { { stderr: '', stdout: '', exit_code: 1 } }
+
+    context 'when not run in parallel' do
+      let(:ran_in_parallel) { false }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when run in parallel' do
+      let(:ran_in_parallel) { true }
+
+      context 'and no tests (puppetlabs_spec_helper <= 2.5.0)' do
+        let(:cmd_result) do
+          { stderr: 'Pass files or folders to run', stdout: '', exit_code: 1 }
+        end
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'and no tests (puppetlabs_spec_helper >= 2.5.1)' do
+        let(:cmd_result) do
+          { stderr: 'No files for parallel_spec to run against', stdout: '', exit_code: 0 }
+        end
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'and there are tests' do
+        let(:json_result) { ['something'] }
+
+        it { is_expected.to be_falsey }
       end
     end
   end


### PR DESCRIPTION
The behavour of the parallel_spec rake task in puppetlabs_spec_helper changed in https://github.com/puppetlabs/puppetlabs_spec_helper/pull/216. This PR updates our logic to detect no tests vs fail in `pdk test unit --parallel`.