### PR TITLE
(PDK-754) Interview for missing or Forge only metadata before build

### DIFF
--- a/lib/pdk/cli/build.rb
+++ b/lib/pdk/cli/build.rb
@@ -26,7 +26,10 @@ module PDK::CLI
       # TODO: Ensure forge metadata has been set, or call out to interview
       #       to set it.
       #
-      # module_metadata.interview_for_forge! unless module_metadata.forge_ready?
+      unless module_metadata.forge_ready?
+        module_metadata.interview_for_forge!
+        module_metadata.write!('metadata.json')
+      end
 
       builder = PDK::Module::Build.new(opts)
 

--- a/lib/pdk/module/build.rb
+++ b/lib/pdk/module/build.rb
@@ -160,8 +160,10 @@ module PDK
       def build_package
         FileUtils.rm_f(package_file)
 
-        Zlib::GzipWriter.open(package_file) do |package_fd|
-          Minitar.pack(build_dir, package_fd)
+        Dir.chdir(target_dir) do
+          Zlib::GzipWriter.open(package_file) do |package_fd|
+            Minitar.pack(release_name, package_fd)
+          end
         end
       end
 

--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -79,7 +79,20 @@ module PDK
         end
       end
 
+      def forge_ready?
+        missing_fields.empty?
+      end
+
+      def interview_for_forge!
+        PDK::Generate::Module.module_interview(self, only_ask: missing_fields)
+      end
+
       private
+
+      def missing_fields
+        fields = DEFAULTS.keys - %w[data_provider requirements dependencies]
+        fields.select { |key| @data[key].nil? || @data[key].empty? }
+      end
 
       # Do basic validation and parsing of the name parameter.
       def process_name(data)

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -274,6 +274,34 @@ describe PDK::Generate::Module do
       prompt.input.rewind
     end
 
+    context 'when only interviewing for specific missing fields' do
+      let(:options) do
+        { only_ask: ['source'] }
+      end
+
+      let(:default_metadata) do
+        {
+          'name' => 'test-module',
+        }
+      end
+
+      let(:responses) do
+        [
+          'https://something',
+          'yes',
+        ]
+      end
+
+      it 'populates the metadata object based on user input' do
+        allow($stdout).to receive(:puts).with(a_string_matching(%r{1 question}m))
+
+        expected_metadata = PDK::Module::Metadata.new.update!(default_metadata).data.dup
+        expected_metadata['source'] = 'https://something'
+
+        expect(interview_metadata).to eq(expected_metadata)
+      end
+    end
+
     context 'with --full-interview' do
       let(:options) { { :module_name => module_name, :'full-interview' => true } }
 

--- a/spec/unit/pdk/module/metadata_spec.rb
+++ b/spec/unit/pdk/module/metadata_spec.rb
@@ -62,4 +62,88 @@ describe PDK::Module::Metadata do
       expect { metadata.update!('name' => 'foo-1bar') }.to raise_error(ArgumentError, %r{Invalid 'name' field in metadata.json: module name must begin with a letter}i)
     end
   end
+
+  describe '#forge_ready?' do
+    subject { described_class.new(metadata).forge_ready? }
+
+    context 'when the metadata contains all the required fields' do
+      let(:metadata) do
+        {
+          'name'                    => 'test-module',
+          'version'                 => '0.1.0',
+          'author'                  => 'Test User',
+          'summary'                 => 'This module is amazing. Really.',
+          'license'                 => 'Apache-2.0',
+          'source'                  => 'https://github.com/puppetlabs/test-module',
+          'project_page'            => 'https://github.com/puppetlabs/test-module',
+          'issues_url'              => 'https://github.com/puppetlabs/test-module/issues',
+          'dependencies'            => [],
+          'operatingsystem_support' => [
+            {
+              'operatingsystem'        => 'Debian',
+              'operatingsystemrelease' => ['8'],
+            },
+          ],
+          'requirements' => [
+            {
+              'name'                => 'puppet',
+              'version_requirement' => '>= 4.7.0 < 6.0.0',
+            },
+          ],
+        }
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the metadata is missing fields' do
+      let(:metadata) do
+        {
+          'name'    => 'test-module',
+          'version' => '0.1.0',
+        }
+      end
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe '#interview_for_forge!' do
+    let(:metadata_instance) { described_class.new(metadata) }
+
+    after(:each) do
+      metadata_instance.interview_for_forge!
+    end
+
+    context 'when the metadata is missing fields' do
+      let(:metadata) do
+        {
+          'name'                    => 'test-module',
+          'version'                 => '0.1.0',
+          'author'                  => 'Test User',
+          'summary'                 => 'This module is amazing. Really.',
+          'license'                 => 'Apache-2.0',
+          'project_page'            => 'https://github.com/puppetlabs/test-module',
+          'issues_url'              => 'https://github.com/puppetlabs/test-module/issues',
+          'dependencies'            => [],
+          'operatingsystem_support' => [
+            {
+              'operatingsystem'        => 'Debian',
+              'operatingsystemrelease' => ['8'],
+            },
+          ],
+          'requirements' => [
+            {
+              'name'                => 'puppet',
+              'version_requirement' => '>= 4.7.0 < 6.0.0',
+            },
+          ],
+        }
+      end
+
+      it 'interviews the user for only the missing fields' do
+        expect(PDK::Generate::Module).to receive(:module_interview).with(metadata_instance, only_ask: ['source'])
+      end
+    end
+  end
 end


### PR DESCRIPTION
When the user triggers a module build via the CLI, check for any missing metadata fields (forge specific things like `source`, `issues_url`, etc) and interview the user for these specific values.