### PR TITLE
(PDK-643) Disable non-exec validator spinners when noninteractive

### DIFF
--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -90,7 +90,7 @@ module PDK
         end
 
         def register_spinner(spinner, opts = {})
-          return unless display_spinner?
+          return unless PDK::CLI::Util.interactive?
           @success_message = opts.delete(:success)
           @failure_message = opts.delete(:failure)
 
@@ -98,19 +98,11 @@ module PDK
         end
 
         def add_spinner(message, opts = {})
-          return unless display_spinner?
+          return unless PDK::CLI::Util.interactive?
           @success_message = opts.delete(:success)
           @failure_message = opts.delete(:failure)
 
           @spinner = TTY::Spinner.new("[:spinner] #{message}", opts.merge(PDK::CLI::Util.spinner_opts_for_platform))
-        end
-
-        def display_spinner?
-          return false if PDK.logger.debug?
-          return (ENV['PDK_FRONTEND'] != 'NONINTERACTIVE') if ENV['PDK_FRONTEND']
-          return false unless $stderr.isatty
-
-          true
         end
 
         def execute!

--- a/lib/pdk/cli/exec_group.rb
+++ b/lib/pdk/cli/exec_group.rb
@@ -11,7 +11,7 @@ module PDK
       def initialize(message, opts = {})
         @options = opts.merge(PDK::CLI::Util.spinner_opts_for_platform)
 
-        unless PDK.logger.debug?
+        if PDK::CLI::Util.interactive?
           @multi_spinner = TTY::Spinner::Multi.new("[:spinner] #{message}", @options)
           @multi_spinner.auto_spin
         end
@@ -31,7 +31,7 @@ module PDK
       end
 
       def add_spinner(message, opts = {})
-        return if PDK.logger.debug?
+        return unless PDK::CLI::Util.interactive?
         @multi_spinner.register("[:spinner] #{message}", @options.merge(opts).merge(PDK::CLI::Util.spinner_opts_for_platform))
       end
 

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -55,6 +55,15 @@ module PDK
         response
       end
       module_function :prompt_for_yes
+
+      def interactive?
+        return false if PDK.logger.debug?
+        return !ENV['PDK_FRONTEND'].casecmp('noninteractive').zero? if ENV['PDK_FRONTEND']
+        return false unless $stderr.isatty
+
+        true
+      end
+      module_function :interactive?
     end
   end
 end

--- a/lib/pdk/validate/metadata/metadata_syntax.rb
+++ b/lib/pdk/validate/metadata/metadata_syntax.rb
@@ -21,7 +21,7 @@ module PDK
       end
 
       def self.create_spinner(targets = [], options = {})
-        return if PDK.logger.debug?
+        return unless PDK::CLI::Util.interactive?
         options = options.merge(PDK::CLI::Util.spinner_opts_for_platform)
 
         exec_group = options[:exec_group]

--- a/lib/pdk/validate/metadata/task_metadata_lint.rb
+++ b/lib/pdk/validate/metadata/task_metadata_lint.rb
@@ -25,7 +25,7 @@ module PDK
       end
 
       def self.create_spinner(targets = [], options = {})
-        return if PDK.logger.debug?
+        return unless PDK::CLI::Util.interactive?
         options = options.merge(PDK::CLI::Util.spinner_opts_for_platform)
 
         exec_group = options[:exec_group]

--- a/spec/unit/pdk/cli/util_spec.rb
+++ b/spec/unit/pdk/cli/util_spec.rb
@@ -57,4 +57,42 @@ describe PDK::CLI::Util do
       end
     end
   end
+
+  describe '.interactive?' do
+    subject { described_class.interactive? }
+
+    before(:each) do
+      allow(PDK.logger).to receive(:debug?).and_return(false)
+      allow($stderr).to receive(:isatty).and_return(true)
+      ENV.delete('PDK_FRONTEND')
+    end
+
+    context 'by default' do
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the logger is in debug mode' do
+      before(:each) do
+        allow(PDK.logger).to receive(:debug?).and_return(true)
+      end
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when PDK_FRONTEND env var is set to noninteractive' do
+      before(:each) do
+        ENV['PDK_FRONTEND'] = 'noninteractive'
+      end
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when STDERR is not a TTY' do
+      before(:each) do
+        allow($stderr).to receive(:isatty).and_return(false)
+      end
+
+      it { is_expected.to be_falsey }
+    end
+  end
 end


### PR DESCRIPTION
The spinners in `PDK::Validate::MetadataSyntax` and `PDK::Validate::TaskMetadataLint` were missed in the first pass as they don't follow the usual pattern of executing an external command.