### PR TITLE
Update validation regex and error message for module name question

### DIFF
--- a/lib/pdk/generate/module.rb
+++ b/lib/pdk/generate/module.rb
@@ -154,8 +154,8 @@ module PDK
             question:         _('If you have a name for your module, add it here.'),
             help:             _('This is the name that will be associated with your module, it should be relevant to the modules content.'),
             required:         true,
-            validate_pattern: %r{\A[a-z0-9]+\Z}i,
-            validate_message: _('Module names can only contain lowercase letters and numbers'),
+            validate_pattern: %r{\A[a-z][a-z0-9_]*\Z}i,
+            validate_message: _('Module names must begin with a lowercase letter and can only include lowercase letters, numbers, and underscores.'),
           },
           {
             name:             'forge_username',


### PR DESCRIPTION
PDK does not correctly validate module names if a module name is not supplied to `pdk new module`.

The user question prompts for a module name but fails to pass underscores as valid.

- `pdk new module test_name` will pass
- `pdk new module` will fail on `test_name` given as the module name.

This update uses the regex [referred to in the docs](https://puppet.com/docs/puppet/5.4/modules_fundamentals.html#module-names) for validating module names. 

I have included a similar error message to the options validation line, while referring to "numbers" as the docs do.