### PR TITLE
(FIXUP) Make `pdk build` overwrite prompt consistent

### DIFF
--- a/lib/pdk/cli/build.rb
+++ b/lib/pdk/cli/build.rb
@@ -40,12 +40,9 @@ module PDK::CLI
 
       unless opts[:force]
         if builder.package_already_exists?
-          continue = PDK::CLI::Util.prompt_for_yes(
-            _("The file '%{package}' already exists. Overwrite?") % { package: builder.package_file },
-            default: false,
-          )
+          PDK.logger.info _("The file '%{package}' already exists.") % { package: builder.package_file }
 
-          unless continue
+          unless PDK::CLI::Util.prompt_for_yes(_('Overwrite?'), default: false)
             PDK.logger.info _('Build cancelled; exiting.')
             exit 0
           end
@@ -55,6 +52,7 @@ module PDK::CLI
           PDK.logger.info _('This module is not compatible with PDK, so PDK can not validate or test this build. ' \
                             'Unvalidated modules may have errors when uploading to the Forge. ' \
                             'To make this module PDK compatible and use validate features, cancel the build and run `pdk convert`.')
+
           unless PDK::CLI::Util.prompt_for_yes(_('Continue build without converting?'))
             PDK.logger.info _('Build cancelled; exiting.')
             exit 0

--- a/spec/unit/pdk/cli/build_spec.rb
+++ b/spec/unit/pdk/cli/build_spec.rb
@@ -125,7 +125,8 @@ describe 'PDK::CLI build' do
         end
 
         it 'continue to build' do
-          expect(PDK::CLI::Util).to receive(:prompt_for_yes).with(a_string_matching(%r{The file 'testuser-testmodule' already exists. Overwrite}i), default: false).and_return(true)
+          expect(logger).to receive(:info).with(a_string_matching(%r{The file 'testuser-testmodule' already exists}i))
+          expect(PDK::CLI::Util).to receive(:prompt_for_yes).with(a_string_matching(%r{Overwrite}i), default: false).and_return(true)
         end
       end
 
@@ -136,7 +137,8 @@ describe 'PDK::CLI build' do
         end
 
         it 'cancel' do
-          expect(PDK::CLI::Util).to receive(:prompt_for_yes).with(a_string_matching(%r{The file 'testuser-testmodule' already exists. Overwrite}i), default: false).and_return(false)
+          expect(logger).to receive(:info).with(a_string_matching(%r{The file 'testuser-testmodule' already exists}i))
+          expect(PDK::CLI::Util).to receive(:prompt_for_yes).with(a_string_matching(%r{Overwrite}i), default: false).and_return(false)
 
           expect { PDK::CLI.run(['build'] + command_opts) }.to exit_with_status(0)
         end


### PR DESCRIPTION
This was something I noticed during the demo today, that the overwrite prompt was the only thing that wasn't prefixed with the standard logger stuff.