### PR TITLE
(MAINT) Add Ruby 2.5 to Travis and Appveyor config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,29 @@ script:
 cache: bundler
 matrix:
   include:
-    - rvm: 2.4.1
+    - rvm: 2.4.3
+      env: CHECK=rubocop
+    - rvm: 2.4.3
+      env: CHECK=acceptance:local
+    - rvm: 2.4.3
+      env: CHECK=spec
+    - rvm: 2.4.3
       env: CHECK=spec:coverage
-    - rvm: 2.4.1
+    - rvm: 2.4.3
+      env: CHECK=license_finder
+      bundler_args: "" # license_finder requires all gems installed
+    - rvm: 2.5
+      env: CHECK=rubocop
+    - rvm: 2.5
+      env: CHECK=spec
+    - rvm: 2.3
+      env: CHECK=rubocop
+    - rvm: 2.3
+      env: CHECK=spec
+    - rvm: 2.1.9
       env: CHECK=rubocop
     - rvm: 2.1.9
-      env: CHECK=acceptance:local
-    - rvm: 2.1.9
       env: CHECK=spec
-    # license_finder requires all gems installed
-    - rvm: 2.1.9
-      env: CHECK=license_finder
-      bundler_args: ""
 notifications:
   hipchat:
     rooms:

--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,16 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in pdk.gemspec
 gemspec
 
-# avoid newer versions that do not support ruby 2.1 anymore
-gem 'nokogiri', '1.7.2'
+if RUBY_VERSION < '2.4.0'
+  # avoid newer versions that do not support ruby 2.1 anymore
+  gem 'nokogiri', '1.7.2'
+else
+  # rubocop:disable Bundler/DuplicatedGem
+  gem 'nokogiri', '~> 1.8.2'
+end
 
 group :development do
   gem 'activesupport', '4.2.9'
-  # TODO: Use gem instead of git. Section mapping is merged into master, but not yet released
   gem 'github_changelog_generator', '~> 1.14'
   gem 'pry-byebug', '~> 3.4'
   if RUBY_VERSION < '2.2.2'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,29 +1,48 @@
 # version: 1.0.{build}-{branch}
 
 environment:
+  LOG_SPEC_ORDER: true
   matrix:
+    # FIXME: enable ruby 2.5 on windows once puppet and puppet-module gems have unpinned ffi
+    # - RUBY_VERSION: 25-x64
+    #   USE_MSYS: true
+    #   SUITES: "spec"
+    - RUBY_VERSION: 24-x64
+      USE_MSYS: true
+      SUITES: "spec acceptance:local"
     - RUBY_VERSION: 23-x64
+      USE_CYGWIN: true
+      SUITES: "spec"
     - RUBY_VERSION: 21-x64
+      USE_CYGWIN: true
+      SUITES: "spec"
 
 install:
-  - set PATH=C:\Ruby%RUBY_VERSION%\bin;C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
-  - SET LOG_SPEC_ORDER=true
+  - ps: |
+      if ($ENV:USE_MSYS -ne $Null) {
+        Push-Location "C:\Ruby${ENV:RUBY_VERSION}\bin"
+        .\ridk.ps1 install 2 3
+        .\ridk.ps1 enable
+        Pop-Location
+      }
+      ElseIf ($ENV:USE_CYGWIN) {
+        $ENV:PATH = "C:\Ruby${ENV:RUBY_VERSION}\bin;C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;" + $ENV:PATH
+      }
+  - echo %PATH%
   - bundle install --jobs 4 --retry 2 --without development
 
 build: off
 
 before_test:
-  - ruby -v
-  - gem -v
-  - bundle -v
+  - bundle env
   - type Gemfile.lock
 
 test_script:
-  - bundle exec rake spec acceptance:local
+  - bundle exec rake %SUITES%
 
 # Uncomment this block to enable RDP access to the AppVeyor test instance for
 # debugging purposes.
-#on_finish:
+# on_finish:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 notifications:


### PR DESCRIPTION
Also moves "primary" Ruby version in Travis to 2.4.3