### PR TITLE
(maint) add a `pdk module build` command to point to `pdk build`

### DIFF
--- a/lib/pdk/cli/module.rb
+++ b/lib/pdk/cli/module.rb
@@ -10,4 +10,5 @@ module PDK::CLI
   @module_cmd.add_command Cri::Command.new_basic_help
 end
 
+require 'pdk/cli/module/build'
 require 'pdk/cli/module/generate'

--- a/lib/pdk/cli/module/build.rb
+++ b/lib/pdk/cli/module/build.rb
@@ -1,0 +1,14 @@
+require 'tty-prompt'
+
+module PDK::CLI
+  @module_build_cmd = @module_cmd.define_command do
+    name 'build'
+    usage _('build')
+    summary _('This command is now \'pdk build\'.')
+
+    run do |_opts, _args, _cmd|
+      PDK.logger.warn(_('Modules are built using the ‘pdk build’ command.'))
+      exit 1
+    end
+  end
+end

--- a/spec/unit/pdk/cli/module/build_spec.rb
+++ b/spec/unit/pdk/cli/module/build_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'Running pdk module build' do
+  subject { PDK::CLI.instance_variable_get(:@module_build_cmd) }
+
+  describe 'when called' do
+    it do
+      expect(logger).to receive(:warn).with(%r{Modules are built using the ‘pdk build’ command}i)
+      expect {
+        PDK::CLI.run(%w[module build])
+      }.to exit_nonzero
+    end
+  end
+end

--- a/spec/unit/pdk/cli/module/generate_spec.rb
+++ b/spec/unit/pdk/cli/module/generate_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Running pdk module generate' do
-  subject { PDK::CLI.instance_variable_get(:@new_module_cmd) }
+  subject { PDK::CLI.instance_variable_get(:@module_generate_cmd) }
 
   let(:module_name) { 'foo' }
 


### PR DESCRIPTION
This is a UI hint similar to `pdk module generate` to point folks used
to the puppet faces towards the new pdk commands.