### PR TITLE
(maint) Manually load lib/pdk/version.rb in spec

### DIFF
--- a/spec/unit/pdk/version_spec.rb
+++ b/spec/unit/pdk/version_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+load File.expand_path(File.join(__FILE__, '..', '..', '..', '..', 'lib', 'pdk', 'version.rb'))
 
 describe 'PDK version string' do
   it 'has major minor and patch numbers' do


### PR DESCRIPTION
Because this file only contains constants and no runtime code, it
doesn't play well with code coverage as it's evaluated at load time
only. Adding a manual load in the spec works around this.