### PR TITLE
(PDK-715) Use correct module template branch/ref

### DIFF
--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -58,8 +58,13 @@ module PDK
     end
     module_function :package_install?
 
+    def development_mode?
+      !PDK::Util::Version.git_ref.nil?
+    end
+    module_function :development_mode?
+
     def gem_install?
-      !package_install?
+      !(package_install? || development_mode?)
     end
     module_function :gem_install?
 

--- a/lib/pdk/util/bundler.rb
+++ b/lib/pdk/util/bundler.rb
@@ -77,7 +77,7 @@ module PDK
           PDK.logger.debug(_('Checking for missing Gemfile dependencies.'))
 
           argv = ['check', "--gemfile=#{gemfile}"]
-          argv << "--path=#{bundle_cachedir}" if PDK::Util.gem_install?
+          argv << "--path=#{bundle_cachedir}" unless PDK::Util.package_install?
 
           result = bundle_command(*argv).execute!
 
@@ -104,7 +104,7 @@ module PDK
 
         def install!
           argv = ['install', "--gemfile=#{gemfile}", '-j4']
-          argv << "--path=#{bundle_cachedir}" if PDK::Util.gem_install?
+          argv << "--path=#{bundle_cachedir}" unless PDK::Util.package_install?
 
           command = bundle_command(*argv).tap do |c|
             c.add_spinner(_('Installing missing Gemfile dependencies.'))

--- a/lib/pdk/version.rb
+++ b/lib/pdk/version.rb
@@ -1,3 +1,4 @@
 module PDK
   VERSION = '1.3.0.pre'.freeze
+  TEMPLATE_VERSION = '0.x'.freeze
 end

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -144,14 +144,46 @@ describe PDK::Util do
     end
   end
 
+  describe '.development_mode?' do
+    subject { described_class.development_mode? }
+
+    context 'when the source is not using git' do
+      before(:each) do
+        allow(PDK::Util::Version).to receive(:git_ref).and_return(nil)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the source is using git' do
+      before(:each) do
+        allow(PDK::Util::Version).to receive(:git_ref).and_return('abc')
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
   describe '.gem_install?' do
     subject { described_class.gem_install? }
+
+    before(:each) do
+      allow(described_class).to receive(:development_mode?).and_return(false)
+    end
 
     context 'when there is no version file', version_file: false do
       it { is_expected.to be true }
     end
 
     context 'when a version file is present', version_file: true do
+      it { is_expected.to be false }
+    end
+
+    context 'when a version file is present and in development mode is true', version_file: false do
+      before(:each) do
+        allow(described_class).to receive(:development_mode?).and_return(true)
+      end
+
       it { is_expected.to be false }
     end
   end


### PR DESCRIPTION
For gem installs, we need to make sure they use a compatible
module-template version, similar to what we do for package installs
in our build process. For development, we still want to use the
default git branch.