### PR TITLE
(PDK-758) Initial port & cleanup of the module build code

### DIFF
--- a/lib/pdk/module/build.rb
+++ b/lib/pdk/module/build.rb
@@ -1,8 +1,186 @@
+require 'fileutils'
+require 'minitar'
+require 'zlib'
+require 'pathspec'
+require 'find'
+
 module PDK
   module Module
     class Build
-      def self.invoke(_options)
-        'pkg/dummy-path'
+      def self.invoke(options = {})
+        new(options).build
+      end
+
+      attr_reader :module_dir
+      attr_reader :target_dir
+
+      def initialize(options = {})
+        @module_dir = options[:module_dir] || Dir.pwd
+        @target_dir = options[:target_dir] || File.join(module_dir, 'pkg')
+      end
+
+      # Read and parse the values from metadata.json for the module that is
+      # being built.
+      #
+      # @return [Hash{String => Object}] The hash of metadata values.
+      def metadata
+        @metadata ||= PDK::Module::Metadata.from_file(File.join(module_dir, 'metadata.json')).data
+      end
+
+      # Return the path where the built package file will be written to.
+      def package_file
+        @package_file ||= File.join(target_dir, "#{release_name}.tar.gz")
+      end
+
+      # Build a module package from a module directory.
+      #
+      # @return [String] The path to the built package file.
+      def build
+        create_build_dir
+
+        stage_module_in_build_dir
+        build_package
+
+        package_file
+      ensure
+        cleanup_build_dir
+      end
+
+      # Return the path to the temporary build directory, which will be placed
+      # inside the target directory and match the release name (see #release_name).
+      def build_dir
+        @build_dir ||= File.join(target_dir, release_name)
+      end
+
+      # Create a temporary build directory where the files to be included in
+      # the package will be staged before building the tarball.
+      #
+      # If the directory already exists, remove it first.
+      def create_build_dir
+        cleanup_build_dir
+
+        FileUtils.mkdir_p(build_dir)
+      end
+
+      # Remove the temporary build directory and all its contents from disk.
+      #
+      # @return nil.
+      def cleanup_build_dir
+        FileUtils.rm_rf(build_dir, secure: true)
+      end
+
+      # Combine the module name and version into a Forge-compatible dash
+      # separated string.
+      #
+      # @return [String] The module name and version, joined by a dash.
+      def release_name
+        @release_name ||= [
+          metadata['name'],
+          metadata['version'],
+        ].join('-')
+      end
+
+      # Iterate through all the files and directories in the module and stage
+      # them into the temporary build directory (unless ignored).
+      #
+      # @return nil
+      def stage_module_in_build_dir
+        Find.find(module_dir) do |path|
+          next if path == module_dir
+
+          ignored_path?(path) ? Find.prune : stage_path(path)
+        end
+      end
+
+      # Stage a file or directory from the module into the build directory.
+      #
+      # @param path [String] The path to the file or directory.
+      #
+      # @return nil.
+      def stage_path(path)
+        relative_path = Pathname.new(path).relative_path_from(Pathname.new(module_dir))
+        dest_path = File.join(build_dir, relative_path)
+
+        if File.directory?(path)
+          FileUtils.mkdir_p(dest_path, mode: File.stat(path).mode)
+        elsif File.symlink?(path)
+          warn_symlink(path)
+        else
+          FileUtils.cp(path, dest_path, preserve: true)
+        end
+      end
+
+      # Check if the given path matches one of the patterns listed in the
+      # ignore file.
+      #
+      # @param path [String] The path to be checked.
+      #
+      # @return [Boolean] true if the path matches and should be ignored.
+      def ignored_path?(path)
+        path = path.to_s + '/' if File.directory?(path)
+
+        !ignored_files.match_paths([path], module_dir).empty?
+      end
+
+      # Warn the user about a symlink that would have been included in the
+      # built package.
+      #
+      # @param path [String] The relative or absolute path to the symlink.
+      #
+      # @return nil.
+      def warn_symlink(path)
+        symlink_path = Pathname.new(path)
+        module_path = Pathname.new(module_dir)
+
+        PDK.logger.warn _('Symlinks in modules are not supported and will not be included in the package. Please investigate symlink %{from} -> %{to}.') % {
+          from: symlink_path.relative_path_from(module_path),
+          to:   symlink_path.realpath.relative_path_from(module_path),
+        }
+      end
+
+      # Creates a gzip compressed tarball of the build directory.
+      #
+      # If the destination package already exists, it will be removed before
+      # creating the new tarball.
+      #
+      # @return nil.
+      def build_package
+        FileUtils.rm_f(package_file)
+
+        Zlib::GzipWriter.open(package_file) do |package_fd|
+          Minitar.pack(build_dir, package_fd)
+        end
+      end
+
+      # Select the most appropriate ignore file in the module directory.
+      #
+      # In order of preference, we first try `.pdkignore`, then `.pmtignore`
+      # and finally `.gitignore`.
+      #
+      # @return [String] The path to the file containing the patterns of file
+      #   paths to ignore.
+      def ignore_file
+        @ignore_file ||= [
+          File.join(module_dir, '.pdkignore'),
+          File.join(module_dir, '.pmtignore'),
+          File.join(module_dir, '.gitignore'),
+        ].find { |file| File.file?(file) && File.readable?(file) }
+      end
+
+      # Instantiate a new PathSpec class and populate it with the pattern(s) of
+      # files to be ignored.
+      #
+      # @return [PathSpec] The populated ignore path matcher.
+      def ignored_files
+        @ignored_files ||= if ignore_file.nil?
+                             PathSpec.new
+                           else
+                             fd = File.open(ignore_file, 'rb:UTF-8')
+                             data = fd.read
+                             fd.close
+
+                             PathSpec.new(data)
+                           end
       end
     end
   end

--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -31,6 +31,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'json-schema', '2.8.0'
   spec.add_runtime_dependency 'tty-which', '0.3.0'
   spec.add_runtime_dependency 'diff-lcs', '1.3'
+  spec.add_runtime_dependency 'minitar', '~> 0.6.1'
+  spec.add_runtime_dependency 'pathspec', '~> 0.2.1'
 
   # Used in the pdk-templates
   spec.add_runtime_dependency 'deep_merge', '~> 1.1'

--- a/spec/unit/pdk/module/build_spec.rb
+++ b/spec/unit/pdk/module/build_spec.rb
@@ -1,0 +1,339 @@
+require 'spec_helper'
+require 'pdk/module/build'
+
+describe PDK::Module::Build do
+  subject { described_class.new(initialize_options) }
+
+  let(:initialize_options) { {} }
+
+  shared_context 'with mock metadata' do
+    let(:mock_metadata) { PDK::Module::Metadata.new('name' => 'my-module') }
+
+    before(:each) do
+      allow(PDK::Module::Metadata).to receive(:from_file).with(anything).and_return(mock_metadata)
+    end
+  end
+
+  describe '.invoke' do
+    it 'creates a new PDK::Module::Build instance and calls #build' do
+      build_double = instance_double(described_class, build: true)
+
+      expect(described_class).to receive(:new).with(module_dir: 'test').and_return(build_double)
+      expect(build_double).to receive(:build)
+
+      described_class.invoke(module_dir: 'test')
+    end
+  end
+
+  describe '#initialize' do
+    before(:each) do
+      allow(Dir).to receive(:pwd).and_return(pwd)
+    end
+
+    let(:pwd) { '/path/to/my/module' }
+
+    context 'by default' do
+      it 'uses the current working directory as the module directory' do
+        is_expected.to have_attributes(module_dir: pwd)
+      end
+
+      it 'places the built packages in the pkg directory in the module' do
+        is_expected.to have_attributes(target_dir: File.join(pwd, 'pkg'))
+      end
+    end
+
+    context 'if module_dir has been customised' do
+      let(:initialize_options) do
+        {
+          module_dir: '/some/other/module',
+        }
+      end
+
+      it 'uses the provided path as the module directory' do
+        is_expected.to have_attributes(module_dir: initialize_options[:module_dir])
+      end
+
+      it 'places the built packages in the pkg directory in the module' do
+        is_expected.to have_attributes(target_dir: File.join(initialize_options[:module_dir], 'pkg'))
+      end
+    end
+
+    context 'if target_dir has been customised' do
+      let(:initialize_options) do
+        {
+          target_dir: '/tmp',
+        }
+      end
+
+      it 'uses the current working directory as the module directory' do
+        is_expected.to have_attributes(module_dir: pwd)
+      end
+
+      it 'places the built packages in the provided path' do
+        is_expected.to have_attributes(target_dir: initialize_options[:target_dir])
+      end
+    end
+
+    context 'if both module_dir and target_dir have been customised' do
+      let(:initialize_options) do
+        {
+          target_dir: '/var/cache',
+          module_dir: '/tmp/git/my-module',
+        }
+      end
+
+      it 'uses the provided module_dir path as the module directory' do
+        is_expected.to have_attributes(module_dir: initialize_options[:module_dir])
+      end
+
+      it 'places the built packages in the provided target_dir path' do
+        is_expected.to have_attributes(target_dir: initialize_options[:target_dir])
+      end
+    end
+  end
+
+  describe '#metadata' do
+    subject { described_class.new.metadata }
+
+    include_context 'with mock metadata'
+
+    it { is_expected.to be_a(Hash) }
+    it { is_expected.to include('name' => 'my-module', 'version' => '0.1.0') }
+  end
+
+  describe '#release_name' do
+    subject { described_class.new.release_name }
+
+    include_context 'with mock metadata'
+
+    it { is_expected.to eq('my-module-0.1.0') }
+  end
+
+  describe '#package_file' do
+    subject { described_class.new(target_dir: target_dir).package_file }
+
+    let(:target_dir) { '/tmp' }
+
+    include_context 'with mock metadata'
+
+    it { is_expected.to eq(File.join(target_dir, 'my-module-0.1.0.tar.gz')) }
+  end
+
+  describe '#build_dir' do
+    subject { described_class.new(target_dir: target_dir).build_dir }
+
+    let(:target_dir) { '/tmp' }
+
+    include_context 'with mock metadata'
+
+    it { is_expected.to eq(File.join(target_dir, 'my-module-0.1.0')) }
+  end
+
+  describe '#stage_module_in_build_dir' do
+    let(:instance) { described_class.new(module_dir: module_dir) }
+    let(:module_dir) { '/tmp/my-module' }
+
+    before(:each) do
+      allow(instance).to receive(:ignored_files).and_return(PathSpec.new("/spec/\n"))
+      allow(Find).to receive(:find).with(module_dir).and_yield(found_file)
+    end
+
+    after(:each) do
+      instance.stage_module_in_build_dir
+    end
+
+    context 'when it finds a non-ignored path' do
+      let(:found_file) { File.join(module_dir, 'metadata.json') }
+
+      it 'stages the path into the build directory' do
+        expect(instance).to receive(:stage_path).with(found_file)
+      end
+    end
+
+    context 'when it finds an ignored path' do
+      let(:found_file) { File.join(module_dir, 'spec', 'spec_helper.rb') }
+
+      it 'does not stage the path' do
+        expect(Find).to receive(:prune)
+        expect(instance).not_to receive(:stage_path).with(found_file)
+      end
+    end
+
+    context 'when it finds the module directory itself' do
+      let(:found_file) { module_dir }
+
+      it 'does not stage the path' do
+        expect(instance).not_to receive(:stage_path).with(module_dir)
+      end
+    end
+  end
+
+  describe '#stage_path' do
+    let(:instance) { described_class.new(module_dir: module_dir) }
+    let(:module_dir) { '/tmp/my-module' }
+    let(:path_to_stage) { File.join(module_dir, 'test') }
+    let(:path_in_build_dir) { File.join(module_dir, 'pkg', release_name, 'test') }
+    let(:release_name) { 'my-module-0.0.1' }
+
+    before(:each) do
+      allow(instance).to receive(:release_name).and_return(release_name)
+    end
+
+    after(:each) do
+      instance.stage_path(path_to_stage)
+    end
+
+    context 'when the path is a directory' do
+      before(:each) do
+        allow(File).to receive(:directory?).with(path_to_stage).and_return(true)
+        allow(File).to receive(:stat).with(path_to_stage).and_return(instance_double(File::Stat, mode: 0o100755))
+      end
+
+      it 'creates the directory in the build directory' do
+        expect(FileUtils).to receive(:mkdir_p).with(path_in_build_dir, mode: 0o100755)
+      end
+    end
+
+    context 'when the path is a symlink' do
+      before(:each) do
+        allow(File).to receive(:directory?).with(path_to_stage).and_return(false)
+        allow(File).to receive(:symlink?).with(path_to_stage).and_return(true)
+      end
+
+      it 'warns the user about the symlink and skips over it' do
+        expect(instance).to receive(:warn_symlink).with(path_to_stage)
+        expect(FileUtils).not_to receive(:mkdir_p).with(any_args)
+        expect(FileUtils).not_to receive(:cp).with(any_args)
+      end
+    end
+
+    context 'when the path is a regular file' do
+      before(:each) do
+        allow(File).to receive(:directory?).with(path_to_stage).and_return(false)
+        allow(File).to receive(:symlink?).with(path_to_stage).and_return(false)
+      end
+
+      it 'copies the file into the build directory, preserving the permissions' do
+        expect(FileUtils).to receive(:cp).with(path_to_stage, path_in_build_dir, preserve: true)
+      end
+    end
+  end
+
+  describe '#ignored_path?' do
+    let(:instance) { described_class.new(module_dir: module_dir) }
+    let(:ignore_patterns) do
+      [
+        '/vendor/',
+        'foo',
+      ]
+    end
+    let(:module_dir) { '/tmp/my-module' }
+
+    before(:each) do
+      allow(instance).to receive(:ignored_files).and_return(PathSpec.new(ignore_patterns.join("\n")))
+    end
+
+    it 'returns false for paths not matched by the patterns' do
+      expect(instance.ignored_path?(File.join(module_dir, 'bar'))).to be_falsey
+    end
+
+    it 'returns true for paths matched by the patterns' do
+      expect(instance.ignored_path?(File.join(module_dir, 'foo'))).to be_truthy
+    end
+
+    it 'returns true for children of ignored parent directories' do
+      expect(instance.ignored_path?(File.join(module_dir, 'vendor', 'test'))).to be_truthy
+    end
+  end
+
+  describe '#ignore_file' do
+    subject { described_class.new(module_dir: module_dir).ignore_file }
+
+    let(:module_dir) { '/tmp/my-module' }
+    let(:possible_files) do
+      [
+        '.pdkignore',
+        '.pmtignore',
+        '.gitignore',
+      ]
+    end
+    let(:available_files) { [] }
+
+    before(:each) do
+      available_files.each do |file|
+        file_path = File.join(module_dir, file)
+
+        allow(File).to receive(:file?).with(file_path).and_return(true)
+        allow(File).to receive(:readable?).with(file_path).and_return(true)
+      end
+
+      (possible_files - available_files).each do |file|
+        file_path = File.join(module_dir, file)
+
+        allow(File).to receive(:file?).with(file_path).and_return(false)
+        allow(File).to receive(:readable?).with(file_path).and_return(false)
+      end
+    end
+
+    context 'when none of the possible ignore files are present' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'when .gitignore is present' do
+      let(:available_files) { ['.gitignore'] }
+
+      it 'returns the path to the .gitignore file' do
+        is_expected.to eq(File.join(module_dir, '.gitignore'))
+      end
+
+      context 'and .pmtignore is present' do
+        let(:available_files) { ['.gitignore', '.pmtignore'] }
+
+        it 'returns the path to the .pmtignore file' do
+          is_expected.to eq(File.join(module_dir, '.pmtignore'))
+        end
+
+        context 'and .pdkignore is present' do
+          let(:available_files) { possible_files }
+
+          it 'returns the path to the .pdkignore file' do
+            is_expected.to eq(File.join(module_dir, '.pdkignore'))
+          end
+        end
+      end
+    end
+  end
+
+  describe '#ignored_files' do
+    subject { instance.ignored_files }
+
+    let(:module_dir) { '/tmp/my-module' }
+    let(:instance) { described_class.new(module_dir: module_dir) }
+
+    context 'when no ignore file is present in the module' do
+      before(:each) do
+        allow(instance).to receive(:ignore_file).and_return(nil)
+      end
+
+      it 'returns a empty PathSpec object' do
+        is_expected.to be_a(PathSpec)
+        is_expected.to have_attributes(specs: [])
+      end
+    end
+
+    context 'when an ignore file is present in the module' do
+      before(:each) do
+        ignore_file_path = File.join(module_dir, '.pdkignore')
+        ignore_file_content = StringIO.new "/vendor/\n"
+
+        allow(instance).to receive(:ignore_file).and_return(ignore_file_path)
+        allow(File).to receive(:open).with(ignore_file_path, 'rb:UTF-8').and_return(ignore_file_content)
+      end
+
+      it 'returns a PathSpec object populated by the ignore file' do
+        is_expected.to be_a(PathSpec)
+        is_expected.to have_attributes(specs: array_including(an_instance_of(PathSpec::GitIgnoreSpec)))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Port of the build code from PMT, with some changes to bring it inline with the PDK and unit tests. Next up, bolt this into the CLI and get some acceptance tests going.