### PR TITLE
(PDK-489) unhide experimental commands

### DIFF
--- a/lib/pdk/cli/bundle.rb
+++ b/lib/pdk/cli/bundle.rb
@@ -16,8 +16,6 @@ Note that for PowerShell the '--' needs to be escaped using a backtick: '`--' to
 EOF
                  )
 
-    be_hidden
-
     run do |_opts, args, _cmd|
       PDK::CLI::Util.ensure_in_module!
 

--- a/lib/pdk/cli/module.rb
+++ b/lib/pdk/cli/module.rb
@@ -2,10 +2,9 @@ module PDK::CLI
   @module_cmd = @base_cmd.define_command do
     name 'module'
     usage _('module [options]')
-    summary _('Perform administrative tasks on your module.')
-    description _('Perform tasks on the module project.')
+    summary _('Provide CLI-backwards compatibility to the puppet module tool.')
+    description _('This command is only for reminding you how to accomplish tasks with the PDK, when you were previously doing them with the puppet module command.')
     default_subcommand 'help'
-    be_hidden
   end
 
   @module_cmd.add_command Cri::Command.new_basic_help

--- a/lib/pdk/cli/module/generate.rb
+++ b/lib/pdk/cli/module/generate.rb
@@ -5,7 +5,6 @@ module PDK::CLI
     name 'generate'
     usage _('generate [options] <module_name>')
     summary _('This command is now \'pdk new module\'.')
-    be_hidden
 
     PDK::CLI.template_url_option(self)
     PDK::CLI.skip_interview_option(self)


### PR DESCRIPTION
Since CRI's message about hidden commands is very confusing to users
this commit just unhides everything, and makes it clear that those
subcommands are experimental, or for compatibility purporses only.