### PR TITLE
(PDK-719) Check for module directory layout when converting

### DIFF
--- a/lib/pdk/cli/convert.rb
+++ b/lib/pdk/cli/convert.rb
@@ -12,7 +12,7 @@ module PDK::CLI
 
     run do |opts, _args, _cmd|
       require 'pdk/module/convert'
-      PDK::CLI::Util.ensure_in_module!
+      PDK::CLI::Util.ensure_in_module!(check_module_layout: true)
 
       if opts[:noop] && opts[:force]
         raise PDK::CLI::ExitWithError, _('You can not specify --noop and --force when converting a module')

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -1,13 +1,30 @@
 module PDK
   module CLI
     module Util
+      MODULE_FOLDERS = %w[
+        manifests
+        lib
+        tasks
+        facts.d
+        functions
+        types
+      ].freeze
+
       # Ensures the calling code is being run from inside a module directory.
       #
-      # @raise [PDK::CLI::ExitWithError] if the current directory or parents do
-      #   not contain a `metadata.json` file.
-      def ensure_in_module!
+      # @param opts [Hash] options to change the behavior of the check logic.
+      # @option opts [Boolean] :check_module_layout Set to true to check for
+      #   stardard module folder layout if the module does not contain
+      #   a metadata.json file.
+      #
+      # @raise [PDK::CLI::ExitWithError] if the current directory does not
+      #   contain a Puppet module.
+      def ensure_in_module!(opts = {})
+        return unless PDK::Util.module_root.nil?
+        return if opts[:check_module_layout] && PDK::CLI::Util::MODULE_FOLDERS.any? { |dir| File.directory?(dir) }
+
         message = _('This command must be run from inside a valid module (no metadata.json found).')
-        raise PDK::CLI::ExitWithError, message if PDK::Util.module_root.nil?
+        raise PDK::CLI::ExitWithError, message
       end
       module_function :ensure_in_module!
 

--- a/spec/support/run_outside_module.rb
+++ b/spec/support/run_outside_module.rb
@@ -1,0 +1,6 @@
+RSpec.shared_context 'run outside module' do
+  before(:each) do
+    msg = 'must be run from inside a valid module (no metadata.json found)'
+    allow(PDK::CLI::Util).to receive(:ensure_in_module!).and_raise(PDK::CLI::ExitWithError, msg)
+  end
+end

--- a/spec/unit/pdk/cli/convert_spec.rb
+++ b/spec/unit/pdk/cli/convert_spec.rb
@@ -5,9 +5,7 @@ describe 'PDK::CLI convert' do
   let(:backup_warning) { a_string_matching(%r{backup before continuing}i) }
 
   context 'when not run from inside a module' do
-    before(:each) do
-      allow(PDK::Util).to receive(:module_root).and_return(nil)
-    end
+    include_context 'run outside module'
 
     it 'exits with an error' do
       expect(logger).to receive(:error).with(a_string_matching(%r{must be run from inside a valid module}))

--- a/spec/unit/pdk/cli/new/class_spec.rb
+++ b/spec/unit/pdk/cli/new/class_spec.rb
@@ -4,9 +4,7 @@ describe 'PDK::CLI new class' do
   let(:help_text) { a_string_matching(%r{^USAGE\s+pdk new class}m) }
 
   context 'when not run from inside a module' do
-    before(:each) do
-      allow(PDK::Util).to receive(:module_root).and_return(nil)
-    end
+    include_context 'run outside module'
 
     it 'exits with an error' do
       expect(logger).to receive(:error).with(a_string_matching(%r{must be run from inside a valid module}))

--- a/spec/unit/pdk/cli/new/defined_type_spec.rb
+++ b/spec/unit/pdk/cli/new/defined_type_spec.rb
@@ -30,6 +30,7 @@ describe 'PDK::CLI new defined_type' do
   end
 
   context 'when not run from inside a module' do
+    include_context 'run outside module'
     let(:module_root) { nil }
     let(:args) { %w[new defined_type test_define] }
 

--- a/spec/unit/pdk/cli/new/task_spec.rb
+++ b/spec/unit/pdk/cli/new/task_spec.rb
@@ -30,6 +30,7 @@ describe 'PDK::CLI new task' do
   end
 
   context 'when not run from inside a module' do
+    include_context 'run outside module'
     let(:module_root) { nil }
     let(:args) { %w[new task test_task] }
 

--- a/spec/unit/pdk/cli/util_spec.rb
+++ b/spec/unit/pdk/cli/util_spec.rb
@@ -1,12 +1,60 @@
 require 'spec_helper'
 require 'pdk/cli/util'
 
-describe 'PDK::CLI::Util' do
-  context 'ensure_in_module! method' do
-    subject(:ensure_in_module) { PDK::CLI::Util.ensure_in_module! }
+describe PDK::CLI::Util do
+  describe '.ensure_in_module!' do
+    subject(:ensure_in_module) { described_class.ensure_in_module!(options) }
 
-    it 'raises an error when not in a module directory' do
-      expect { ensure_in_module }.to raise_error(PDK::CLI::ExitWithError)
+    let(:error_msg) { a_string_matching(%r{no metadata\.json found}) }
+    let(:options) { {} }
+
+    context 'when a metadata.json exists' do
+      before(:each) do
+        allow(PDK::Util).to receive(:module_root).and_return('something')
+      end
+
+      it 'does not raise an error' do
+        expect { ensure_in_module }.not_to raise_error
+      end
+    end
+
+    context 'when there is no metadata.json' do
+      before(:each) do
+        allow(PDK::Util).to receive(:module_root).and_return(nil)
+        allow(File).to receive(:directory?).with(anything).and_return(false)
+      end
+
+      context 'when passed :check_module_layout => true' do
+        let(:options) { { check_module_layout: true } }
+
+        %w[manifests lib tasks facts.d functions types].each do |dir|
+          context "when the current directory contains a '#{dir}' directory" do
+            before(:each) do
+              allow(File).to receive(:directory?).with(dir).and_return(true)
+            end
+
+            it 'does not raise an error' do
+              expect { ensure_in_module }.not_to raise_error
+            end
+          end
+        end
+
+        context 'when the current directory does not contain a module layout' do
+          it 'raises an error' do
+            expect { ensure_in_module }.to raise_error(PDK::CLI::ExitWithError, error_msg)
+          end
+        end
+      end
+
+      context 'when not passed :check_module_layout' do
+        before(:each) do
+          allow(File).to receive(:directory?).with(anything).and_return(true)
+        end
+
+        it 'raises an error' do
+          expect { ensure_in_module }.to raise_error(PDK::CLI::ExitWithError, error_msg)
+        end
+      end
     end
   end
 end

--- a/spec/unit/pdk/cli_spec.rb
+++ b/spec/unit/pdk/cli_spec.rb
@@ -14,6 +14,8 @@ describe PDK::CLI do
 
   ['validate', 'test unit', 'bundle'].each do |command|
     context "when #{command} command used but not in a module folder" do
+      include_context 'run outside module'
+
       it 'informs the user that this is not a module folder' do
         expect {
           described_class.run(command.split(' '))


### PR DESCRIPTION
Falls back to checking for `manifests/`, `lib/`, `tasks/`, `functions/`, and
`types/` if the module does not contain a `metadata.json`. This logic is not
enabled by default as we should only need to do this during convert (after
that, a `metadata.json` file should be present).

`templates/`, `files/`, `spec/` are not checked for, as it's unlikely they'll
exist without one of the other directories being present.