### PR TITLE
(maint) Update unit tests to use exit_zero/exit_nonzero matchers

### DIFF
--- a/spec/support/exit_with_status.rb
+++ b/spec/support/exit_with_status.rb
@@ -15,3 +15,19 @@ RSpec::Matchers.define(:exit_with_status) do |expected_status|
     expectation_passed
   end
 end
+
+RSpec::Matchers.define(:exit_zero) do
+  supports_block_expectations
+
+  match do |block|
+    expect { block.call }.to exit_with_status(0)
+  end
+end
+
+RSpec::Matchers.define(:exit_nonzero) do
+  supports_block_expectations
+
+  match do |block|
+    expect { block.call }.to exit_with_status(be_nonzero)
+  end
+end

--- a/spec/unit/pdk/cli/build_spec.rb
+++ b/spec/unit/pdk/cli/build_spec.rb
@@ -16,7 +16,7 @@ describe 'PDK::CLI build' do
     it 'exits with an error' do
       expect(logger).to receive(:error).with(a_string_matching(%r{must be run from inside a valid module}))
 
-      expect { PDK::CLI.run(['build']) }.to exit_with_status(1)
+      expect { PDK::CLI.run(['build']) }.to exit_nonzero
     end
   end
 
@@ -73,7 +73,7 @@ describe 'PDK::CLI build' do
 
         it 'outputs an error message' do
           expect(logger).to receive(:error).with(a_string_matching(%r{This module is missing required fields in the metadata.json}i))
-          expect { PDK::CLI.run(['build'] + command_opts) }.to exit_with_status(1)
+          expect { PDK::CLI.run(['build'] + command_opts) }.to exit_nonzero
         end
       end
     end
@@ -138,7 +138,7 @@ describe 'PDK::CLI build' do
         it 'cancel' do
           expect(PDK::CLI::Util).to receive(:prompt_for_yes).with(a_string_matching(%r{The file 'testuser-testmodule' already exists. Overwrite}i), default: false).and_return(false)
 
-          expect { PDK::CLI.run(['build'] + command_opts) }.to exit_with_status(0)
+          expect { PDK::CLI.run(['build'] + command_opts) }.to exit_zero
         end
       end
     end
@@ -172,7 +172,7 @@ describe 'PDK::CLI build' do
         it 'cancel' do
           expect(logger).to receive(:info).with(a_string_matching(%r{This module is not compatible with PDK}))
           expect(PDK::CLI::Util).to receive(:prompt_for_yes).with(a_string_matching(%r{Continue build without converting}i)).and_return(false)
-          expect { PDK::CLI.run(['build'] + command_opts) }.to exit_with_status(0)
+          expect { PDK::CLI.run(['build'] + command_opts) }.to exit_zero
         end
       end
     end

--- a/spec/unit/pdk/cli/convert_spec.rb
+++ b/spec/unit/pdk/cli/convert_spec.rb
@@ -9,11 +9,7 @@ describe 'PDK::CLI convert' do
     it 'exits with an error' do
       expect(logger).to receive(:error).with(a_string_matching(%r{must be run from inside a valid module}))
 
-      expect {
-        PDK::CLI.run(%w[convert])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).not_to eq(0)
-      }
+      expect { PDK::CLI.run(%w[convert]) }.to exit_nonzero
     end
   end
 
@@ -58,11 +54,7 @@ describe 'PDK::CLI convert' do
       it 'exits with an error' do
         expect(logger).to receive(:error).with(a_string_matching(%r{can not specify --noop and --force}i))
 
-        expect {
-          PDK::CLI.run(['convert', '--noop', '--force'])
-        }.to raise_error(SystemExit) { |error|
-          expect(error.status).not_to eq(0)
-        }
+        expect { PDK::CLI.run(['convert', '--noop', '--force']) }.to exit_nonzero
       end
     end
 

--- a/spec/unit/pdk/cli/module/generate_spec.rb
+++ b/spec/unit/pdk/cli/module/generate_spec.rb
@@ -9,9 +9,7 @@ describe 'Running pdk module generate' do
     it do
       expect {
         PDK::CLI.run(%w[module generate])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).to eq(1)
-      }.and output(a_string_matching(%r{^USAGE\s+pdk module generate}m)).to_stdout
+      }.to exit_nonzero.and output(a_string_matching(%r{^USAGE\s+pdk module generate}m)).to_stdout
     end
   end
 

--- a/spec/unit/pdk/cli/new/class_spec.rb
+++ b/spec/unit/pdk/cli/new/class_spec.rb
@@ -9,11 +9,7 @@ describe 'PDK::CLI new class' do
     it 'exits with an error' do
       expect(logger).to receive(:error).with(a_string_matching(%r{must be run from inside a valid module}))
 
-      expect {
-        PDK::CLI.run(%w[new class test_class])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).not_to eq(0)
-      }
+      expect { PDK::CLI.run(%w[new class test_class]) }.to exit_nonzero
     end
   end
 
@@ -24,21 +20,13 @@ describe 'PDK::CLI new class' do
 
     context 'and not provided with a class name' do
       it 'exits non-zero and prints the `pdk new class` help' do
-        expect {
-          PDK::CLI.run(%w[new class])
-        }.to raise_error(SystemExit) { |error|
-          expect(error.status).not_to eq(0)
-        }.and output(help_text).to_stdout
+        expect { PDK::CLI.run(%w[new class]) }.to exit_nonzero.and output(help_text).to_stdout
       end
     end
 
     context 'and provided an empty string as the class name' do
       it 'exits non-zero and prints the `pdk new class` help' do
-        expect {
-          PDK::CLI.run(['new', 'class', ''])
-        }.to raise_error(SystemExit) { |error|
-          expect(error.status).not_to eq(0)
-        }.and output(help_text).to_stdout
+        expect { PDK::CLI.run(['new', 'class', '']) }.to exit_nonzero.and output(help_text).to_stdout
       end
     end
 
@@ -46,11 +34,7 @@ describe 'PDK::CLI new class' do
       it 'exits with an error' do
         expect(logger).to receive(:error).with(a_string_matching(%r{'test-class' is not a valid class name}))
 
-        expect {
-          PDK::CLI.run(%w[new class test-class])
-        }.to raise_error(SystemExit) { |error|
-          expect(error.status).not_to eq(0)
-        }
+        expect { PDK::CLI.run(%w[new class test-class]) }.to exit_nonzero
       end
     end
 

--- a/spec/unit/pdk/cli/new/defined_type_spec.rb
+++ b/spec/unit/pdk/cli/new/defined_type_spec.rb
@@ -9,11 +9,7 @@ describe 'PDK::CLI new defined_type' do
 
   shared_examples 'it exits non-zero and prints the help text' do
     it 'exits non-zero and prints the `pdk new defined_type` help' do
-      expect {
-        PDK::CLI.run(args)
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).not_to be_zero
-      }.and output(help_text).to_stdout
+      expect { PDK::CLI.run(args) }.to exit_nonzero.and output(help_text).to_stdout
     end
   end
 
@@ -21,11 +17,7 @@ describe 'PDK::CLI new defined_type' do
     it 'exits with an error' do
       expect(logger).to receive(:error).with(a_string_matching(expected_error))
 
-      expect {
-        PDK::CLI.run(args)
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).not_to be_zero
-      }
+      expect { PDK::CLI.run(args) }.to exit_nonzero
     end
   end
 

--- a/spec/unit/pdk/cli/new/module_spec.rb
+++ b/spec/unit/pdk/cli/new/module_spec.rb
@@ -15,11 +15,7 @@ describe 'Running `pdk new module`' do
     it 'informs the user that the module name is invalid' do
       expect(logger).to receive(:error).with(a_string_matching(%r{'123test'.*not.*valid module name}m))
 
-      expect {
-        PDK::CLI.run(%w[new module 123test])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).to eq(1)
-      }
+      expect { PDK::CLI.run(%w[new module 123test]) }.to exit_nonzero
     end
   end
 

--- a/spec/unit/pdk/cli/new/task_spec.rb
+++ b/spec/unit/pdk/cli/new/task_spec.rb
@@ -9,11 +9,7 @@ describe 'PDK::CLI new task' do
 
   shared_examples 'it exits non-zero and prints the help text' do
     it 'exits non-zero and prints the `pdk new task` help' do
-      expect {
-        PDK::CLI.run(args)
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).not_to be_zero
-      }.and output(help_text).to_stdout
+      expect { PDK::CLI.run(args) }.to exit_nonzero.and output(help_text).to_stdout
     end
   end
 
@@ -21,11 +17,7 @@ describe 'PDK::CLI new task' do
     it 'exits with an error' do
       expect(logger).to receive(:error).with(a_string_matching(expected_error))
 
-      expect {
-        PDK::CLI.run(args)
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).not_to be_zero
-      }
+      expect { PDK::CLI.run(args) }.to exit_nonzero
     end
   end
 

--- a/spec/unit/pdk/cli/test/unit_spec.rb
+++ b/spec/unit/pdk/cli/test/unit_spec.rb
@@ -8,11 +8,7 @@ describe '`pdk test unit`' do
 
   context 'with --help' do
     it do
-      expect {
-        PDK::CLI.run(['test', 'unit', '--help'])
-      }.to raise_error(SystemExit) { |e|
-        expect(e.status).to eq 0
-      }.and output(%r{^USAGE\s+pdk test unit}m).to_stdout
+      expect { PDK::CLI.run(['test', 'unit', '--help']) }.to exit_zero.and output(%r{^USAGE\s+pdk test unit}m).to_stdout
     end
   end
 
@@ -92,11 +88,7 @@ describe '`pdk test unit`' do
         end
 
         it do
-          expect {
-            test_unit_cmd.run_this([])
-          }.to raise_error(SystemExit) { |e|
-            expect(e.status).to eq 0
-          }
+          expect { test_unit_cmd.run_this([]) }.to exit_zero
         end
 
         context 'with a format option' do
@@ -105,11 +97,7 @@ describe '`pdk test unit`' do
           end
 
           it do
-            expect {
-              test_unit_cmd.run_this(['--format=text:results.txt'])
-            }.to raise_error(SystemExit) { |e|
-              expect(e.status).to eq 0
-            }
+            expect { test_unit_cmd.run_this(['--format=text:results.txt']) }.to exit_zero
           end
         end
 
@@ -121,11 +109,7 @@ describe '`pdk test unit`' do
           end
 
           it do
-            expect {
-              test_unit_cmd.run_this(["--tests=#{tests}"])
-            }.to raise_error(SystemExit) { |e|
-              expect(e.status).to eq 0
-            }
+            expect { test_unit_cmd.run_this(["--tests=#{tests}"]) }.to exit_zero
           end
         end
       end
@@ -136,11 +120,7 @@ describe '`pdk test unit`' do
         end
 
         it do
-          expect {
-            test_unit_cmd.run_this([])
-          }.to raise_error(SystemExit) { |e|
-            expect(e.status).not_to eq 0
-          }
+          expect { test_unit_cmd.run_this([]) }.to exit_nonzero
         end
       end
     end

--- a/spec/unit/pdk/cli/update_spec.rb
+++ b/spec/unit/pdk/cli/update_spec.rb
@@ -9,11 +9,7 @@ describe 'PDK::CLI update' do
     it 'exits with an error' do
       expect(logger).to receive(:error).with(a_string_matching(%r{must be run from inside a valid module}))
 
-      expect {
-        PDK::CLI.run(%w[update])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).not_to eq(0)
-      }
+      expect { PDK::CLI.run(%w[update]) }.to exit_nonzero
     end
   end
 
@@ -50,11 +46,7 @@ describe 'PDK::CLI update' do
       it 'exits with an error' do
         expect(logger).to receive(:error).with(a_string_matching(%r{can not specify --noop and --force}i))
 
-        expect {
-          PDK::CLI.run(%w[update --noop --force])
-        }.to raise_error(SystemExit) { |error|
-          expect(error.status).not_to eq(0)
-        }
+        expect { PDK::CLI.run(%w[update --noop --force]) }.to exit_nonzero
       end
     end
   end

--- a/spec/unit/pdk/cli/validate_spec.rb
+++ b/spec/unit/pdk/cli/validate_spec.rb
@@ -22,11 +22,7 @@ describe 'Running `pdk validate` in a module' do
 
       expect(logger).to receive(:info).with('Running all available validators...')
 
-      expect {
-        PDK::CLI.run(['validate'])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).to eq(0)
-      }
+      expect { PDK::CLI.run(['validate']) }.to exit_zero
     end
 
     context 'with --parallel' do
@@ -41,11 +37,7 @@ describe 'Running `pdk validate` in a module' do
 
         expect(logger).to receive(:info).with('Running all available validators...')
 
-        expect {
-          PDK::CLI.run(['validate', '--parallel'])
-        }.to raise_error(SystemExit) { |error|
-          expect(error.status).to eq(0)
-        }
+        expect { PDK::CLI.run(['validate', '--parallel']) }.to exit_zero
       end
     end
   end
@@ -54,11 +46,7 @@ describe 'Running `pdk validate` in a module' do
     it 'lists all of the available validators and exits zero' do
       expect(logger).to receive(:info).with("Available validators: #{validator_names}")
 
-      expect {
-        PDK::CLI.run(['validate', '--list'])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).to eq(0)
-      }
+      expect { PDK::CLI.run(['validate', '--list']) }.to exit_zero
     end
   end
 
@@ -72,11 +60,7 @@ describe 'Running `pdk validate` in a module' do
         expect(v).not_to receive(:invoke)
       end
 
-      expect {
-        PDK::CLI.run(%w[validate metadata])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).to eq(0)
-      }
+      expect { PDK::CLI.run(%w[validate metadata]) }.to exit_zero
     end
   end
 
@@ -95,11 +79,7 @@ describe 'Running `pdk validate` in a module' do
         expect(validator).not_to receive(:invoke)
       end
 
-      expect {
-        PDK::CLI.run(['validate', 'puppet,metadata'])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).to eq(0)
-      }
+      expect { PDK::CLI.run(['validate', 'puppet,metadata']) }.to exit_zero
     end
   end
 
@@ -110,11 +90,7 @@ describe 'Running `pdk validate` in a module' do
       expect(logger).to receive(:warn).with(%r{Unknown validator 'bad-val'. Available validators: #{validator_names}}i)
       expect(validator).to receive(:invoke).with(report, {}).and_return(0)
 
-      expect {
-        PDK::CLI.run(['validate', 'puppet,bad-val'])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).to eq(0)
-      }
+      expect { PDK::CLI.run(['validate', 'puppet,bad-val']) }.to exit_zero
     end
   end
 
@@ -124,11 +100,7 @@ describe 'Running `pdk validate` in a module' do
     it 'invokes the specified validator with the target as an option' do
       expect(validator).to receive(:invoke).with(report, targets: ['lib/', 'manifests/']).and_return(0)
 
-      expect {
-        PDK::CLI.run(['validate', 'metadata', 'lib/', 'manifests/'])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).to eq(0)
-      }
+      expect { PDK::CLI.run(['validate', 'metadata', 'lib/', 'manifests/']) }.to exit_zero
     end
   end
 
@@ -138,11 +110,7 @@ describe 'Running `pdk validate` in a module' do
 
       expect(logger).to receive(:info).with('Running all available validators...')
 
-      expect {
-        PDK::CLI.run(['validate', 'lib/', 'manifests/'])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).to eq(0)
-      }
+      expect { PDK::CLI.run(['validate', 'lib/', 'manifests/']) }.to exit_zero
     end
   end
 
@@ -152,11 +120,7 @@ describe 'Running `pdk validate` in a module' do
       expect(report).to receive(:write_text).with($stdout)
       expect(report).not_to receive(:write_junit)
 
-      expect {
-        PDK::CLI.run(['validate'])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).to eq(0)
-      }
+      expect { PDK::CLI.run(['validate']) }.to exit_zero
     end
   end
 
@@ -166,11 +130,7 @@ describe 'Running `pdk validate` in a module' do
       expect(report).to receive(:write_junit).with($stdout)
       expect(report).not_to receive(:write_text)
 
-      expect {
-        PDK::CLI.run(['validate', '--format', 'junit'])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).to eq(0)
-      }
+      expect { PDK::CLI.run(['validate', '--format', 'junit']) }.to exit_zero
     end
   end
 
@@ -183,9 +143,7 @@ describe 'Running `pdk validate` in a module' do
 
       expect {
         PDK::CLI.run(%w[validate --format text:stderr --format junit:testfile.xml --format text])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).to eq(0)
-      }
+      }.to exit_zero
     end
   end
 end

--- a/spec/unit/pdk/cli_spec.rb
+++ b/spec/unit/pdk/cli_spec.rb
@@ -4,11 +4,8 @@ describe PDK::CLI do
   context 'when invoking help' do
     it 'outputs basic help' do
       expect($stdout).to receive(:puts).with(a_string_matching(%r{NAME.*USAGE.*DESCRIPTION.*COMMANDS.*OPTIONS}m))
-      expect {
-        described_class.run(['--help'])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).to eq(0)
-      }
+
+      expect { described_class.run(['--help']) }.to exit_zero
     end
   end
 
@@ -17,12 +14,9 @@ describe PDK::CLI do
       include_context 'run outside module'
 
       it 'informs the user that this is not a module folder' do
-        expect {
-          described_class.run(command.split(' '))
-        }.to raise_error(SystemExit) { |error|
-          expect(error.status).not_to eq(0)
-          expect(error.cause.to_s).to match(%r{no metadata\.json found}i)
-        }
+        expect(logger).to receive(:error).with(a_string_matching(%r{no metadata\.json found}i))
+
+        expect { described_class.run(command.split(' ')) }.to exit_nonzero
       end
     end
   end
@@ -31,11 +25,7 @@ describe PDK::CLI do
     it 'informs the user and exits' do
       expect(logger).to receive(:error).with(a_string_matching(%r{'non_existant_format'.*valid report format}))
 
-      expect {
-        described_class.run(['--format', 'non_existant_format'])
-      }.to raise_error(SystemExit) { |error|
-        expect(error.status).not_to eq(0)
-      }
+      expect { described_class.run(%w[--format non_existant_format]) }.to exit_nonzero
     end
   end
 

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -518,9 +518,7 @@ describe PDK::Generate::Module do
         allow(logger).to receive(:info).with(a_string_matching(%r{interview cancelled}i))
         allow($stdout).to receive(:puts).with(a_string_matching(%r{4 questions}m))
 
-        expect { interview_metadata }.to raise_error(SystemExit) { |error|
-          expect(error.status).to eq(0)
-        }
+        expect { interview_metadata }.to exit_zero
       end
     end
 
@@ -541,9 +539,7 @@ describe PDK::Generate::Module do
         allow(logger).to receive(:info).with(a_string_matching(%r{Process cancelled; exiting.}i))
         allow($stdout).to receive(:puts).with(a_string_matching(%r{4 questions}m))
 
-        expect { interview_metadata }.to raise_error(SystemExit) { |error|
-          expect(error.status).to eq(0)
-        }
+        expect { interview_metadata }.to exit_zero
       end
     end
 


### PR DESCRIPTION
Adds a couple of convenience aliases to the `exit_with_status` matcher introduced in #423 to test the two common cases: exiting 0 (`exit_zero`) and exiting not zero (`exit_nonzero`). Updated the rest of the unit tests to use the new matcher.