### PR TITLE
(PDK-739) Fall back to default template if necessary

### DIFF
--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -181,6 +181,11 @@ module PDK
       return puppetlabs_template_url if answer_file_url == 'https://github.com/puppetlabs/pdk-module-template'
       return puppetlabs_template_url if answer_file_url == puppetlabs_template_url
 
+      unless PDK::Util::Git.repo_exists?(answer_file_url)
+        PDK.logger.warn(_("Unable to access the previously used template '%{template}', using the default template instead.") % { template: answer_file_url })
+        return puppetlabs_template_url
+      end
+
       answer_file_url
     end
     module_function :default_template_url

--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -183,6 +183,7 @@ module PDK
 
       unless PDK::Util::Git.repo_exists?(answer_file_url)
         PDK.logger.warn(_("Unable to access the previously used template '%{template}', using the default template instead.") % { template: answer_file_url })
+        PDK.answers.update!('template-url' => nil)
         return puppetlabs_template_url
       end
 

--- a/lib/pdk/util/git.rb
+++ b/lib/pdk/util/git.rb
@@ -31,6 +31,12 @@ module PDK
 
         PDK::CLI::Exec.execute(git_bin, *args)
       end
+
+      def self.repo_exists?(repo, ref = nil)
+        args = ['ls-remote', '--exit-code', repo, ref].compact
+
+        git(*args)[:exit_code].zero?
+      end
     end
   end
 end

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -166,6 +166,7 @@ describe PDK::Generate::Module do
       context 'when a template-url is supplied on the command line' do
         before(:each) do
           allow(FileUtils).to receive(:mv).with(temp_target_dir, target_dir).and_return(0)
+          allow(PDK::Util).to receive(:default_template_url).and_return('https://github.com/puppetlabs/pdk-templates')
         end
 
         it 'uses that template to generate the module' do

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -204,6 +204,10 @@ describe PDK::Generate::Module do
         end
 
         context 'and a template-url answer exists' do
+          before(:each) do
+            allow(PDK::Util::Git).to receive(:repo_exists?).with('answer-template').and_return(true)
+          end
+
           it 'uses the template-url from the answer file to generate the module' do
             PDK.answers.update!('template-url' => 'answer-template')
             expect(PDK::Module::TemplateDir).to receive(:new).with('answer-template', anything, anything).and_yield(test_template_dir)

--- a/spec/unit/pdk/util/git_spec.rb
+++ b/spec/unit/pdk/util/git_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe PDK::Util::Git do
+  describe '.repo_exists?' do
+    subject { described_class.repo_exists?(repo) }
+
+    let(:repo) { 'pdk-templates' }
+
+    before(:each) do
+      allow(described_class).to receive(:git).with('ls-remote', '--exit-code', repo).and_return(result)
+    end
+
+    context 'when git ls-remote finds refs in the repository' do
+      let(:result) do
+        { exit_code: 0 }
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when git ls-remote can not find any refs in the repository' do
+      let(:result) do
+        { exit_code: 2 }
+      end
+
+      it { is_expected.to be_falsey }
+    end
+  end
+end

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -371,8 +371,25 @@ describe PDK::Util do
         allow(PDK).to receive(:answers).and_return('template-url' => 'custom_template_url')
       end
 
-      it 'returns custom url' do
-        is_expected.to eq('custom_template_url')
+      context 'and the template is a valid repo' do
+        before(:each) do
+          allow(PDK::Util::Git).to receive(:repo_exists?).with('custom_template_url').and_return(true)
+        end
+
+        it 'returns custom url' do
+          is_expected.to eq('custom_template_url')
+        end
+      end
+
+      context 'and the template is not a valid repo' do
+        before(:each) do
+          allow(PDK::Util::Git).to receive(:repo_exists?).with('custom_template_url').and_return(false)
+        end
+
+        it 'returns the puppetlabs template url' do
+          expect(logger).to receive(:warn).with(a_string_matching(%r{using the default template}))
+          is_expected.to eq('puppetlabs_template_url')
+        end
       end
     end
   end

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -384,6 +384,7 @@ describe PDK::Util do
       context 'and the template is not a valid repo' do
         before(:each) do
           allow(PDK::Util::Git).to receive(:repo_exists?).with('custom_template_url').and_return(false)
+          allow(PDK.answers).to receive(:update!).with('template-url' => nil)
         end
 
         it 'returns the puppetlabs template url' do


### PR DESCRIPTION
Checks if the repo pointed to by the saved template-url from the answer file contains valid refs and fall back if it doesn't. `git ls-remote` will return non-zero (or specifically 2) if the remote does not exist or does not contain the specified ref (if supplied).