### PR TITLE
(PDK-923) Honour PDK::Util::RubyVersion.active_ruby_version when executing commands

### DIFF
--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -35,7 +35,7 @@ module PDK
 
       def self.bundle_bin
         bundle_bin = Gem.win_platform? ? 'bundle.bat' : 'bundle'
-        vendored_bin_path = File.join('private', 'ruby', PDK::Util::RubyVersion.active_ruby_version, 'bin', bundle_bin)
+        vendored_bin_path = File.join(PDK::Util::RubyVersion.bin_path, bundle_bin)
 
         try_vendored_bin(vendored_bin_path, bundle_bin)
       end
@@ -130,7 +130,7 @@ module PDK
             # Make sure invocation of Ruby prefers our private installation.
             package_binpath = PDK::Util.package_install? ? File.join(PDK::Util.pdk_package_basedir, 'bin') : nil
             @process.environment['PATH'] = [
-              PDK::Util::RubyVersion.path,
+              PDK::Util::RubyVersion.bin_path,
               File.join(@process.environment['GEM_HOME'], 'bin'),
               File.join(@process.environment['GEM_PATH'], 'bin'),
               package_binpath,

--- a/lib/pdk/util/ruby_version.rb
+++ b/lib/pdk/util/ruby_version.rb
@@ -6,7 +6,7 @@ module PDK
       class << self
         extend Forwardable
 
-        def_delegators :instance, :gem_path, :gem_home, :available_puppet_versions, :path
+        def_delegators :instance, :gem_path, :gem_home, :available_puppet_versions, :bin_path
 
         attr_reader :instance
 
@@ -64,7 +64,7 @@ module PDK
         @ruby_version = ruby_version || default_ruby_version
       end
 
-      def path
+      def bin_path
         if PDK::Util.package_install?
           File.join(PDK::Util.pdk_package_basedir, 'private', 'ruby', ruby_version, 'bin')
         else

--- a/spec/unit/pdk/util/ruby_version_spec.rb
+++ b/spec/unit/pdk/util/ruby_version_spec.rb
@@ -36,8 +36,8 @@ describe PDK::Util::RubyVersion do
     end
   end
 
-  describe '#path' do
-    subject { instance.path }
+  describe '#bin_path' do
+    subject { instance.bin_path }
 
     context 'when running from a package install' do
       include_context 'is a package install'


### PR DESCRIPTION
This is safe to merge in as is, but it might make more sense to cherry-pick it into the branch for PDK-842 as it won't take effect until then.