### PR TITLE
(maint) Allow `pdk bundle` to work without `--`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,29 +50,29 @@ This command asks a series of metadata questions and then generates the basic co
 
 To generate a class in your module, use the `pdk new class` command, specifying the name of your new class. To generate the main class of the module, which is defined in an `init.pp` file, give the class the same name as the module.
 
-1. From the command line, in your module's directory, run: 
+1. From the command line, in your module's directory, run:
 ```
-pdk new class class_name 
+pdk new class class_name
 ```
 
-PDK creates the new class manifest and a test file (as `class_name_spec.rb`) in your module's `/spec/classes` directory. 
+PDK creates the new class manifest and a test file (as `class_name_spec.rb`) in your module's `/spec/classes` directory.
 
 ### Generate a defined type
 
 To generate a defined type in your module, use the `pdk new defined_type` command, specifying the name of your new defined type.
 
-1. From the command line, in your module's directory, run: 
+1. From the command line, in your module's directory, run:
 ```
 pdk new defined_type defined_type_name
 ```
 
-PDK creates the new defined\_type manifest and a test file (as `defined_type_name_spec.rb`) in your module's `/spec/defines` directory. 
+PDK creates the new defined\_type manifest and a test file (as `defined_type_name_spec.rb`) in your module's `/spec/defines` directory.
 
 ### Generate a task
 
 To generate a task in your module, use the `pdk new task` command, specifying the name of your new task.
 
-1. From the command line, in your module's directory, run: 
+1. From the command line, in your module's directory, run:
 ```
 pdk new task task_name
 ```
@@ -110,28 +110,6 @@ This command runs all available unit tests.
 This command executes arbitrary commands in a bundler context within the module you're currently working on. Arguments to this command are passed straight through to bundler. This command is experimental  and can lead to errors that can't be resolved by the pdk itself.
 
 Note that for most uses, you must use the `--` to separate bundler options from pdk options. Compare the following two commands:
-
-```
-$ pdk bundle exec rake -T
-bundle: illegal option -- T
-
-```
-
-and
-
-```
-$ pdk bundle -- exec rake -T
-rake beaker                # Run beaker acceptance tests
-rake beaker:sets           # List available beaker nodesets
-rake beaker:ssh[set,node]  # Try to use vagrant to login to the Beaker node
-rake build                 # Build puppet module package
-[...]
-```
-
-#### Known issues
-
-
-Note that for PowerShell the `--` must be escaped using a backtick ( <code>`-- </code> ) or the shell parses it and strips it out of the command. See [PDK-408](https://tickets.puppet.com/browse/PDK-408) for details.
 
 ## Module Compatibility
 

--- a/lib/pdk/cli/bundle.rb
+++ b/lib/pdk/cli/bundle.rb
@@ -2,11 +2,7 @@
 module PDK::CLI
   @bundle_cmd = @base_cmd.define_command do
     name 'bundle'
-    if Gem.win_platform?
-      usage _('bundle `-- [bundler_options]')
-    else
-      usage _('bundle -- [bundler_options]')
-    end
+    usage _('bundle [bundler_options]')
     summary _('(Experimental) Command pass-through to bundler')
     description _(<<-EOF
 [experimental] For advanced users, pdk bundle runs arbitrary commands in the bundler environment that pdk manages.
@@ -15,6 +11,7 @@ Careless use of this command can lead to errors that pdk can't help recover from
 Note that for PowerShell the '--' needs to be escaped using a backtick: '`--' to avoid it being parsed by the shell.
 EOF
                  )
+    skip_option_parsing
 
     run do |_opts, args, _cmd|
       PDK::CLI::Util.ensure_in_module!(

--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.1.9'
 
   spec.add_runtime_dependency 'bundler', '~> 1.15'
-  spec.add_runtime_dependency 'cri', '~> 2.9.1'
+  spec.add_runtime_dependency 'cri', '~> 2.10.1'
   spec.add_runtime_dependency 'childprocess', '~> 0.7.1'
   spec.add_runtime_dependency 'gettext-setup', '~> 0.24'
   spec.add_runtime_dependency 'tty-spinner', '0.5.0'


### PR DESCRIPTION
By upgrading to the new version of CRI, the `skip_option_parsing`
call can be used to avoid the previous confusion of bundle vs pdk
options.