### PR TITLE
(PDK-550) Removes unrequired questions from module interview

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -45,6 +45,10 @@ module PDK::CLI
     dsl.option nil, 'skip-interview', _('When specified, skips interactive querying of metadata.')
   end
 
+  def self.full_interview_option(dsl)
+    dsl.option nil, 'full-interview', _('When specified, interactive querying of metadata will include all optional questions.')
+  end
+
   @base_cmd = Cri::Command.define do
     name 'pdk'
     usage _('pdk command [options]')

--- a/lib/pdk/cli/convert.rb
+++ b/lib/pdk/cli/convert.rb
@@ -8,6 +8,7 @@ module PDK::CLI
 
     PDK::CLI.template_url_option(self)
     PDK::CLI.skip_interview_option(self)
+    PDK::CLI.full_interview_option(self)
     flag nil, :noop, _('Do not convert the module, just output what would be done.')
     flag nil, :force, _('Convert the module automatically, with no prompts.')
 
@@ -22,6 +23,16 @@ module PDK::CLI
 
       if opts[:noop] && opts[:force]
         raise PDK::CLI::ExitWithError, _('You can not specify --noop and --force when converting a module')
+      end
+
+      if opts[:'skip-interview'] && opts[:'full-interview']
+        PDK.logger.info _('Ignoring --full-interview and continuing with --skip-interview.')
+        opts[:'full-interview'] = false
+      end
+
+      if opts[:force] && opts[:'full-interview']
+        PDK.logger.info _('Ignoring --full-interview and continuing with --force.')
+        opts[:'full-interview'] = false
       end
 
       PDK::Module::Convert.invoke(opts)

--- a/lib/pdk/cli/new/module.rb
+++ b/lib/pdk/cli/new/module.rb
@@ -6,6 +6,7 @@ module PDK::CLI
 
     PDK::CLI.template_url_option(self)
     PDK::CLI.skip_interview_option(self)
+    PDK::CLI.full_interview_option(self)
 
     option nil, 'license', _('Specifies the license this module is written under. ' \
       "This should be a identifier from https://spdx.org/licenses/. Common values are 'Apache-2.0', 'MIT', or 'proprietary'."), argument: :required

--- a/lib/pdk/cli/new/module.rb
+++ b/lib/pdk/cli/new/module.rb
@@ -17,6 +17,11 @@ module PDK::CLI
       module_name = args[0]
       target_dir = args[1]
 
+      if opts[:'skip-interview'] && opts[:'full-interview']
+        PDK.logger.info _('Ignoring --full-interview and continuing with --skip-interview.')
+        opts[:'full-interview'] = false
+      end
+
       unless module_name.nil? || module_name.empty?
         module_name_parts = module_name.split('-', 2)
         if module_name_parts.size > 1

--- a/lib/pdk/generate/module.rb
+++ b/lib/pdk/generate/module.rb
@@ -98,7 +98,7 @@ module PDK
         login_clean = 'username' if login_clean.empty?
 
         if login_clean != login
-          PDK.logger.warn _('Your username is not a valid Forge username. Proceeding with the username %{username}. You can fix this later in metadata.json.') % {
+          PDK.logger.debug _('Your username is not a valid Forge username. Proceeding with the username %{username}. You can fix this later in metadata.json.') % {
             username: login_clean,
           }
         end

--- a/lib/pdk/generate/module.rb
+++ b/lib/pdk/generate/module.rb
@@ -176,6 +176,7 @@ module PDK
             validate_pattern: %r{\A[0-9]+\.[0-9]+\.[0-9]+},
             validate_message: _('Semantic Version numbers must be in the form MAJOR.MINOR.PATCH'),
             default:          metadata.data['version'],
+            forge_only:       true,
           },
           {
             name:     'author',
@@ -249,30 +250,34 @@ module PDK
             default: [1, 2, 7],
           },
           {
-            name:     'summary',
-            question: _('Summarize the purpose of this module in a single sentence.'),
-            help:     _('This helps other Puppet users understand what the module does.'),
-            required: true,
-            default:  metadata.data['summary'],
+            name:       'summary',
+            question:   _('Summarize the purpose of this module in a single sentence.'),
+            help:       _('This helps other Puppet users understand what the module does.'),
+            required:   true,
+            default:    metadata.data['summary'],
+            forge_only: true,
           },
           {
-            name:     'source',
-            question: _('If there is a source code repository for this module, enter the URL here.'),
-            help:     _('Skip this if no repository exists yet. You can update this later in the metadata.json.'),
-            required: true,
-            default:  metadata.data['source'],
+            name:       'source',
+            question:   _('If there is a source code repository for this module, enter the URL here.'),
+            help:       _('Skip this if no repository exists yet. You can update this later in the metadata.json.'),
+            required:   true,
+            default:    metadata.data['source'],
+            forge_only: true,
           },
           {
-            name:     'project_page',
-            question: _('If there is a URL where others can learn more about this module, enter it here.'),
-            help:     _('Optional. You can update this later in the metadata.json.'),
-            default:  metadata.data['project_page'],
+            name:       'project_page',
+            question:   _('If there is a URL where others can learn more about this module, enter it here.'),
+            help:       _('Optional. You can update this later in the metadata.json.'),
+            default:    metadata.data['project_page'],
+            forge_only: true,
           },
           {
-            name:     'issues_url',
-            question: _('If there is a public issue tracker for this module, enter its URL here.'),
-            help:     _('Optional. You can update this later in the metadata.json.'),
-            default:  metadata.data['issues_url'],
+            name:       'issues_url',
+            question:   _('If there is a public issue tracker for this module, enter its URL here.'),
+            help:       _('Optional. You can update this later in the metadata.json.'),
+            default:    metadata.data['issues_url'],
+            forge_only: true,
           },
         ]
 
@@ -282,6 +287,7 @@ module PDK
 
         questions.reject! { |q| q[:name] == 'module_name' } if opts.key?(:module_name)
         questions.reject! { |q| q[:name] == 'license' } if opts.key?(:license)
+        questions.reject! { |q| q[:forge_only] } unless opts.key?(:'full-interview')
 
         interview.add_questions(questions)
 

--- a/spec/unit/pdk/cli/convert_spec.rb
+++ b/spec/unit/pdk/cli/convert_spec.rb
@@ -65,5 +65,39 @@ describe 'PDK::CLI convert' do
         }
       end
     end
+
+    context 'and the --skip-interview flag has been passed' do
+      it 'passes the skip-interview option through to the converter' do
+        expect(PDK::Module::Convert).to receive(:invoke).with(:'skip-interview' => true, :'template-url' => anything)
+
+        PDK::CLI.run(['convert', '--skip-interview'])
+      end
+    end
+
+    context 'and the --full-interview flag has been passed' do
+      it 'passes the full-interview option through to the converter' do
+        expect(PDK::Module::Convert).to receive(:invoke).with(:'full-interview' => true, :'template-url' => anything)
+
+        PDK::CLI.run(['convert', '--full-interview'])
+      end
+    end
+
+    context 'and the --skip-interview and --full-interview flags have been passed' do
+      it 'ignores full-interview and continues with a log message' do
+        expect(logger).to receive(:info).with(a_string_matching(%r{Ignoring --full-interview and continuing with --skip-interview.}i))
+        expect(PDK::Module::Convert).to receive(:invoke).with(:'skip-interview' => true, :'full-interview' => false, :'template-url' => anything)
+
+        PDK::CLI.run(['convert', '--skip-interview', '--full-interview'])
+      end
+    end
+
+    context 'and the --force and --full-interview flags have been passed' do
+      it 'ignores full-interview and continues with a log message' do
+        expect(logger).to receive(:info).with(a_string_matching(%r{Ignoring --full-interview and continuing with --force.}i))
+        expect(PDK::Module::Convert).to receive(:invoke).with(:force => true, :'full-interview' => false, :'template-url' => anything)
+
+        PDK::CLI.run(['convert', '--force', '--full-interview'])
+      end
+    end
   end
 end

--- a/spec/unit/pdk/cli/new/module_spec.rb
+++ b/spec/unit/pdk/cli/new/module_spec.rb
@@ -77,6 +77,15 @@ describe 'Running `pdk new module`' do
         PDK::CLI.run(['new', 'module', '--full-interview', module_name])
       end
     end
+
+    context 'and the --skip-interview and --full-interview flags have been passed' do
+      it 'ignores full-interview and continues with a log message' do
+        expect(logger).to receive(:info).with(a_string_matching(%r{Ignoring --full-interview and continuing with --skip-interview.}i))
+        expect(PDK::Generate::Module).to receive(:invoke).with(hash_including(:'skip-interview' => true, :'full-interview' => false))
+
+        PDK::CLI.run(['new', 'module', '--skip-interview', '--full-interview'])
+      end
+    end
   end
 
   context 'when passed a module name with a forge user' do

--- a/spec/unit/pdk/cli/new/module_spec.rb
+++ b/spec/unit/pdk/cli/new/module_spec.rb
@@ -69,6 +69,14 @@ describe 'Running `pdk new module`' do
         PDK::CLI.run(['new', 'module', '--skip-interview', module_name])
       end
     end
+
+    context 'and the full-interview flag' do
+      it 'passes true as the value of the full-interview option to PDK::Generate::Module.invoke' do
+        expect(PDK::Generate::Module).to receive(:invoke).with(hash_including(:'full-interview' => true))
+        expect(logger).to receive(:info).with("Creating new module: #{module_name}")
+        PDK::CLI.run(['new', 'module', '--full-interview', module_name])
+      end
+    end
   end
 
   context 'when passed a module name with a forge user' do

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -265,7 +265,7 @@ describe PDK::Generate::Module do
 
     let(:module_name) { 'bar' }
     let(:default_metadata) { {} }
-    let(:options) { { :module_name => module_name, :'full-interview' => true } }
+    let(:options) { { module_name: module_name } }
 
     before(:each) do
       prompt = TTY::TestPrompt.new
@@ -274,167 +274,166 @@ describe PDK::Generate::Module do
       prompt.input.rewind
     end
 
-    context 'when provided answers to all the questions' do
-      include_context 'allow summary to be printed to stdout'
+    context 'with --full-interview' do
+      let(:options) { { :module_name => module_name, :'full-interview' => true } }
 
-      let(:responses) do
-        [
-          'foo',
-          '2.2.0',
-          'William Hopper',
-          'Apache-2.0',
-          '',
-          'A simple module to do some stuff.',
-          'github.com/whopper/bar',
-          'forge.puppet.com/whopper/bar',
-          'tickets.foo.com/whopper/bar',
-          'yes',
-        ]
+      context 'when provided answers to all the questions' do
+        include_context 'allow summary to be printed to stdout'
+
+        let(:responses) do
+          [
+            'foo',
+            '2.2.0',
+            'William Hopper',
+            'Apache-2.0',
+            '',
+            'A simple module to do some stuff.',
+            'github.com/whopper/bar',
+            'forge.puppet.com/whopper/bar',
+            'tickets.foo.com/whopper/bar',
+            'yes',
+          ]
+        end
+
+        it 'populates the Metadata object based on user input' do
+          allow($stdout).to receive(:puts).with(a_string_matching(%r{9 questions}m))
+
+          expect(interview_metadata).to include(
+            'name'                    => 'foo-bar',
+            'version'                 => '2.2.0',
+            'author'                  => 'William Hopper',
+            'license'                 => 'Apache-2.0',
+            'summary'                 => 'A simple module to do some stuff.',
+            'source'                  => 'github.com/whopper/bar',
+            'project_page'            => 'forge.puppet.com/whopper/bar',
+            'issues_url'              => 'tickets.foo.com/whopper/bar',
+            'operatingsystem_support' => [
+              {
+                'operatingsystem'        => 'CentOS',
+                'operatingsystemrelease' => ['7'],
+              },
+              {
+                'operatingsystem'        => 'OracleLinux',
+                'operatingsystemrelease' => ['7'],
+              },
+              {
+                'operatingsystem'        => 'RedHat',
+                'operatingsystemrelease' => ['7'],
+              },
+              {
+                'operatingsystem'        => 'Scientific',
+                'operatingsystemrelease' => ['7'],
+              },
+              {
+                'operatingsystem'        => 'Debian',
+                'operatingsystemrelease' => ['8'],
+              },
+              {
+                'operatingsystem'        => 'Ubuntu',
+                'operatingsystemrelease' => ['16.04'],
+              },
+              {
+                'operatingsystem'        => 'windows',
+                'operatingsystemrelease' => ['2008 R2', '2012 R2', '10'],
+              },
+            ],
+          )
+        end
+
+        it 'saves the forge username to the answer file' do
+          expect(answers['forge_username']).to eq('foo')
+        end
+
+        it 'saves the module author to the answer file' do
+          expect(answers['author']).to eq('William Hopper')
+        end
+
+        it 'saves the license to the answer file' do
+          expect(answers['license']).to eq('Apache-2.0')
+        end
       end
 
-      it 'populates the Metadata object based on user input' do
-        allow($stdout).to receive(:puts).with(a_string_matching(%r{9 questions}m))
+      context 'when the user chooses the default values for everything' do
+        include_context 'allow summary to be printed to stdout'
 
-        expect(interview_metadata).to include(
-          'name'                    => 'foo-bar',
-          'version'                 => '2.2.0',
-          'author'                  => 'William Hopper',
-          'license'                 => 'Apache-2.0',
-          'summary'                 => 'A simple module to do some stuff.',
-          'source'                  => 'github.com/whopper/bar',
-          'project_page'            => 'forge.puppet.com/whopper/bar',
-          'issues_url'              => 'tickets.foo.com/whopper/bar',
-          'operatingsystem_support' => [
-            {
-              'operatingsystem'        => 'CentOS',
-              'operatingsystemrelease' => ['7'],
-            },
-            {
-              'operatingsystem'        => 'OracleLinux',
-              'operatingsystemrelease' => ['7'],
-            },
-            {
-              'operatingsystem'        => 'RedHat',
-              'operatingsystemrelease' => ['7'],
-            },
-            {
-              'operatingsystem'        => 'Scientific',
-              'operatingsystemrelease' => ['7'],
-            },
-            {
-              'operatingsystem'        => 'Debian',
-              'operatingsystemrelease' => ['8'],
-            },
-            {
-              'operatingsystem'        => 'Ubuntu',
-              'operatingsystemrelease' => ['16.04'],
-            },
-            {
-              'operatingsystem'        => 'windows',
-              'operatingsystemrelease' => ['2008 R2', '2012 R2', '10'],
-            },
-          ],
-        )
-      end
+        let(:options) { { :module_name => 'bar', :username => 'defaultauthor', :'full-interview' => true } }
+        let(:default_metadata) do
+          {
+            'author'  => 'defaultauthor',
+            'version' => '0.0.1',
+            'summary' => 'default summary',
+            'source'  => 'default source',
+            'license' => 'default license',
+          }
+        end
 
-      it 'saves the forge username to the answer file' do
-        expect(answers['forge_username']).to eq('foo')
-      end
+        let(:responses) do
+          [
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+          ]
+        end
 
-      it 'saves the module author to the answer file' do
-        expect(answers['author']).to eq('William Hopper')
-      end
+        it 'populates the interview question defaults with existing metadata values' do
+          allow($stdout).to receive(:puts).with(a_string_matching(%r{9 questions}))
 
-      it 'saves the license to the answer file' do
-        expect(answers['license']).to eq('Apache-2.0')
-      end
-    end
+          expect(interview_metadata).to include(
+            'name'    => 'defaultauthor-bar',
+            'version' => '0.0.1',
+            'author'  => 'defaultauthor',
+            'license' => 'default license',
+            'summary' => 'default summary',
+            'source'  => 'default source',
+          )
+        end
 
-    context 'when the user chooses the default values for everything' do
-      include_context 'allow summary to be printed to stdout'
+        it 'saves the forge username to the answer file' do
+          expect(answers['forge_username']).to eq('defaultauthor')
+        end
 
-      let(:options) { { :module_name => 'bar', :username => 'defaultauthor', :'full-interview' => true } }
-      let(:default_metadata) do
-        {
-          'author'  => 'defaultauthor',
-          'version' => '0.0.1',
-          'summary' => 'default summary',
-          'source'  => 'default source',
-          'license' => 'default license',
-        }
-      end
+        it 'saves the module author to the answer file' do
+          expect(answers['author']).to eq('defaultauthor')
+        end
 
-      let(:responses) do
-        [
-          '',
-          '',
-          '',
-          '',
-          '',
-          '',
-          '',
-          '',
-          '',
-        ]
-      end
-
-      it 'populates the interview question defaults with existing metadata values' do
-        allow($stdout).to receive(:puts).with(a_string_matching(%r{9 questions}))
-
-        expect(interview_metadata).to include(
-          'name'    => 'defaultauthor-bar',
-          'version' => '0.0.1',
-          'author'  => 'defaultauthor',
-          'license' => 'default license',
-          'summary' => 'default summary',
-          'source'  => 'default source',
-        )
-      end
-
-      it 'saves the forge username to the answer file' do
-        expect(answers['forge_username']).to eq('defaultauthor')
-      end
-
-      it 'saves the module author to the answer file' do
-        expect(answers['author']).to eq('defaultauthor')
-      end
-
-      it 'saves the license to the answer file' do
-        expect(answers['license']).to eq('default license')
+        it 'saves the license to the answer file' do
+          expect(answers['license']).to eq('default license')
+        end
       end
     end
 
     context 'when there is no module_name provided' do
       include_context 'allow summary to be printed to stdout'
 
-      let(:options) { { :license => 'MIT', :'full-interview' => true } }
+      let(:options) { { license: 'MIT' } }
       let(:responses) do
         [
           'mymodule',
           'myforgename',
-          '2.2.0',
           'William Hopper',
           '',
-          'A simple module to do some stuff.',
-          'github.com/whopper/bar',
-          'forge.puppet.com/whopper/bar',
-          'tickets.foo.com/whopper/bar',
           'yes',
         ]
       end
 
       it 'populates the Metadata object based on user input for both module name and forge name' do
-        allow($stdout).to receive(:puts).with(a_string_matching(%r{9 questions}))
+        allow($stdout).to receive(:puts).with(a_string_matching(%r{4 questions}))
 
         expect(interview_metadata).to include(
           'name'         => 'myforgename-mymodule',
-          'version'      => '2.2.0',
+          'version'      => '0.1.0',
           'author'       => 'William Hopper',
           'license'      => 'MIT',
-          'summary'      => 'A simple module to do some stuff.',
-          'source'       => 'github.com/whopper/bar',
-          'project_page' => 'forge.puppet.com/whopper/bar',
-          'issues_url'   => 'tickets.foo.com/whopper/bar',
+          'summary'      => '',
+          'source'       => '',
+          'project_page' => nil,
+          'issues_url'   => nil,
         )
       end
     end
@@ -442,33 +441,28 @@ describe PDK::Generate::Module do
     context 'when the user provides the license as a command line option' do
       include_context 'allow summary to be printed to stdout'
 
-      let(:options) { { :module_name => module_name, :license => 'MIT', :'full-interview' => true } }
+      let(:options) { { module_name: module_name, license: 'MIT' } }
       let(:responses) do
         [
           'foo',
-          '2.2.0',
           'William Hopper',
           '',
-          'A simple module to do some stuff.',
-          'github.com/whopper/bar',
-          'forge.puppet.com/whopper/bar',
-          'tickets.foo.com/whopper/bar',
           'yes',
         ]
       end
 
       it 'populates the Metadata object based on user input' do
-        allow($stdout).to receive(:puts).with(a_string_matching(%r{8 questions}m))
+        allow($stdout).to receive(:puts).with(a_string_matching(%r{3 questions}m))
 
         expect(interview_metadata).to include(
           'name'         => 'foo-bar',
-          'version'      => '2.2.0',
+          'version'      => '0.1.0',
           'author'       => 'William Hopper',
           'license'      => 'MIT',
-          'summary'      => 'A simple module to do some stuff.',
-          'source'       => 'github.com/whopper/bar',
-          'project_page' => 'forge.puppet.com/whopper/bar',
-          'issues_url'   => 'tickets.foo.com/whopper/bar',
+          'summary'      => '',
+          'source'       => '',
+          'project_page' => nil,
+          'issues_url'   => nil,
         )
       end
 
@@ -494,7 +488,7 @@ describe PDK::Generate::Module do
 
       it 'exits cleanly' do
         allow(logger).to receive(:info).with(a_string_matching(%r{interview cancelled}i))
-        allow($stdout).to receive(:puts).with(a_string_matching(%r{9 questions}m))
+        allow($stdout).to receive(:puts).with(a_string_matching(%r{4 questions}m))
 
         expect { interview_metadata }.to raise_error(SystemExit) { |error|
           expect(error.status).to eq(0)
@@ -508,21 +502,16 @@ describe PDK::Generate::Module do
       let(:responses) do
         [
           'foo',
-          '2.2.0',
           'William Hopper',
           'Apache-2.0',
           '',
-          'A simple module to do some stuff.',
-          'github.com/whopper/bar',
-          'forge.puppet.com/whopper/bar',
-          'tickets.foo.com/whopper/bar',
           'no',
         ]
       end
 
       it 'exits cleanly' do
         allow(logger).to receive(:info).with(a_string_matching(%r{Process cancelled; exiting.}i))
-        allow($stdout).to receive(:puts).with(a_string_matching(%r{9 questions}m))
+        allow($stdout).to receive(:puts).with(a_string_matching(%r{4 questions}m))
 
         expect { interview_metadata }.to raise_error(SystemExit) { |error|
           expect(error.status).to eq(0)
@@ -536,14 +525,9 @@ describe PDK::Generate::Module do
       let(:responses) do
         [
           'foo',
-          '2.2.0',
           'William Hopper',
           'Apache-2.0',
           '',
-          'A simple module to do some stuff.',
-          'github.com/whopper/bar',
-          'forge.puppet.com/whopper/bar',
-          'tickets.foo.com/whopper/bar',
           'test', # incorrect confirmation
           'yes',  # reattempted confirmation
         ]
@@ -555,13 +539,13 @@ describe PDK::Generate::Module do
 
         expect(interview_metadata).to include(
           'name'         => 'foo-bar',
-          'version'      => '2.2.0',
+          'version'      => '0.1.0',
           'author'       => 'William Hopper',
           'license'      => 'Apache-2.0',
-          'summary'      => 'A simple module to do some stuff.',
-          'source'       => 'github.com/whopper/bar',
-          'project_page' => 'forge.puppet.com/whopper/bar',
-          'issues_url'   => 'tickets.foo.com/whopper/bar',
+          'summary'      => '',
+          'source'       => '',
+          'project_page' => nil,
+          'issues_url'   => nil,
         )
       end
     end
@@ -572,14 +556,9 @@ describe PDK::Generate::Module do
       let(:responses) do
         [
           'foo',
-          '2.2.0',
           'William Hopper',
           'Apache-2.0',
           "\e[A 1 ", # \e[A == up arrow
-          'A simple module to do some stuff.',
-          'github.com/whopper/bar',
-          'forge.puppet.com/whopper/bar',
-          'tickets.foo.com/whopper/bar',
           'yes',
         ]
       end
@@ -590,13 +569,13 @@ describe PDK::Generate::Module do
 
         expect(interview_metadata).to include(
           'name'         => 'foo-bar',
-          'version'      => '2.2.0',
+          'version'      => '0.1.0',
           'author'       => 'William Hopper',
           'license'      => 'Apache-2.0',
-          'summary'      => 'A simple module to do some stuff.',
-          'source'       => 'github.com/whopper/bar',
-          'project_page' => 'forge.puppet.com/whopper/bar',
-          'issues_url'   => 'tickets.foo.com/whopper/bar',
+          'summary'      => '',
+          'source'       => '',
+          'project_page' => nil,
+          'issues_url'   => nil,
           'operatingsystem_support' => [
             {
               'operatingsystem'        => 'Debian',

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -265,7 +265,7 @@ describe PDK::Generate::Module do
 
     let(:module_name) { 'bar' }
     let(:default_metadata) { {} }
-    let(:options) { { module_name: module_name } }
+    let(:options) { { :module_name => module_name, :'full-interview' => true } }
 
     before(:each) do
       prompt = TTY::TestPrompt.new
@@ -353,7 +353,7 @@ describe PDK::Generate::Module do
     context 'when the user chooses the default values for everything' do
       include_context 'allow summary to be printed to stdout'
 
-      let(:options) { { module_name: 'bar', username: 'defaultauthor' } }
+      let(:options) { { :module_name => 'bar', :username => 'defaultauthor', :'full-interview' => true } }
       let(:default_metadata) do
         {
           'author'  => 'defaultauthor',
@@ -407,7 +407,7 @@ describe PDK::Generate::Module do
     context 'when there is no module_name provided' do
       include_context 'allow summary to be printed to stdout'
 
-      let(:options) { { license: 'MIT' } }
+      let(:options) { { :license => 'MIT', :'full-interview' => true } }
       let(:responses) do
         [
           'mymodule',
@@ -442,7 +442,7 @@ describe PDK::Generate::Module do
     context 'when the user provides the license as a command line option' do
       include_context 'allow summary to be printed to stdout'
 
-      let(:options) { { module_name: module_name, license: 'MIT' } }
+      let(:options) { { :module_name => module_name, :license => 'MIT', :'full-interview' => true } }
       let(:responses) do
         [
           'foo',
@@ -751,7 +751,7 @@ describe PDK::Generate::Module do
       let(:login) { 'test_user' }
 
       it 'warns the user and returns the login with the characters removed' do
-        expect(logger).to receive(:warn).with(a_string_matching(%r{not a valid forge username}i))
+        expect(logger).to receive(:debug).with(a_string_matching(%r{not a valid forge username}i))
         is_expected.to eq('testuser')
       end
     end
@@ -760,7 +760,7 @@ describe PDK::Generate::Module do
       let(:login) { 'Administrator' }
 
       it 'warns the user and returns the login with the characters downcased' do
-        expect(logger).to receive(:warn).with(a_string_matching(%r{not a valid forge username}i))
+        expect(logger).to receive(:debug).with(a_string_matching(%r{not a valid forge username}i))
         is_expected.to eq('administrator')
       end
     end
@@ -769,7 +769,7 @@ describe PDK::Generate::Module do
       let(:login) { 'Αρίσταρχος ό Σάμιος' }
 
       it 'warns the user and returns the string "username"' do
-        expect(logger).to receive(:warn).with(a_string_matching(%r{not a valid forge username}i))
+        expect(logger).to receive(:debug).with(a_string_matching(%r{not a valid forge username}i))
         is_expected.to eq('username')
       end
     end


### PR DESCRIPTION
PR includes:
- Removes unrequired questions from module interview
- Adds a `--full-interview` option to `new module` to ask all of the questions from the module interview.
- changes the warning about forge username sanitization to a debug msg.