### PR TITLE
(PDK-840) Add PDK::Util::PuppetVersion.from_module_metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ script:
   - cat Gemfile.lock
   - bundle list
   - bundle exec rake $CHECK
+before_install: gem install bundler
 cache: bundler
 matrix:
   include:

--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -87,6 +87,25 @@ module PDK
         PDK::Generate::Module.module_interview(self, only_ask: missing_fields)
       end
 
+      def validate_puppet_version_requirement!
+        msgs = {
+          no_reqs:       _('Module metadata does not contain any requirements'),
+          no_puppet_req: _('Module metadata does not contain a "puppet" requirement'),
+          no_puppet_ver: _('"puppet" requirement in module metadata does not specify a "version_requirement"'),
+        }
+
+        raise ArgumentError, msgs[:no_reqs] unless @data.key?('requirements')
+        raise ArgumentError, msgs[:no_puppet_req] if puppet_requirement.nil?
+        raise ArgumentError, msgs[:no_puppet_ver] unless puppet_requirement.key?('version_requirement')
+        raise ArgumentError, msgs[:no_puppet_ver] if puppet_requirement['version_requirement'].empty?
+      end
+
+      def puppet_requirement
+        @data['requirements'].find do |r|
+          r.key?('name') && r['name'] == 'puppet'
+        end
+      end
+
       private
 
       def missing_fields

--- a/lib/pdk/util/puppet_version.rb
+++ b/lib/pdk/util/puppet_version.rb
@@ -6,7 +6,7 @@ module PDK
       class << self
         extend Forwardable
 
-        def_delegators :instance, :find_gem_for, :from_pe_version
+        def_delegators :instance, :find_gem_for, :from_pe_version, :from_module_metadata
 
         attr_writer :instance
 
@@ -20,17 +20,17 @@ module PDK
         version = Gem::Version.new(version_str)
 
         exact_requirement = Gem::Requirement.create(version)
-        gem_version = find_gem(exact_requirement)
-        return gem_version.version unless gem_version.nil?
+        found_gem = find_gem(exact_requirement)
+        return found_gem unless found_gem.nil?
 
         latest_requirement = Gem::Requirement.create("#{version.approximate_recommendation}.0")
-        gem_version = find_gem(latest_requirement)
-        unless gem_version.nil?
+        found_gem = find_gem(latest_requirement)
+        unless found_gem.nil?
           PDK.logger.info _('Unable to find Puppet %{requested_version}, using %{found_version} instead') % {
             requested_version: version_str,
-            found_version:     gem_version.version,
+            found_version:     found_gem[:gem_version].version,
           }
-          return gem_version.version
+          return found_gem
         end
 
         raise ArgumentError, _('Unable to find a Puppet version matching %{requirement}') % {
@@ -57,6 +57,36 @@ module PDK
           puppet_version: gem_version[:gem_version],
         }
         find_gem_for(gem_version[:gem_version])
+      end
+
+      def from_module_metadata(metadata)
+        msgs = {
+          not_metadata:  _('Not a valid PDK::Module::Metadata object'),
+          no_reqs:       _('Module metadata does not contain any requirements'),
+          no_puppet_req: _('Module metadata does not contain a "puppet" requirement'),
+          no_puppet_ver: _('"puppet" requirement in module metadata does not specify a "version_requirement"'),
+        }
+
+        raise ArgumentError, msgs[:not_metadata] unless metadata.is_a?(PDK::Module::Metadata)
+        raise ArgumentError, msgs[:no_reqs] unless metadata.data.key?('requirements')
+
+        metadata_requirement = metadata.data['requirements'].find do |r|
+          r.key?('name') && r['name'] == 'puppet'
+        end
+
+        raise ArgumentError, msgs[:no_puppet_req] if metadata_requirement.nil?
+        raise ArgumentError, msgs[:no_puppet_ver] unless metadata_requirement.key?('version_requirement')
+        raise ArgumentError, msgs[:no_puppet_ver] if metadata_requirement['version_requirement'].empty?
+
+        # Split combined requirements like ">= 4.7.0 < 6.0.0" into their
+        # component requirements [">= 4.7.0", "< 6.0.0"]
+        pattern = %r{#{Gem::Requirement::PATTERN_RAW}}
+        requirement_strings = metadata_requirement['version_requirement'].scan(pattern).map do |req|
+          req.compact.join(' ')
+        end
+
+        gem_requirement = Gem::Requirement.create(requirement_strings)
+        find_gem(gem_requirement)
       end
 
       private
@@ -119,11 +149,18 @@ module PDK
       end
 
       def find_in_rubygems(requirement)
-        rubygems_puppet_versions.find { |r| requirement.satisfied_by?(r) }
+        version = rubygems_puppet_versions.find { |r| requirement.satisfied_by?(r) }
+        version.nil? ? nil : { gem_version: version, ruby_version: PDK::Util::RubyVersion.default_ruby_version }
       end
 
       def find_in_package_cache(requirement)
-        PDK::Util::RubyVersion.available_puppet_versions.find { |r| requirement.satisfied_by?(r) }
+        PDK::Util::RubyVersion.versions.each do |ruby_version, _|
+          PDK::Util::RubyVersion.use(ruby_version)
+          version = PDK::Util::RubyVersion.available_puppet_versions.find { |r| requirement.satisfied_by?(r) }
+          return { gem_version: version, ruby_version: ruby_version } unless version.nil?
+        end
+
+        nil
       end
     end
   end

--- a/lib/pdk/util/puppet_version.rb
+++ b/lib/pdk/util/puppet_version.rb
@@ -60,23 +60,8 @@ module PDK
       end
 
       def from_module_metadata(metadata)
-        msgs = {
-          not_metadata:  _('Not a valid PDK::Module::Metadata object'),
-          no_reqs:       _('Module metadata does not contain any requirements'),
-          no_puppet_req: _('Module metadata does not contain a "puppet" requirement'),
-          no_puppet_ver: _('"puppet" requirement in module metadata does not specify a "version_requirement"'),
-        }
-
-        raise ArgumentError, msgs[:not_metadata] unless metadata.is_a?(PDK::Module::Metadata)
-        raise ArgumentError, msgs[:no_reqs] unless metadata.data.key?('requirements')
-
-        metadata_requirement = metadata.data['requirements'].find do |r|
-          r.key?('name') && r['name'] == 'puppet'
-        end
-
-        raise ArgumentError, msgs[:no_puppet_req] if metadata_requirement.nil?
-        raise ArgumentError, msgs[:no_puppet_ver] unless metadata_requirement.key?('version_requirement')
-        raise ArgumentError, msgs[:no_puppet_ver] if metadata_requirement['version_requirement'].empty?
+        metadata.validate_puppet_version_requirement!
+        metadata_requirement = metadata.puppet_requirement
 
         # Split combined requirements like ">= 4.7.0 < 6.0.0" into their
         # component requirements [">= 4.7.0", "< 6.0.0"]

--- a/lib/pdk/util/ruby_version.rb
+++ b/lib/pdk/util/ruby_version.rb
@@ -35,7 +35,11 @@ module PDK
         end
 
         def scan_for_packaged_rubies
-          { '2.4.3' => '2.4.0' }
+          ruby_basedir = File.join(PDK::Util.pdk_package_basedir, 'private', 'ruby', '*')
+          Dir[ruby_basedir].map { |ruby_dir|
+            version = File.basename(ruby_dir)
+            [version, version.split('.').take(2).concat(['0']).join('.')]
+          }.to_h
         end
 
         def default_ruby_version

--- a/lib/pdk/util/ruby_version.rb
+++ b/lib/pdk/util/ruby_version.rb
@@ -10,7 +10,9 @@ module PDK
 
         attr_reader :instance
 
-        def instance
+        def instance(version = nil)
+          use(version) unless version.nil?
+
           if @instance.nil?
             @instance = {}
             @instance.default_proc = proc do |hash, key|

--- a/spec/unit/pdk/module/metadata_spec.rb
+++ b/spec/unit/pdk/module/metadata_spec.rb
@@ -146,4 +146,64 @@ describe PDK::Module::Metadata do
       end
     end
   end
+
+  describe '#validate_puppet_version_requirement!' do
+    let(:metadata) { described_class.new }
+
+    context 'when the metadata contains a puppet requirement with a version_requirement' do
+      it 'does not raise an error' do
+        expect {
+          metadata.validate_puppet_version_requirement!
+        }.not_to raise_error
+      end
+    end
+
+    context 'when the metadata does not contain any requirements' do
+      before(:each) do
+        metadata.data.delete('requirements')
+      end
+
+      it 'raises an ArgumentError' do
+        expect {
+          metadata.validate_puppet_version_requirement!
+        }.to raise_error(ArgumentError, %r{does not contain any requirements}i)
+      end
+    end
+
+    context 'when the metadata does not contain a puppet requirement' do
+      before(:each) do
+        metadata.data['requirements'] = [{ 'name' => 'not_puppet', 'version_requirement' => '1.0.0' }]
+      end
+
+      it 'raises an ArgumentError' do
+        expect {
+          metadata.validate_puppet_version_requirement!
+        }.to raise_error(ArgumentError, %r{does not contain a "puppet" requirement}i)
+      end
+    end
+
+    context 'when the puppet requirement does not have a version_requirement' do
+      before(:each) do
+        metadata.data['requirements'] = [{ 'name' => 'puppet' }]
+      end
+
+      it 'raises an ArgumentError' do
+        expect {
+          metadata.validate_puppet_version_requirement!
+        }.to raise_error(ArgumentError, %r{does not specify a "version_requirement"}i)
+      end
+    end
+
+    context 'when the puppet requirement has a blank version_requirement' do
+      before(:each) do
+        metadata.data['requirements'] = [{ 'name' => 'puppet', 'version_requirement' => '' }]
+      end
+
+      it 'raises an ArgumentError' do
+        expect {
+          metadata.validate_puppet_version_requirement!
+        }.to raise_error(ArgumentError, %r{does not specify a "version_requirement"}i)
+      end
+    end
+  end
 end

--- a/spec/unit/pdk/util/puppet_version_spec.rb
+++ b/spec/unit/pdk/util/puppet_version_spec.rb
@@ -24,9 +24,22 @@ describe PDK::Util::PuppetVersion do
   shared_context 'is a package install' do
     before(:each) do
       allow(PDK::Util).to receive(:package_install?).and_return(true)
+      allow(PDK::Util::RubyVersion).to receive(:versions).and_return('2.1.9' => '2.1.0', '2.4.3' => '2.4.0')
 
-      mock_response = cache_versions.map { |r| Gem::Version.new(r) }
-      allow(PDK::Util::RubyVersion).to receive(:available_puppet_versions).and_return(mock_response)
+      PDK::Util::RubyVersion.use('2.1.9')
+      instance219 = PDK::Util::RubyVersion.instance
+      PDK::Util::RubyVersion.use('2.4.3')
+      instance243 = PDK::Util::RubyVersion.instance
+
+      versions219 = cache_versions.select { |r| r.start_with?('4') }.map { |r| Gem::Version.new(r) }
+      versions243 = cache_versions.reject { |r| r.start_with?('4') }.map { |r| Gem::Version.new(r) }
+      allow(instance219).to receive(:available_puppet_versions).and_return(versions219)
+      allow(instance243).to receive(:available_puppet_versions).and_return(versions243)
+    end
+
+    after(:each) do
+      PDK::Util::RubyVersion.instance_variable_set('@instance', nil)
+      PDK::Util::RubyVersion.instance_variable_set('@active_ruby_version', nil)
     end
   end
 
@@ -64,7 +77,11 @@ describe PDK::Util::PuppetVersion do
       end
 
       it 'returns the specified version if it exists in the cache' do
-        expect(described_class.find_gem_for('5.3.5')).to eq('5.3.5')
+        expected_result = {
+          gem_version:  Gem::Version.new('5.3.5'),
+          ruby_version: '2.4.3',
+        }
+        expect(described_class.find_gem_for('5.3.5')).to eq(expected_result)
       end
 
       context 'when the specified version does not exist in the cache' do
@@ -74,7 +91,11 @@ describe PDK::Util::PuppetVersion do
         end
 
         it 'returns the latest Z release' do
-          expect(described_class.find_gem_for('5.3.1')).to eq('5.3.5')
+          expected_result = {
+            gem_version:  Gem::Version.new('5.3.5'),
+            ruby_version: '2.4.3',
+          }
+          expect(described_class.find_gem_for('5.3.1')).to eq(expected_result)
         end
 
         it 'raises an ArgumentError if no version can be found' do
@@ -89,6 +110,13 @@ describe PDK::Util::PuppetVersion do
       include_context 'is not a package install'
       include_context 'with a mocked rubygems response'
 
+      def result(version)
+        {
+          gem_version:  Gem::Version.new(version),
+          ruby_version: PDK::Util::RubyVersion.default_ruby_version,
+        }
+      end
+
       it 'raises an ArgumentError if passed a non X.Y.Z version' do
         expect {
           described_class.find_gem_for('5')
@@ -96,7 +124,7 @@ describe PDK::Util::PuppetVersion do
       end
 
       it 'returns the specified version if it exists on Rubygems' do
-        expect(described_class.find_gem_for('4.9.0')).to eq('4.9.0')
+        expect(described_class.find_gem_for('4.9.0')).to eq(result('4.9.0'))
       end
 
       context 'when the specified version does not exist on Rubygems' do
@@ -106,7 +134,7 @@ describe PDK::Util::PuppetVersion do
         end
 
         it 'returns the latest Z release' do
-          expect(described_class.find_gem_for('4.10.999')).to eq('4.10.10')
+          expect(described_class.find_gem_for('4.10.999')).to eq(result('4.10.10'))
         end
 
         it 'raises an ArgumentError if no version can be found' do
@@ -122,6 +150,13 @@ describe PDK::Util::PuppetVersion do
     context 'when running from a package install' do
       include_context 'is a package install'
 
+      def result(gem_version, ruby_version)
+        {
+          gem_version:  Gem::Version.new(gem_version),
+          ruby_version: ruby_version,
+        }
+      end
+
       it 'raises an ArgumentError if passed a non X.Y.Z version' do
         expect {
           described_class.from_pe_version('5')
@@ -129,31 +164,31 @@ describe PDK::Util::PuppetVersion do
       end
 
       it 'returns the latest Puppet Z release for PE 2017.3.x' do
-        expect(described_class.from_pe_version('2017.3.1')).to eq('5.3.5')
+        expect(described_class.from_pe_version('2017.3.1')).to eq(result('5.3.5', '2.4.3'))
       end
 
       it 'returns the latest Puppet Z release for PE 2017.2.x' do
-        expect(described_class.from_pe_version('2017.2.1')).to eq('4.10.10')
+        expect(described_class.from_pe_version('2017.2.1')).to eq(result('4.10.10', '2.1.9'))
       end
 
       it 'returns the latest Puppet Z release for PE 2017.1.x' do
-        expect(described_class.from_pe_version('2017.1.1')).to eq('4.9.4')
+        expect(described_class.from_pe_version('2017.1.1')).to eq(result('4.9.4', '2.1.9'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.5.x' do
-        expect(described_class.from_pe_version('2016.5.1')).to eq('4.8.1')
+        expect(described_class.from_pe_version('2016.5.1')).to eq(result('4.8.1', '2.1.9'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.4.x' do
-        expect(described_class.from_pe_version('2016.4.1')).to eq('4.7.0')
+        expect(described_class.from_pe_version('2016.4.1')).to eq(result('4.7.0', '2.1.9'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.2.x' do
-        expect(described_class.from_pe_version('2016.2.1')).to eq('4.5.3')
+        expect(described_class.from_pe_version('2016.2.1')).to eq(result('4.5.3', '2.1.9'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.1.x' do
-        expect(described_class.from_pe_version('2016.1.1')).to eq('4.4.2')
+        expect(described_class.from_pe_version('2016.1.1')).to eq(result('4.4.2', '2.1.9'))
       end
 
       it 'raises an ArgumentError if given an unknown PE version' do
@@ -167,6 +202,13 @@ describe PDK::Util::PuppetVersion do
       include_context 'is not a package install'
       include_context 'with a mocked rubygems response'
 
+      def result(version)
+        {
+          gem_version:  Gem::Version.new(version),
+          ruby_version: PDK::Util::RubyVersion.default_ruby_version,
+        }
+      end
+
       it 'raises an ArgumentError if passed a non X.Y.Z version' do
         expect {
           described_class.from_pe_version('5')
@@ -174,37 +216,111 @@ describe PDK::Util::PuppetVersion do
       end
 
       it 'returns the latest Puppet Z release for PE 2017.3.x' do
-        expect(described_class.from_pe_version('2017.3.1')).to eq('5.3.2')
+        expect(described_class.from_pe_version('2017.3.1')).to eq(result('5.3.2'))
       end
 
       it 'returns the latest Puppet Z release for PE 2017.2.x' do
-        expect(described_class.from_pe_version('2017.2.1')).to eq('4.10.1')
+        expect(described_class.from_pe_version('2017.2.1')).to eq(result('4.10.1'))
       end
 
       it 'returns the latest Puppet Z release for PE 2017.1.x' do
-        expect(described_class.from_pe_version('2017.1.1')).to eq('4.9.4')
+        expect(described_class.from_pe_version('2017.1.1')).to eq(result('4.9.4'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.5.x' do
-        expect(described_class.from_pe_version('2016.5.1')).to eq('4.8.1')
+        expect(described_class.from_pe_version('2016.5.1')).to eq(result('4.8.1'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.4.x' do
-        expect(described_class.from_pe_version('2016.4.1')).to eq('4.7.0')
+        expect(described_class.from_pe_version('2016.4.1')).to eq(result('4.7.0'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.2.x' do
-        expect(described_class.from_pe_version('2016.2.1')).to eq('4.5.2')
+        expect(described_class.from_pe_version('2016.2.1')).to eq(result('4.5.2'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.1.x' do
-        expect(described_class.from_pe_version('2016.1.1')).to eq('4.4.1')
+        expect(described_class.from_pe_version('2016.1.1')).to eq(result('4.4.1'))
       end
 
       it 'raises an ArgumentError if given an unknown PE version' do
         expect {
           described_class.from_pe_version('9999.1.1')
         }.to raise_error(ArgumentError, %r{unable to map puppet enterprise version}i)
+      end
+    end
+  end
+
+  describe '.from_module_metadata' do
+    context 'when passed something other than a PDK::Module::Metadata instance' do
+      it 'raises an ArgumentError' do
+        expect {
+          described_class.from_module_metadata('')
+        }.to raise_error(ArgumentError, %r{not a valid pdk::module::metadata object}i)
+      end
+    end
+
+    context 'when passed a metadata object with no requirements' do
+      it 'raises an ArgumentError' do
+        metadata = PDK::Module::Metadata.new
+        metadata.data.delete('requirements')
+
+        expect {
+          described_class.from_module_metadata(metadata)
+        }.to raise_error(ArgumentError, %r{does not contain any requirements}i)
+      end
+    end
+
+    context 'when passed a metadata object without a "puppet" requirement' do
+      it 'raises an ArgumentError' do
+        metadata = PDK::Module::Metadata.new
+        metadata.data['requirements'] = [{ 'name' => 'not_puppet', 'version_requirement' => '1.0.0' }]
+
+        expect {
+          described_class.from_module_metadata(metadata)
+        }.to raise_error(ArgumentError, %r{does not contain a "puppet" requirement}i)
+      end
+    end
+
+    context 'when the puppet requirement does not have a "version_requirement"' do
+      it 'raises an ArgumentError' do
+        metadata = PDK::Module::Metadata.new
+        metadata.data['requirements'] = [{ 'name' => 'puppet' }]
+
+        expect {
+          described_class.from_module_metadata(metadata)
+        }.to raise_error(ArgumentError, %r{does not specify a "version_requirement"}i)
+      end
+    end
+
+    context 'when the puppet requirement has a blank "version_requirement"' do
+      it 'raises an ArgumentError' do
+        metadata = PDK::Module::Metadata.new
+        metadata.data['requirements'] = [{ 'name' => 'puppet', 'version_requirement' => '' }]
+
+        expect {
+          described_class.from_module_metadata(metadata)
+        }.to raise_error(ArgumentError, %r{does not specify a "version_requirement"}i)
+      end
+    end
+
+    context 'with default metadata' do
+      it 'searches for a Puppet gem >= 4.7.0 < 6.0.0' do
+        requirement = Gem::Requirement.create(['>= 4.7.0', '< 6.0.0'])
+        expect(described_class.instance).to receive(:find_gem).with(requirement)
+
+        described_class.from_module_metadata(PDK::Module::Metadata.new)
+      end
+    end
+
+    context 'with a pinned version requirement' do
+      it 'searches for a Puppet gem matching the exact version' do
+        metadata = PDK::Module::Metadata.new
+        metadata.data['requirements'] = [{ 'name' => 'puppet', 'version_requirement' => '4.10.10' }]
+
+        expect(described_class.instance).to receive(:find_gem).with(Gem::Requirement.create('4.10.10'))
+
+        described_class.from_module_metadata(metadata)
       end
     end
   end

--- a/spec/unit/pdk/util/puppet_version_spec.rb
+++ b/spec/unit/pdk/util/puppet_version_spec.rb
@@ -26,10 +26,8 @@ describe PDK::Util::PuppetVersion do
       allow(PDK::Util).to receive(:package_install?).and_return(true)
       allow(PDK::Util::RubyVersion).to receive(:versions).and_return('2.1.9' => '2.1.0', '2.4.3' => '2.4.0')
 
-      PDK::Util::RubyVersion.use('2.1.9')
-      instance219 = PDK::Util::RubyVersion.instance
-      PDK::Util::RubyVersion.use('2.4.3')
-      instance243 = PDK::Util::RubyVersion.instance
+      instance219 = PDK::Util::RubyVersion.instance('2.1.9')
+      instance243 = PDK::Util::RubyVersion.instance('2.4.3')
 
       versions219 = cache_versions.select { |r| r.start_with?('4') }.map { |r| Gem::Version.new(r) }
       versions243 = cache_versions.reject { |r| r.start_with?('4') }.map { |r| Gem::Version.new(r) }

--- a/spec/unit/pdk/util/ruby_version_spec.rb
+++ b/spec/unit/pdk/util/ruby_version_spec.rb
@@ -68,8 +68,15 @@ describe PDK::Util::RubyVersion do
     context 'when running from a package install' do
       include_context 'is a package install'
 
-      it 'returns Ruby 2.4.3' do
-        is_expected.to include('2.4.3' => '2.4.0')
+      before(:each) do
+        basedir = File.join('/', 'basedir')
+        ruby_dirs = ['2.1.9', '2.4.3'].map { |r| File.join(basedir, 'private', 'ruby', r) }
+        allow(PDK::Util).to receive(:pdk_package_basedir).and_return(basedir)
+        allow(Dir).to receive(:[]).with(File.join(basedir, 'private', 'ruby', '*')).and_return(ruby_dirs)
+      end
+
+      it 'returns the Ruby versions included in the package' do
+        is_expected.to eq('2.1.9' => '2.1.0', '2.4.3' => '2.4.0')
       end
     end
 

--- a/spec/unit/pdk/util/ruby_version_spec.rb
+++ b/spec/unit/pdk/util/ruby_version_spec.rb
@@ -30,7 +30,7 @@ describe PDK::Util::RubyVersion do
       include_context 'is a package install'
 
       it 'returns the path to the packaged ruby cachedir' do
-        is_expected.to eq(File.join(package_cachedir, 'ruby', instance.versions[instance.active_ruby_version]))
+        is_expected.to eq(File.join(package_cachedir, 'ruby', described_class.versions[described_class.active_ruby_version]))
       end
     end
 
@@ -54,12 +54,16 @@ describe PDK::Util::RubyVersion do
     end
 
     it 'returns a Ruby version specific path under the user cachedir' do
-      is_expected.to eq(File.join(cachedir, 'ruby', instance.versions[instance.active_ruby_version]))
+      is_expected.to eq(File.join(cachedir, 'ruby', described_class.versions[described_class.active_ruby_version]))
     end
   end
 
-  describe '#versions' do
-    subject { instance.versions }
+  describe '.versions' do
+    subject { described_class.versions }
+
+    before(:each) do
+      described_class.instance_variable_set('@versions', nil)
+    end
 
     context 'when running from a package install' do
       include_context 'is a package install'


### PR DESCRIPTION
For use when selecting the default Puppet & Ruby version if the user doesn't specify one