### PR TITLE
(PDK-722) Remove prompt to continue from start of convert

### DIFF
--- a/lib/pdk/cli/convert.rb
+++ b/lib/pdk/cli/convert.rb
@@ -18,11 +18,6 @@ module PDK::CLI
         raise PDK::CLI::ExitWithError, _('You can not specify --noop and --force when converting a module')
       end
 
-      unless opts[:noop] || opts[:force]
-        PDK.logger.info _('Module conversion is a potentially destructive action. Please ensure that you have committed it to a version control system or have a backup before continuing.')
-        exit 0 unless PDK::CLI::Util.prompt_for_yes(_('Do you want to proceed with conversion?'))
-      end
-
       PDK::Module::Convert.invoke(opts)
     end
   end

--- a/lib/pdk/module/convert.rb
+++ b/lib/pdk/module/convert.rb
@@ -36,7 +36,11 @@ module PDK
         return if options[:noop]
 
         unless options[:force]
-          PDK.logger.info _('Please review the changes above before continuing.')
+          PDK.logger.info _(
+            'Module conversion is a potentially destructive action. ' \
+            'Please ensure that you have committed your module to a version control ' \
+            'system or have a backup, and review the changes above before continuing.',
+          )
           continue = PDK::CLI::Util.prompt_for_yes(_('Do you want to continue and make these changes to your module?'))
           return unless continue
         end

--- a/spec/unit/pdk/cli/convert_spec.rb
+++ b/spec/unit/pdk/cli/convert_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe 'PDK::CLI convert' do
   let(:help_text) { a_string_matching(%r{^USAGE\s+pdk convert}m) }
-  let(:backup_warning) { a_string_matching(%r{backup before continuing}i) }
 
   context 'when not run from inside a module' do
     before(:each) do
@@ -26,31 +25,7 @@ describe 'PDK::CLI convert' do
     end
 
     context 'and provided no flags' do
-      before(:each) do
-        allow(logger).to receive(:info).with(backup_warning)
-        allow(PDK::CLI::Util).to receive(:prompt_for_yes).with(a_string_matching(%r{Do you want to proceed with conversion?}i)).and_return(true)
-      end
-
-      it 'asks the user if they want to continue' do
-        expect(logger).to receive(:info).with(backup_warning)
-        expect(PDK::CLI::Util).to receive(:prompt_for_yes).with(a_string_matching(%r{Do you want to proceed with conversion?}i)).and_return(true)
-        allow(PDK::Module::Convert).to receive(:invoke).with(any_args).and_return(0)
-
-        PDK::CLI.run(%w[convert])
-      end
-
-      it 'exits cleanly if the user chooses not to continue' do
-        allow(PDK::CLI::Util).to receive(:prompt_for_yes).with(a_string_matching(%r{Do you want to proceed with conversion?}i)).and_return(false)
-        expect(PDK::Module::Convert).not_to receive(:invoke)
-
-        expect {
-          PDK::CLI.run(['convert'])
-        }.to raise_error(SystemExit) { |error|
-          expect(error.status).to eq(0)
-        }
-      end
-
-      it 'invokes the converter with the default template if the user chooses to continue' do
+      it 'invokes the converter with the default template' do
         expect(PDK::Module::Convert).to receive(:invoke).with(:'template-url' => PDK::Util.default_template_url)
 
         PDK::CLI.run(['convert'])
@@ -58,11 +33,6 @@ describe 'PDK::CLI convert' do
     end
 
     context 'and the --template-url option has been passed' do
-      before(:each) do
-        allow(logger).to receive(:info).with(backup_warning)
-        allow(PDK::CLI::Util).to receive(:prompt_for_yes).with(a_string_matching(%r{Do you want to proceed with conversion?}i)).and_return(true)
-      end
-
       it 'invokes the converter with the user supplied template' do
         expect(PDK::Module::Convert).to receive(:invoke).with(:'template-url' => 'https://my/template')
 
@@ -71,14 +41,6 @@ describe 'PDK::CLI convert' do
     end
 
     context 'and the --noop flag has been passed' do
-      it 'does not prompt the user before invoking the converter' do
-        expect(logger).not_to receive(:info).with(backup_warning)
-        expect(PDK::CLI::Util).not_to receive(:prompt_for_yes)
-        allow(PDK::Module::Convert).to receive(:invoke).with(any_args)
-
-        PDK::CLI.run(['convert', '--noop'])
-      end
-
       it 'passes the noop option through to the converter' do
         expect(PDK::Module::Convert).to receive(:invoke).with(:noop => true, :'template-url' => anything)
 
@@ -87,14 +49,6 @@ describe 'PDK::CLI convert' do
     end
 
     context 'and the --force flag has been passed' do
-      it 'does not prompt the user before invoking the converter' do
-        expect(logger).not_to receive(:info).with(backup_warning)
-        expect(PDK::CLI::Util).not_to receive(:prompt_for_yes)
-        allow(PDK::Module::Convert).to receive(:invoke).with(any_args)
-
-        PDK::CLI.run(['convert', '--force'])
-      end
-
       it 'passes the force option through to the converter' do
         expect(PDK::Module::Convert).to receive(:invoke).with(:force => true, :'template-url' => anything)
 


### PR DESCRIPTION
We already ask the user if they want to continue before applying any of the
changes, so we don't really need this one here. The warning about having
a backup has been moved to the confirmation before the changes are applied.