### PR TITLE
(PDK-552) Soften PDK::CLI::Util.ensure_in_module! error messages

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -16,7 +16,7 @@ module PDK::CLI
   def self.run(args)
     @base_cmd.run(args)
   rescue PDK::CLI::ExitWithError => e
-    PDK.logger.error(e.message)
+    PDK.logger.send(e.log_level, e.message)
 
     exit e.exit_code
   rescue PDK::CLI::FatalError => e

--- a/lib/pdk/cli/bundle.rb
+++ b/lib/pdk/cli/bundle.rb
@@ -17,7 +17,9 @@ EOF
                  )
 
     run do |_opts, args, _cmd|
-      PDK::CLI::Util.ensure_in_module!
+      PDK::CLI::Util.ensure_in_module!(
+        message: _('`pdk bundle` can only be run from inside a valid module directory.'),
+      )
 
       command = PDK::CLI::Exec::Command.new(PDK::CLI::Exec.bundle_bin, *args).tap do |c|
         c.context = :module

--- a/lib/pdk/cli/convert.rb
+++ b/lib/pdk/cli/convert.rb
@@ -13,7 +13,12 @@ module PDK::CLI
 
     run do |opts, _args, _cmd|
       require 'pdk/module/convert'
-      PDK::CLI::Util.ensure_in_module!(check_module_layout: true)
+
+      PDK::CLI::Util.ensure_in_module!(
+        check_module_layout: true,
+        message:             _('`pdk convert` can only be run from inside a valid module directory.'),
+        log_level:           :info,
+      )
 
       if opts[:noop] && opts[:force]
         raise PDK::CLI::ExitWithError, _('You can not specify --noop and --force when converting a module')

--- a/lib/pdk/cli/errors.rb
+++ b/lib/pdk/cli/errors.rb
@@ -3,17 +3,19 @@ module PDK
     class FatalError < StandardError
       attr_reader :exit_code
 
-      def initialize(msg = _('An unexpected error has occurred. Try running the command again with --debug'), exit_code = 1)
-        @exit_code = exit_code
+      def initialize(msg = _('An unexpected error has occurred. Try running the command again with --debug'), opts = {})
+        @exit_code = opts.fetch(:exit_code, 1)
         super(msg)
       end
     end
 
     class ExitWithError < StandardError
       attr_reader :exit_code
+      attr_reader :log_level
 
-      def initialize(msg, exit_code = 1)
-        @exit_code = exit_code
+      def initialize(msg, opts = {})
+        @exit_code = opts.fetch(:exit_code, 1)
+        @log_level = opts.fetch(:log_level, :error)
         super(msg)
       end
     end

--- a/lib/pdk/cli/new/class.rb
+++ b/lib/pdk/cli/new/class.rb
@@ -9,7 +9,10 @@ module PDK::CLI
     run do |opts, args, _cmd|
       require 'pdk/generate/puppet_class'
 
-      PDK::CLI::Util.ensure_in_module!
+      PDK::CLI::Util.ensure_in_module!(
+        message:   _('Classes can only be created from inside a valid module directory.'),
+        log_level: :info,
+      )
 
       class_name = args[0]
       module_dir = Dir.pwd

--- a/lib/pdk/cli/new/defined_type.rb
+++ b/lib/pdk/cli/new/defined_type.rb
@@ -7,7 +7,10 @@ module PDK::CLI
     PDK::CLI.template_url_option(self)
 
     run do |opts, args, _cmd|
-      PDK::CLI::Util.ensure_in_module!
+      PDK::CLI::Util.ensure_in_module!(
+        message: _('Defined types can only be created from inside a valid module directory.'),
+        log_level: :info,
+      )
 
       defined_type_name = args[0]
       module_dir = Dir.pwd

--- a/lib/pdk/cli/new/task.rb
+++ b/lib/pdk/cli/new/task.rb
@@ -8,7 +8,10 @@ module PDK::CLI
     option nil, :description, _('A short description of the purpose of the task'), argument: :required
 
     run do |opts, args, _cmd|
-      PDK::CLI::Util.ensure_in_module!
+      PDK::CLI::Util.ensure_in_module!(
+        message:   _('Tasks can only be created from inside a valid module directory.'),
+        log_level: :info,
+      )
 
       task_name = args[0]
       module_dir = Dir.pwd

--- a/lib/pdk/cli/test/unit.rb
+++ b/lib/pdk/cli/test/unit.rb
@@ -21,7 +21,10 @@ module PDK::CLI
     run do |opts, _args, _cmd|
       require 'pdk/tests/unit'
 
-      PDK::CLI::Util.ensure_in_module!
+      PDK::CLI::Util.ensure_in_module!(
+        message:   _('Unit tests can only be run from inside a valid module directory.'),
+        log_level: :info,
+      )
 
       report = nil
 

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -23,8 +23,8 @@ module PDK
         return unless PDK::Util.module_root.nil?
         return if opts[:check_module_layout] && PDK::CLI::Util::MODULE_FOLDERS.any? { |dir| File.directory?(dir) }
 
-        message = _('This command must be run from inside a valid module (no metadata.json found).')
-        raise PDK::CLI::ExitWithError, message
+        message = opts.fetch(:message, _('This command must be run from inside a valid module (no metadata.json found).'))
+        raise PDK::CLI::ExitWithError.new(message, opts)
       end
       module_function :ensure_in_module!
 

--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -32,7 +32,10 @@ module PDK::CLI
         exit 0
       end
 
-      PDK::CLI::Util.ensure_in_module!
+      PDK::CLI::Util.ensure_in_module!(
+        message:   _('Code validation can only be run from inside a valid module directory'),
+        log_level: :info,
+      )
 
       if args[0]
         # This may be a single validator, a list of validators, or a target.

--- a/spec/acceptance/support/it_requires_running_in_a_module.rb
+++ b/spec/acceptance/support/it_requires_running_in_a_module.rb
@@ -15,7 +15,7 @@ RSpec.shared_examples('it requires running from inside a module', module_command
 
     describe command(top_level_description) do
       its(:exit_status) { is_expected.not_to eq(0) }
-      its(:stderr) { is_expected.to match(%r{must be run from inside a valid module}i) }
+      its(:stderr) { is_expected.to match(%r{a valid module}i) }
       its(:stdout) { is_expected.to match(%r{\A\Z}) }
     end
   end

--- a/spec/support/run_outside_module.rb
+++ b/spec/support/run_outside_module.rb
@@ -1,6 +1,6 @@
 RSpec.shared_context 'run outside module' do
   before(:each) do
     msg = 'must be run from inside a valid module (no metadata.json found)'
-    allow(PDK::CLI::Util).to receive(:ensure_in_module!).and_raise(PDK::CLI::ExitWithError, msg)
+    allow(PDK::CLI::Util).to receive(:ensure_in_module!).with(any_args).and_raise(PDK::CLI::ExitWithError, msg)
   end
 end

--- a/spec/unit/pdk/cli/errors_spec.rb
+++ b/spec/unit/pdk/cli/errors_spec.rb
@@ -1,10 +1,66 @@
 require 'spec_helper'
 
-describe 'PDK FatalError' do
-  subject(:fatal_error) { PDK::CLI::FatalError }
+describe PDK::CLI::FatalError do # rubocop:disable RSpec/MultipleDescribes
+  subject(:error) { described_class.new }
 
-  it 'has a message' do
-    error = fatal_error.new
-    expect(error.message).not_to be_nil
+  it 'has a default error message' do
+    expect(error.message).to match(%r{an unexpected error has occurred}i)
+  end
+
+  it 'has a default non-zero exit code' do
+    expect(error.exit_code).to be_an(Integer)
+    expect(error.exit_code).not_to be_zero
+  end
+
+  context 'when provided a custom error message' do
+    subject(:error) { described_class.new('test message') }
+
+    it 'uses the custom error message' do
+      expect(error.message).to eq('test message')
+    end
+
+    context 'and a custom exit code' do
+      subject(:error) { described_class.new('test message', exit_code: 2) }
+
+      it 'uses the custom exit code' do
+        expect(error.exit_code).to eq(2)
+      end
+    end
+  end
+end
+
+describe PDK::CLI::ExitWithError do
+  subject(:error) { described_class.new(message, options) }
+
+  let(:message) { 'test message' }
+  let(:options) { {} }
+
+  it 'uses the provided error message' do
+    expect(error.message).to eq(message)
+  end
+
+  it 'has a default non-zero exit code' do
+    expect(error.exit_code).to be_an(Integer)
+    expect(error.exit_code).not_to be_zero
+  end
+
+  it 'has a default log level of error' do
+    expect(error.log_level).to eq(:error)
+  end
+
+  context 'when provided with a custom exit code' do
+    let(:options) { { exit_code: 2 } }
+
+    it 'uses the custom exit code' do
+      expect(error.exit_code).to eq(2)
+    end
+  end
+
+  context 'when provided with a custom log level' do
+    let(:options) { { log_level: :info } }
+
+    it 'uses the custom log level' do
+      expect(error.log_level).to eq(:info)
+    end
   end
 end

--- a/spec/unit/pdk/cli/test/unit_spec.rb
+++ b/spec/unit/pdk/cli/test/unit_spec.rb
@@ -18,7 +18,7 @@ describe '`pdk test unit`' do
 
   context 'when executing' do
     before(:each) do
-      expect(PDK::CLI::Util).to receive(:ensure_in_module!).with(no_args).once
+      expect(PDK::CLI::Util).to receive(:ensure_in_module!).with(any_args).once
     end
 
     context 'when listing tests' do


### PR DESCRIPTION
Refactors `PDK::CLI::ExitWithError` to allow it to take a log level option and then modifies `PDK::CLI::Util.ensure_in_module!` definition and uses to allow the message and level to be customised as needed.