### PR TITLE
(maint) Default PDK::TEMPLATE_REF to PDK::VERSION

### DIFF
--- a/lib/pdk/version.rb
+++ b/lib/pdk/version.rb
@@ -1,4 +1,4 @@
 module PDK
   VERSION = '1.3.1'.freeze
-  TEMPLATE_REF = '1.3.0'.freeze
+  TEMPLATE_REF = VERSION
 end


### PR DESCRIPTION
puppetlabs/pdk-templates should be tagged with the PDK version during release, so we should be able to default this to version, preventing future acceptance test failures like https://travis-ci.org/puppetlabs/pdk/jobs/329178285 where one of the `pdk new module` tests failed due to pdk-templates getting belatedly tagged with 1.3.1.

This test will still fail if pdk-templates gets tagged before the version number is bumped, but that'll be fixed with PDK-718.