### PR TITLE
(PDK-736) Improve handling of old template-url and template-ref

### DIFF
--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -173,11 +173,15 @@ module PDK
     module_function :targets_relative_to_pwd
 
     def default_template_url
-      if !PDK.answers['template-url'].nil?
-        PDK.answers['template-url']
-      else
-        puppetlabs_template_url
-      end
+      answer_file_url = PDK.answers['template-url']
+
+      return puppetlabs_template_url if answer_file_url.nil?
+
+      # Ignore answer file template-url if the value is the old or new default.
+      return puppetlabs_template_url if answer_file_url == 'https://github.com/puppetlabs/pdk-module-template'
+      return puppetlabs_template_url if answer_file_url == puppetlabs_template_url
+
+      answer_file_url
     end
     module_function :default_template_url
 
@@ -191,19 +195,18 @@ module PDK
     module_function :puppetlabs_template_url
 
     def default_template_ref
-      if !PDK.answers['template-ref'].nil?
-        PDK.answers['template-ref']
-      else
-        puppetlabs_template_ref
-      end
+      # TODO: This should respect a --template-ref option if we add that
+      return 'origin/master' if default_template_url != puppetlabs_template_url
+
+      puppetlabs_template_ref
     end
     module_function :default_template_ref
 
     def puppetlabs_template_ref
-      if PDK::Util.package_install? || PDK::Util.gem_install?
-        PDK::TEMPLATE_REF
-      else
+      if PDK::Util.development_mode?
         'origin/master'
+      else
+        PDK::TEMPLATE_REF
       end
     end
     module_function :puppetlabs_template_ref

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -329,39 +329,94 @@ describe PDK::Util do
     end
   end
 
+  describe '.default_template_url' do
+    subject { described_class.default_template_url }
+
+    before(:each) do
+      allow(described_class).to receive(:puppetlabs_template_url).and_return('puppetlabs_template_url')
+    end
+
+    context 'when there is no template-url in answers file' do
+      before(:each) do
+        allow(PDK).to receive(:answers).and_return('template-url' => nil)
+      end
+
+      it 'returns puppetlabs template url' do
+        is_expected.to eq('puppetlabs_template_url')
+      end
+    end
+
+    context 'when the template-url in answers file matches current puppetlabs template' do
+      before(:each) do
+        allow(PDK).to receive(:answers).and_return('template-url' => 'puppetlabs_template_url')
+      end
+
+      it 'returns puppetlabs template url' do
+        is_expected.to eq('puppetlabs_template_url')
+      end
+    end
+
+    context 'when the template-url in answers file matches old puppetlabs template' do
+      before(:each) do
+        allow(PDK).to receive(:answers).and_return('template-url' => 'https://github.com/puppetlabs/pdk-module-template')
+      end
+
+      it 'returns puppetlabs template url' do
+        is_expected.to eq('puppetlabs_template_url')
+      end
+    end
+
+    context 'when the template-url in answers file is custom' do
+      before(:each) do
+        allow(PDK).to receive(:answers).and_return('template-url' => 'custom_template_url')
+      end
+
+      it 'returns custom url' do
+        is_expected.to eq('custom_template_url')
+      end
+    end
+  end
+
   describe '.default_template_ref' do
     subject { described_class.default_template_ref }
 
-    context 'it is a package_install' do
-      before(:each) do
-        allow(described_class).to receive(:package_install?).and_return(true)
-        allow(described_class).to receive(:gem_install?).and_return(false)
-      end
-
-      it 'returns the built-in TEMPLATE_REF' do
-        is_expected.to eq(PDK::TEMPLATE_REF)
-      end
+    before(:each) do
+      allow(described_class).to receive(:puppetlabs_template_url).and_return('puppetlabs_template_url')
     end
 
-    context 'it is a gem install' do
+    context 'with a custom template repo' do
       before(:each) do
-        allow(described_class).to receive(:package_install?).and_return(false)
-        allow(described_class).to receive(:gem_install?).and_return(true)
+        allow(described_class).to receive(:default_template_url).and_return('custom_template_url')
       end
 
-      it 'returns the built-in TEMPLATE_REF' do
-        is_expected.to eq(PDK::TEMPLATE_REF)
-      end
-    end
-
-    context 'it is neither package or gem install' do
-      before(:each) do
-        allow(described_class).to receive(:package_install?).and_return(false)
-        allow(described_class).to receive(:gem_install?).and_return(false)
-      end
-
-      it 'returns the built-in TEMPLATE_REF' do
+      it 'returns origin/master' do
         is_expected.to eq('origin/master')
+      end
+    end
+
+    context 'with the default template repo' do
+      before(:each) do
+        allow(described_class).to receive(:default_template_url).and_return('puppetlabs_template_url')
+      end
+
+      context 'not in development mode' do
+        before(:each) do
+          allow(described_class).to receive(:development_mode?).and_return(false)
+        end
+
+        it 'returns the built-in TEMPLATE_REF' do
+          is_expected.to eq(PDK::TEMPLATE_REF)
+        end
+      end
+
+      context 'in development mode' do
+        before(:each) do
+          allow(described_class).to receive(:development_mode?).and_return(true)
+        end
+
+        it 'returns origin/master' do
+          is_expected.to eq('origin/master')
+        end
       end
     end
   end


### PR DESCRIPTION
Previously, if the user had the old puppetlabs/pdk-module-template URL
saved in their answers.json, PDK would still try to use the old repo but
attempt to reset to the `1.3.0` tag which doesn't exist in the old repo.
This commit starts treating a value matching the old repo URL the same
as if there is no template URL specified so that it uses the new
template URL instead.

Furthermore, if the user had a real custom template repo, we were still
attempting to reset to the `1.3.0` tag which probably won't exist in
their custom repo. After this commit, pdk will only try to reset to the
pinned tag when using the official template repo (or packaged repo).