### PR TITLE
(maint) update: don't mention deleted Gemfile.lock and .bundle/config

### DIFF
--- a/lib/pdk/module/convert.rb
+++ b/lib/pdk/module/convert.rb
@@ -40,11 +40,10 @@ module PDK
           return unless continue
         end
 
-        # Mark these files for removal after generating the report as these
-        # changes are not something that the user needs to review.
+        # Remove these files straight away as these changes are not something that the user needs to review.
         if needs_bundle_update?
-          update_manager.remove_file('Gemfile.lock')
-          update_manager.remove_file(File.join('.bundle', 'config'))
+          update_manager.unlink_file('Gemfile.lock')
+          update_manager.unlink_file(File.join('.bundle', 'config'))
         end
 
         update_manager.sync_changes!

--- a/lib/pdk/module/update.rb
+++ b/lib/pdk/module/update.rb
@@ -31,9 +31,10 @@ module PDK
           return unless PDK::CLI::Util.prompt_for_yes(message)
         end
 
+        # Remove these files straight away as these changes are not something that the user needs to review.
         if needs_bundle_update?
-          update_manager.remove_file('Gemfile.lock')
-          update_manager.remove_file(File.join('.bundle', 'config'))
+          update_manager.unlink_file('Gemfile.lock')
+          update_manager.unlink_file(File.join('.bundle', 'config'))
         end
 
         update_manager.sync_changes!

--- a/lib/pdk/module/update_manager.rb
+++ b/lib/pdk/module/update_manager.rb
@@ -95,6 +95,29 @@ module PDK
         end
       end
 
+      # Remove a file from disk.
+      #
+      # Like FileUtils.rm_f, this method will not fail if the file does not
+      # exist. Unlike FileUtils.rm_f, this method will not blindly swallow all
+      # exceptions.
+      #
+      # @param path [String] The path to the file to be removed.
+      #
+      # @raise [PDK::CLI::ExitWithError] if the file could not be removed.
+      def unlink_file(path)
+        if File.file?(path)
+          PDK.logger.debug(_("unlinking '%{path}'") % { path: path })
+          FileUtils.rm(path)
+        else
+          PDK.logger.debug(_("'%{path}': already gone") % { path: path })
+        end
+      rescue => e
+        raise PDK::CLI::ExitWithError, _("Unable to remove '%{path}': %{message}") % {
+          path:    path,
+          message: e.message,
+        }
+      end
+
       private
 
       # Loop through all the files to be modified and cache of unified diff of
@@ -128,29 +151,6 @@ module PDK
         File.open(path, 'w') { |f| f.puts content }
       rescue Errno::EACCES
         raise PDK::CLI::ExitWithError, _("You do not have permission to write to '%{path}'") % { path: path }
-      end
-
-      # Remove a file from disk.
-      #
-      # Like FileUtils.rm_f, this method will not fail if the file does not
-      # exist. Unlink FileUtils.rm_f, this method will not blindly swallow all
-      # exceptions.
-      #
-      # @param path [String] The path to the file to be removed.
-      #
-      # @raise [PDK::CLI::ExitWithError] if the file could not be removed.
-      def unlink_file(path)
-        if File.file?(path)
-          PDK.logger.debug(_("unlinking '%{path}'") % { path: path })
-          FileUtils.rm(path)
-        else
-          PDK.logger.debug(_("'%{path}': already gone") % { path: path })
-        end
-      rescue => e
-        raise PDK::CLI::ExitWithError, _("Unable to remove '%{path}': %{message}") % {
-          path:    path,
-          message: e.message,
-        }
       end
 
       # Generate a unified diff of the changes to be made to a file.

--- a/spec/unit/pdk/module/convert_spec.rb
+++ b/spec/unit/pdk/module/convert_spec.rb
@@ -135,6 +135,7 @@ describe PDK::Module::Convert do
         allow($stdout).to receive(:puts).with(%r{1 files modified})
         allow(update_manager).to receive(:changed?).with('Gemfile').and_return(true)
         allow(update_manager).to receive(:remove_file).with(anything)
+        allow(update_manager).to receive(:unlink_file).with(anything)
         allow(PDK::Util::Bundler).to receive(:ensure_bundle!)
         allow($stdout).to receive(:puts).with(%r{You can find a report of differences in convert_report.txt.})
       end
@@ -146,11 +147,11 @@ describe PDK::Module::Convert do
       end
 
       it 'removes the old Gemfile.lock' do
-        expect(update_manager).to receive(:remove_file).with('Gemfile.lock')
+        expect(update_manager).to receive(:unlink_file).with('Gemfile.lock')
       end
 
       it 'removes the old bundler config' do
-        expect(update_manager).to receive(:remove_file).with(File.join('.bundle', 'config'))
+        expect(update_manager).to receive(:unlink_file).with(File.join('.bundle', 'config'))
       end
 
       it 'updates the bundled gems' do

--- a/spec/unit/pdk/module/update_spec.rb
+++ b/spec/unit/pdk/module/update_spec.rb
@@ -26,15 +26,16 @@ describe PDK::Module::Update do
       before(:each) do
         allow(instance).to receive(:needs_bundle_update?).and_return(true)
         allow(instance.update_manager).to receive(:remove_file)
+        allow(instance.update_manager).to receive(:unlink_file)
         allow(PDK::Util::Bundler).to receive(:ensure_bundle!)
       end
 
       it 'removes the existing Gemfile.lock' do
-        expect(instance.update_manager).to receive(:remove_file).with('Gemfile.lock')
+        expect(instance.update_manager).to receive(:unlink_file).with('Gemfile.lock')
       end
 
       it 'removes the bundler project config' do
-        expect(instance.update_manager).to receive(:remove_file).with(File.join('.bundle', 'config'))
+        expect(instance.update_manager).to receive(:unlink_file).with(File.join('.bundle', 'config'))
       end
 
       it 'triggers a bundle install' do


### PR DESCRIPTION
Previously, when running pdk update, note how in the second case there were "2 files removed":
```
david@davids:~/git/tmp/bar$ rm -f .travis.yml; ~/git/pdk/bin/pdk update --force
pdk (INFO): Updating david-bar using the template at file:///opt/puppetlabs/pdk/share/cache/pdk-templates.git, from 1.4.1 to master@52adbbb

------------Files to be added-----------
.travis.yml

----------------------------------------

------------Update completed------------

1 files added.

david@davids:~/git/tmp/bar$ rm -f Gemfile ; ~/git/pdk/bin/pdk update --force
pdk (INFO): Updating david-bar using the template at file:///opt/puppetlabs/pdk/share/cache/pdk-templates.git, from 1.4.1 to master@52adbbb

------------Files to be added-----------
Gemfile

----------------------------------------
[✔] Resolving Gemfile dependencies.

------------Update completed------------

1 files added, 2 files removed.

david@davids:~/git/tmp/bar$
```

Since the files are not mentioned in the report, this could be very
confusing to users. With this patch, the files are still removed, but
the summary doesn't show them any more:

```
david@davids:~/git/tmp/bar$ rm -f Gemfile ; ~/git/pdk/bin/pdk update --force
pdk (INFO): Updating david-bar using the template at file:///opt/puppetlabs/pdk/share/cache/pdk-templates.git, from 1.4.1 to master@52adbbb

------------Files to be added-----------
Gemfile

----------------------------------------
[✔] Resolving Gemfile dependencies.

------------Update completed------------

1 files added.

david@davids:~/git/tmp/bar$
```