### PR TITLE
Making exit errors generic for interview qs

### DIFF
--- a/lib/pdk/generate/module.rb
+++ b/lib/pdk/generate/module.rb
@@ -312,7 +312,7 @@ module PDK
         answers = interview.run
 
         if answers.nil?
-          PDK.logger.info _('Interview cancelled; not generating the module.')
+          PDK.logger.info _('No answers given, interview cancelled.')
           exit 0
         end
 
@@ -338,11 +338,11 @@ module PDK
         continue = PDK::CLI::Util.prompt_for_yes(
           _('About to generate this module, continue?'),
           prompt:         prompt,
-          cancel_message: _('Interview cancelled; not generating the module.'),
+          cancel_message: _('Interview cancelled; exiting.'),
         )
 
         unless continue
-          PDK.logger.info _('Module not generated.')
+          PDK.logger.info _('Process cancelled; exiting.')
           exit 0
         end
 

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -515,7 +515,7 @@ describe PDK::Generate::Module do
       end
 
       it 'exits cleanly' do
-        allow(logger).to receive(:info).with(a_string_matching(%r{module not generated}i))
+        allow(logger).to receive(:info).with(a_string_matching(%r{Process cancelled; exiting.}i))
         allow($stdout).to receive(:puts).with(a_string_matching(%r{9 questions}m))
 
         expect { interview_metadata }.to raise_error(SystemExit) { |error|


### PR DESCRIPTION
Since we are using the interview for convert now it doesn't make sense to talk about generation of modules in the error messages, so I've made them more generic.