### PR TITLE
(PDK-785) Add --puppet-version and --pe-version CLI options

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -11,6 +11,7 @@ require 'pdk/i18n'
 require 'pdk/logger'
 require 'pdk/report'
 require 'pdk/util/version'
+require 'pdk/util/puppet_version'
 
 module PDK::CLI
   def self.run(args)
@@ -47,6 +48,16 @@ module PDK::CLI
 
   def self.full_interview_option(dsl)
     dsl.option nil, 'full-interview', _('When specified, interactive querying of metadata will include all optional questions.')
+  end
+
+  def self.puppet_version_options(dsl)
+    dsl.option nil, 'puppet-version', _('Puppet version to run tests or validations against.'), argument: :required do |value|
+      PDK::Util::PuppetVersion.find_gem_for(value)
+    end
+
+    dsl.option nil, 'pe-version', _('Puppet Enterprise version to run tests or validations against.'), argument: :required do |value|
+      PDK::Util::PuppetVersion.from_pe_version(value)
+    end
   end
 
   @base_cmd = Cri::Command.define do

--- a/lib/pdk/cli/test/unit.rb
+++ b/lib/pdk/cli/test/unit.rb
@@ -7,6 +7,7 @@ module PDK::CLI
     usage _('unit [options]')
     summary _('Run unit tests.')
 
+    PDK::CLI.puppet_version_options(self)
     flag nil, :list, _('List all available unit test files.')
     flag nil, :parallel, _('Run unit tests in parallel.'), hidden: true
     flag :v, :verbose, _('More verbose output. Displays examples in each unit test file.')
@@ -20,6 +21,10 @@ module PDK::CLI
 
     run do |opts, _args, _cmd|
       require 'pdk/tests/unit'
+
+      if opts[:'puppet-version'] && opts[:'pe-version']
+        raise PDK::CLI::ExitWithError, _('You can not specify both --puppet-version and --pe-version at the same time.')
+      end
 
       PDK::CLI::Util.ensure_in_module!(
         message:   _('Unit tests can only be run from inside a valid module directory.'),

--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -13,6 +13,7 @@ module PDK::CLI
       'If not specified, validators are run against all applicable files in the module.',
     )
 
+    PDK::CLI.puppet_version_options(self)
     flag nil, :list, _('List all available validators.')
     flag :a, 'auto-correct', _('Automatically correct problems where possible.')
     flag nil, :parallel, _('Run validations in parallel.')
@@ -30,6 +31,10 @@ module PDK::CLI
       if opts[:list]
         PDK.logger.info(_('Available validators: %{validator_names}') % { validator_names: validator_names.join(', ') })
         exit 0
+      end
+
+      if opts[:'puppet-version'] && opts[:'pe-version']
+        raise PDK::CLI::ExitWithError, _('You can not specify both --puppet-version and --pe-version at the same time.')
       end
 
       PDK::CLI::Util.ensure_in_module!(

--- a/lib/pdk/util/puppet_version.rb
+++ b/lib/pdk/util/puppet_version.rb
@@ -1,0 +1,130 @@
+require 'pdk/util'
+
+module PDK
+  module Util
+    class PuppetVersion
+      class << self
+        extend Forwardable
+
+        def_delegators :instance, :find_gem_for, :from_pe_version
+
+        attr_writer :instance
+
+        def instance
+          @instance ||= new
+        end
+      end
+
+      def find_gem_for(version_str)
+        ensure_semver_version!(version_str)
+        version = Gem::Version.new(version_str)
+
+        exact_requirement = Gem::Requirement.create(version)
+        gem_version = find_gem(exact_requirement)
+        return gem_version.version unless gem_version.nil?
+
+        latest_requirement = Gem::Requirement.create("#{version.approximate_recommendation}.0")
+        gem_version = find_gem(latest_requirement)
+        unless gem_version.nil?
+          PDK.logger.info _('Unable to find Puppet %{requested_version}, using %{found_version} instead') % {
+            requested_version: version_str,
+            found_version:     gem_version.version,
+          }
+          return gem_version.version
+        end
+
+        raise ArgumentError, _('Unable to find a Puppet version matching %{requirement}') % {
+          requirement: latest_requirement,
+        }
+      end
+
+      def from_pe_version(version_str)
+        ensure_semver_version!(version_str)
+
+        version = Gem::Version.new(version_str)
+        gem_version = pe_version_map.find do |version_map|
+          version_map[:requirement].satisfied_by?(version)
+        end
+
+        if gem_version.nil?
+          raise ArgumentError, _('Unable to map Puppet Enterprise version %{pe_version} to a Puppet version') % {
+            pe_version: version_str,
+          }
+        end
+
+        PDK.logger.info _('Puppet Enterprise %{pe_version} maps to Puppet %{puppet_version}') % {
+          pe_version:     version_str,
+          puppet_version: gem_version[:gem_version],
+        }
+        find_gem_for(gem_version[:gem_version])
+      end
+
+      private
+
+      def ensure_semver_version!(version_str)
+        return if version_str =~ %r{\A\d+\.\d+\.\d+\Z}
+
+        raise ArgumentError, _('%{version} is not a valid version number') % {
+          version: version_str,
+        }
+      end
+
+      def pe_version_map
+        @pe_version_map ||= fetch_pe_version_map.map do |version_map|
+          {
+            requirement: requirement_from_forge_range(version_map['name']),
+            gem_version: version_map['puppet'],
+          }
+        end
+      end
+
+      # TODO: Replace this with a cached forge lookup like we do for the task
+      # metadata schema (PDK-828)
+      def fetch_pe_version_map
+        [
+          { 'name' => '2017.3.x', 'puppet_range' => '5.3.x',  'puppet' => '5.3.2'  },
+          { 'name' => '2017.2.x', 'puppet_range' => '4.10.x', 'puppet' => '4.10.1' },
+          { 'name' => '2017.1.x', 'puppet_range' => '4.9.x',  'puppet' => '4.9.4'  },
+          { 'name' => '2016.5.x', 'puppet_range' => '4.8.x',  'puppet' => '4.8.1'  },
+          { 'name' => '2016.4.x', 'puppet_range' => '4.7.x',  'puppet' => '4.7.0'  },
+          { 'name' => '2016.2.x', 'puppet_range' => '4.5.x',  'puppet' => '4.5.2'  },
+          { 'name' => '2016.1.x', 'puppet_range' => '4.4.x',  'puppet' => '4.4.1'  },
+          { 'name' => '2015.3.x', 'puppet_range' => '4.3.x',  'puppet' => '4.3.2'  },
+          { 'name' => '2015.2.x', 'puppet_range' => '4.2.x',  'puppet' => '4.2.3'  },
+        ]
+      end
+
+      def requirement_from_forge_range(range_str)
+        range_str.gsub!(%r{\.x\Z}, '.0')
+        Gem::Requirement.create("~> #{range_str}")
+      end
+
+      def rubygems_puppet_versions
+        return @rubygems_puppet_versions unless @rubygems_puppet_versions.nil?
+
+        fetcher = Gem::SpecFetcher.fetcher
+        puppet_tuples = fetcher.detect(:released) do |spec_tuple|
+          spec_tuple.name == 'puppet' && Gem::Platform.match(spec_tuple.platform)
+        end
+        puppet_versions = puppet_tuples.map { |name, _| name.version }.uniq
+        @rubygems_puppet_versions = puppet_versions.sort { |a, b| b <=> a }
+      end
+
+      def find_gem(requirement)
+        if PDK::Util.package_install?
+          find_in_package_cache(requirement)
+        else
+          find_in_rubygems(requirement)
+        end
+      end
+
+      def find_in_rubygems(requirement)
+        rubygems_puppet_versions.find { |r| requirement.satisfied_by?(r) }
+      end
+
+      def find_in_package_cache(requirement)
+        PDK::Util::RubyVersion.available_puppet_versions.find { |r| requirement.satisfied_by?(r) }
+      end
+    end
+  end
+end

--- a/lib/pdk/util/ruby_version.rb
+++ b/lib/pdk/util/ruby_version.rb
@@ -1,0 +1,77 @@
+require 'pdk/util'
+
+module PDK
+  module Util
+    class RubyVersion
+      class << self
+        extend Forwardable
+
+        def_delegators :instance, :gem_path, :gem_home, :versions, :available_puppet_versions
+
+        attr_writer :instance
+
+        def instance
+          @instance ||= new
+        end
+      end
+
+      attr_reader :active_ruby_version
+
+      def initialize
+        @active_ruby_version = default_ruby_version
+      end
+
+      def gem_path
+        if PDK::Util.package_install?
+          # Subprocesses use their own set of gems which are managed by pdk or
+          # installed with the package.
+          File.join(PDK::Util.package_cachedir, 'ruby', versions[active_ruby_version])
+        else
+          # This allows the subprocess to find the 'bundler' gem, which isn't
+          # in the cachedir above for gem installs.
+          # TODO: There must be a better way to do this than shelling out to
+          # gem...
+          File.absolute_path(File.join(`gem which bundler`, '..', '..', '..', '..'))
+        end
+      end
+
+      def gem_home
+        # `bundle install --path` ignores all "system" installed gems and
+        # causes unnecessary package installs. `bundle install` (without
+        # --path) installs into GEM_HOME, which by default is non-user
+        # writeable.
+        # To still use the pre-installed packages, but allow folks to install
+        # additional gems, we set GEM_HOME to the user's cachedir and put all
+        # other cache locations onto GEM_PATH.
+        # See https://stackoverflow.com/a/11277228 for background
+        File.join(PDK::Util.cachedir, 'ruby', versions[active_ruby_version])
+      end
+
+      def versions
+        @versions ||= if PDK::Util.package_install?
+                        scan_for_packaged_rubies
+                      else
+                        { RbConfig::CONFIG['RUBY_PROGRAM_VERSION'] => RbConfig::CONFIG['ruby_version'] }
+                      end
+      end
+
+      def available_puppet_versions
+        return @available_puppet_versions unless @available_puppet_versions.nil?
+        puppet_spec_files = Dir[File.join(gem_path, 'specifications', '**', 'puppet*.gemspec')]
+        puppet_spec_files += Dir[File.join(gem_home, 'specifications', '**', 'puppet*.gemspec')]
+        puppet_specs = puppet_spec_files.map { |r| Gem::Specification.load(r) }
+        @available_puppet_versions = puppet_specs.select { |r| r.name == 'puppet' }.map { |r| r.version }.sort { |a, b| b <=> a }
+      end
+
+      private
+
+      def scan_for_packaged_rubies
+        { '2.1.9' => '2.1.0' }
+      end
+
+      def default_ruby_version
+        versions.keys.sort { |a, b| Gem::Version.new(b) <=> Gem::Version.new(a) }.first
+      end
+    end
+  end
+end

--- a/spec/unit/pdk/cli/test/unit_spec.rb
+++ b/spec/unit/pdk/cli/test/unit_spec.rb
@@ -125,4 +125,19 @@ describe '`pdk test unit`' do
       end
     end
   end
+
+  context 'when --puppet-version and --pe-version are specified' do
+    before(:each) do
+      allow(PDK::Util::PuppetVersion).to receive(:find_gem_for).with('4.10.10').and_return('4.10.10')
+      allow(PDK::Util::PuppetVersion).to receive(:from_pe_version).with('2018.1.1').and_return('4.10.10')
+    end
+
+    it 'exits with an error' do
+      expect(logger).to receive(:error).with(a_string_matching(%r{both --puppet-version and --pe-version}i))
+
+      expect {
+        PDK::CLI.run(%w[test unit --puppet-version 4.10.10 --pe-version 2018.1.1])
+      }.to exit_nonzero
+    end
+  end
 end

--- a/spec/unit/pdk/cli/validate_spec.rb
+++ b/spec/unit/pdk/cli/validate_spec.rb
@@ -146,4 +146,19 @@ describe 'Running `pdk validate` in a module' do
       }.to exit_zero
     end
   end
+
+  context 'when --puppet-version and --pe-version are specified' do
+    before(:each) do
+      allow(PDK::Util::PuppetVersion).to receive(:find_gem_for).with('4.10.10').and_return('4.10.10')
+      allow(PDK::Util::PuppetVersion).to receive(:from_pe_version).with('2018.1.1').and_return('4.10.10')
+    end
+
+    it 'exits with an error' do
+      expect(logger).to receive(:error).with(a_string_matching(%r{both --puppet-version and --pe-version}i))
+
+      expect {
+        PDK::CLI.run(%w[validate --puppet-version 4.10.10 --pe-version 2018.1.1])
+      }.to exit_nonzero
+    end
+  end
 end

--- a/spec/unit/pdk/util/puppet_version_spec.rb
+++ b/spec/unit/pdk/util/puppet_version_spec.rb
@@ -1,0 +1,211 @@
+require 'spec_helper'
+require 'pdk/util/puppet_version'
+
+describe PDK::Util::PuppetVersion do
+  shared_context 'with a mocked rubygems response' do
+    before(:each) do
+      mock_fetcher = instance_double(Gem::SpecFetcher)
+      allow(Gem::SpecFetcher).to receive(:fetcher).and_return(mock_fetcher)
+
+      mock_response = rubygems_versions.map do |version|
+        [Gem::NameTuple.new('puppet', Gem::Version.new(version), Gem::Platform.local), nil]
+      end
+
+      allow(mock_fetcher).to receive(:detect).with(:released).and_return(mock_response)
+    end
+  end
+
+  shared_context 'is not a package install' do
+    before(:each) do
+      allow(PDK::Util).to receive(:package_install?).and_return(false)
+    end
+  end
+
+  shared_context 'is a package install' do
+    before(:each) do
+      allow(PDK::Util).to receive(:package_install?).and_return(true)
+
+      mock_response = cache_versions.map { |r| Gem::Version.new(r) }
+      allow(PDK::Util::RubyVersion).to receive(:available_puppet_versions).and_return(mock_response)
+    end
+  end
+
+  let(:rubygems_versions) do
+    %w[
+      5.4.0
+      5.3.5 5.3.4 5.3.3 5.3.2 5.3.1 5.3.0
+      5.2.0
+      5.1.0
+      5.0.1 5.0.0
+      4.10.10 4.10.9 4.10.8 4.10.7 4.10.6 4.10.5 4.10.4 4.10.1 4.10.0
+      4.9.4 4.9.3 4.9.2 4.9.1 4.9.0
+      4.8.2 4.8.1 4.8.0
+      4.7.1 4.7.0
+      4.6.2 4.6.1 4.6.0
+      4.5.3 4.5.2 4.5.1 4.5.0
+      4.4.2 4.4.1 4.4.0
+      4.3.2 4.3.1 4.3.0
+      4.2.3 4.2.2 4.2.1 4.2.0
+    ]
+  end
+
+  let(:cache_versions) do
+    %w[5.4.0 5.3.5 4.10.10 4.8.1 4.9.4 4.7.0 4.5.3 4.4.2]
+  end
+
+  describe '.find_gem_for' do
+    context 'when running from a package install' do
+      include_context 'is a package install'
+
+      it 'raises an ArgumentError if passed a non X.Y.Z version' do
+        expect {
+          described_class.find_gem_for('5')
+        }.to raise_error(ArgumentError, %r{not a valid version number}i)
+      end
+
+      it 'returns the specified version if it exists in the cache' do
+        expect(described_class.find_gem_for('5.3.5')).to eq('5.3.5')
+      end
+
+      context 'when the specified version does not exist in the cache' do
+        it 'notifies the user that it is using the latest Z release instead' do
+          expect(logger).to receive(:info).with(a_string_matching(%r{using 5\.3\.5 instead}i))
+          described_class.find_gem_for('5.3.1')
+        end
+
+        it 'returns the latest Z release' do
+          expect(described_class.find_gem_for('5.3.1')).to eq('5.3.5')
+        end
+
+        it 'raises an ArgumentError if no version can be found' do
+          expect {
+            described_class.find_gem_for('1.0.0')
+          }.to raise_error(ArgumentError, %r{unable to find a puppet version}i)
+        end
+      end
+    end
+
+    context 'when not running from a package install' do
+      include_context 'is not a package install'
+      include_context 'with a mocked rubygems response'
+
+      it 'raises an ArgumentError if passed a non X.Y.Z version' do
+        expect {
+          described_class.find_gem_for('5')
+        }.to raise_error(ArgumentError, %r{not a valid version number}i)
+      end
+
+      it 'returns the specified version if it exists on Rubygems' do
+        expect(described_class.find_gem_for('4.9.0')).to eq('4.9.0')
+      end
+
+      context 'when the specified version does not exist on Rubygems' do
+        it 'notifies the user that it is using the latest Z release instead' do
+          expect(logger).to receive(:info).with(a_string_matching(%r{using 4\.10\.10 instead}i))
+          described_class.find_gem_for('4.10.999')
+        end
+
+        it 'returns the latest Z release' do
+          expect(described_class.find_gem_for('4.10.999')).to eq('4.10.10')
+        end
+
+        it 'raises an ArgumentError if no version can be found' do
+          expect {
+            described_class.find_gem_for('1.0.0')
+          }.to raise_error(ArgumentError, %r{unable to find a puppet version}i)
+        end
+      end
+    end
+  end
+
+  describe '.from_pe_version' do
+    context 'when running from a package install' do
+      include_context 'is a package install'
+
+      it 'raises an ArgumentError if passed a non X.Y.Z version' do
+        expect {
+          described_class.from_pe_version('5')
+        }.to raise_error(ArgumentError, %r{not a valid version number}i)
+      end
+
+      it 'returns the latest Puppet Z release for PE 2017.3.x' do
+        expect(described_class.from_pe_version('2017.3.1')).to eq('5.3.5')
+      end
+
+      it 'returns the latest Puppet Z release for PE 2017.2.x' do
+        expect(described_class.from_pe_version('2017.2.1')).to eq('4.10.10')
+      end
+
+      it 'returns the latest Puppet Z release for PE 2017.1.x' do
+        expect(described_class.from_pe_version('2017.1.1')).to eq('4.9.4')
+      end
+
+      it 'returns the latest Puppet Z release for PE 2016.5.x' do
+        expect(described_class.from_pe_version('2016.5.1')).to eq('4.8.1')
+      end
+
+      it 'returns the latest Puppet Z release for PE 2016.4.x' do
+        expect(described_class.from_pe_version('2016.4.1')).to eq('4.7.0')
+      end
+
+      it 'returns the latest Puppet Z release for PE 2016.2.x' do
+        expect(described_class.from_pe_version('2016.2.1')).to eq('4.5.3')
+      end
+
+      it 'returns the latest Puppet Z release for PE 2016.1.x' do
+        expect(described_class.from_pe_version('2016.1.1')).to eq('4.4.2')
+      end
+
+      it 'raises an ArgumentError if given an unknown PE version' do
+        expect {
+          described_class.from_pe_version('9999.1.1')
+        }.to raise_error(ArgumentError, %r{unable to map puppet enterprise version}i)
+      end
+    end
+
+    context 'when not running from a package install' do
+      include_context 'is not a package install'
+      include_context 'with a mocked rubygems response'
+
+      it 'raises an ArgumentError if passed a non X.Y.Z version' do
+        expect {
+          described_class.from_pe_version('5')
+        }.to raise_error(ArgumentError, %r{not a valid version number}i)
+      end
+
+      it 'returns the latest Puppet Z release for PE 2017.3.x' do
+        expect(described_class.from_pe_version('2017.3.1')).to eq('5.3.2')
+      end
+
+      it 'returns the latest Puppet Z release for PE 2017.2.x' do
+        expect(described_class.from_pe_version('2017.2.1')).to eq('4.10.1')
+      end
+
+      it 'returns the latest Puppet Z release for PE 2017.1.x' do
+        expect(described_class.from_pe_version('2017.1.1')).to eq('4.9.4')
+      end
+
+      it 'returns the latest Puppet Z release for PE 2016.5.x' do
+        expect(described_class.from_pe_version('2016.5.1')).to eq('4.8.1')
+      end
+
+      it 'returns the latest Puppet Z release for PE 2016.4.x' do
+        expect(described_class.from_pe_version('2016.4.1')).to eq('4.7.0')
+      end
+
+      it 'returns the latest Puppet Z release for PE 2016.2.x' do
+        expect(described_class.from_pe_version('2016.2.1')).to eq('4.5.2')
+      end
+
+      it 'returns the latest Puppet Z release for PE 2016.1.x' do
+        expect(described_class.from_pe_version('2016.1.1')).to eq('4.4.1')
+      end
+
+      it 'raises an ArgumentError if given an unknown PE version' do
+        expect {
+          described_class.from_pe_version('9999.1.1')
+        }.to raise_error(ArgumentError, %r{unable to map puppet enterprise version}i)
+      end
+    end
+  end
+end

--- a/spec/unit/pdk/util/ruby_version_spec.rb
+++ b/spec/unit/pdk/util/ruby_version_spec.rb
@@ -1,0 +1,139 @@
+require 'spec_helper'
+require 'pdk/util/ruby_version'
+
+describe PDK::Util::RubyVersion do
+  let(:instance) { described_class.new }
+
+  shared_context 'is a package install' do
+    before(:each) do
+      allow(PDK::Util).to receive(:package_install?).and_return(true)
+      allow(PDK::Util).to receive(:package_cachedir).and_return(package_cachedir)
+    end
+
+    let(:package_cachedir) do
+      File.join('/', 'path', 'to', 'pdk', 'share', 'cache')
+    end
+  end
+
+  shared_context 'is not a package install' do
+    before(:each) do
+      allow(PDK::Util).to receive(:package_install?).and_return(false)
+      bundler_path = File.join('/', 'usr', 'lib', 'ruby', 'gems', '2.1.0', 'gems', 'bundler-1.16.1', 'lib', 'bundler.rb')
+      allow(instance).to receive(:`).with('gem which bundler').and_return(bundler_path)
+    end
+  end
+
+  describe '#gem_path' do
+    subject { instance.gem_path }
+
+    context 'when running from a package install' do
+      include_context 'is a package install'
+
+      it 'returns the path to the packaged ruby cachedir' do
+        is_expected.to eq(File.join(package_cachedir, 'ruby', instance.versions[instance.active_ruby_version]))
+      end
+    end
+
+    context 'when not running from a package install' do
+      include_context 'is not a package install'
+
+      it 'returns the gem path relative to bundler' do
+        path = File.absolute_path(File.join('/', 'usr', 'lib', 'ruby', 'gems', '2.1.0'))
+        is_expected.to eq(path)
+      end
+    end
+  end
+
+  describe '#gem_home' do
+    subject { instance.gem_home }
+
+    let(:cachedir) { File.join('/', 'path', 'to', 'user', 'cache') }
+
+    before(:each) do
+      allow(PDK::Util).to receive(:cachedir).and_return(cachedir)
+    end
+
+    it 'returns a Ruby version specific path under the user cachedir' do
+      is_expected.to eq(File.join(cachedir, 'ruby', instance.versions[instance.active_ruby_version]))
+    end
+  end
+
+  describe '#versions' do
+    subject { instance.versions }
+
+    context 'when running from a package install' do
+      include_context 'is a package install'
+
+      it 'returns Ruby 2.1.9' do
+        is_expected.to include('2.1.9' => '2.1.0')
+      end
+    end
+
+    context 'when not running from a package install' do
+      include_context 'is not a package install'
+
+      it 'returns the running Ruby version' do
+        running_ruby = {
+          RbConfig::CONFIG['RUBY_PROGRAM_VERSION'] => RbConfig::CONFIG['ruby_version'],
+        }
+
+        is_expected.to eq(running_ruby)
+      end
+    end
+  end
+
+  describe '#available_puppet_versions' do
+    subject { instance.available_puppet_versions }
+
+    let(:gem_path) { File.join('/', 'path', 'to', 'ruby', 'gem_path') }
+    let(:gem_path_pattern) { File.join(gem_path, 'specifications', '**', 'puppet*.gemspec') }
+    let(:gem_home) { File.join('/', 'path', 'to', 'ruby', 'gem_home') }
+    let(:gem_home_pattern) { File.join(gem_home, 'specifications', '**', 'puppet*.gemspec') }
+    let(:gem_path_results) do
+      {
+        File.join(gem_path, 'specifications', 'puppet-4.10.10.gemspec') => <<-'END',
+          Gem::Specification.new do |spec|
+            spec.name = 'puppet'
+            spec.version = '4.10.10'
+          end
+        END
+        File.join(gem_path, 'specifications', 'puppet-lint-1.0.0.gemspec') => <<-'END',
+          Gem::Specification.new do |spec|
+            spec.name = 'puppet-lint'
+            spec.version = '1.0.0'
+          end
+        END
+      }
+    end
+    let(:gem_home_results) do
+      {
+        File.join(gem_home, 'specifications', 'puppet-5.3.0.gemspec') => <<-'END',
+          Gem::Specification.new do |spec|
+            spec.name = 'puppet'
+            spec.version = '5.3.0'
+          end
+        END
+      }
+    end
+
+    before(:each) do
+      allow(instance).to receive(:gem_path).and_return(gem_path)
+      allow(Dir).to receive(:[]).with(gem_path_pattern).and_return(gem_path_results.keys)
+      allow(instance).to receive(:gem_home).and_return(gem_home)
+      allow(Dir).to receive(:[]).with(gem_home_pattern).and_return(gem_home_results.keys)
+
+      gem_path_results.merge(gem_home_results).each do |spec_path, spec_content|
+        allow(File).to receive(:file?).with(spec_path).and_return(true)
+        allow(File).to receive(:read).with(spec_path, mode: 'r:UTF-8:-').and_return(spec_content)
+      end
+    end
+
+    it 'does not return versions for similarly named gems' do
+      is_expected.not_to include(Gem::Version.new('1.0.0'))
+    end
+
+    it 'returns an ordered list of Puppet gem versions' do
+      is_expected.to eq([Gem::Version.new('5.3.0'), Gem::Version.new('4.10.10')])
+    end
+  end
+end


### PR DESCRIPTION
The important bit: It adds the `--puppet-version` and `--pe-version` options to the `pdk validate` and `pdk test unit` commands (it's a lot of changed lines for such a simple change, but this PR lays a lot of the groundwork for the rest of the puppet & ruby version switching behaviour).

 * PE versions are mapped to Puppet versions in a static hash (copied from the forge), though this will eventually be made dynamic.
 * `GEM_PATH` and `GEM_HOME` have been extracted from `PDK::CLI::Exec` into a separate class, allowing them to be reused when scanning for available Puppet versions (and eventual ruby version switching).
 * Available Puppet versions are determined by scanning `GEM_HOME` and `GEM_PATH` for puppet gemspec files and parsing their contents.
 * Puppet version selection will prefer an exact match if available, otherwise it'll use the latest patch release for the specified version.

I would recommend not being too worried about the internals of `PDK::Util::PuppetVersion` and `PDK::Util::RubyVersion` at this stage, as they will change as this feature evolves in further PRs.