### PR TITLE
(maint) Allow users to major or major.minor versions

### DIFF
--- a/lib/pdk/util/puppet_version.rb
+++ b/lib/pdk/util/puppet_version.rb
@@ -18,34 +18,37 @@ module PDK
       def find_gem_for(version_str)
         version = parse_specified_version(version_str)
 
+        # Look for a gem matching exactly the version passed in.
         if version.segments.length == 3
-          exact_requirement = Gem::Requirement.create(version)
-          found_gem = find_gem(exact_requirement)
-          return found_gem unless found_gem.nil?
+          exact_match_gem = find_gem(Gem::Requirement.create(version))
+          return exact_match_gem unless exact_match_gem.nil?
         end
 
-        requirement_string = if version.segments.length == 1
-                               version.approximate_recommendation
-                             else
-                               "#{version.approximate_recommendation}.0"
-                             end
+        # Construct a pessimistic version constraint to find the latest
+        # available gem matching the level of specificity of version_str.
+        requirement_string = version.approximate_recommendation
+        requirement_string += '.0' unless version.segments.length == 1
         latest_requirement = Gem::Requirement.create(requirement_string)
-        found_gem = find_gem(latest_requirement)
-        unless found_gem.nil?
-          PDK.logger.info _('Unable to find Puppet %{requested_version}, using %{found_version} instead') % {
-            requested_version: version_str,
-            found_version:     found_gem[:gem_version].version,
+
+        latest_available_gem = find_gem(latest_requirement)
+
+        if latest_available_gem.nil?
+          raise ArgumentError, _('Unable to find a Puppet gem matching %{requirement}') % {
+            requirement: latest_requirement,
           }
-          return found_gem
         end
 
-        raise ArgumentError, _('Unable to find a Puppet version matching %{requirement}') % {
-          requirement: latest_requirement,
+        PDK.logger.info _('Unable to find Puppet gem matching %{requested_version}, using %{found_version} instead') % {
+          requested_version: version_str,
+          found_version:     latest_available_gem[:gem_version].version,
         }
+
+        latest_available_gem
       end
 
       def from_pe_version(version_str)
         version = parse_specified_version(version_str)
+
         gem_version = pe_version_map.find do |version_map|
           version_map[:requirement].satisfied_by?(version)
         end
@@ -60,6 +63,7 @@ module PDK
           pe_version:     version_str,
           puppet_version: gem_version[:gem_version],
         }
+
         find_gem_for(gem_version[:gem_version])
       end
 

--- a/spec/unit/pdk/util/puppet_version_spec.rb
+++ b/spec/unit/pdk/util/puppet_version_spec.rb
@@ -121,7 +121,7 @@ describe PDK::Util::PuppetVersion do
         it 'raises an ArgumentError if no version can be found' do
           expect {
             described_class.find_gem_for('1.0.0')
-          }.to raise_error(ArgumentError, %r{unable to find a puppet version}i)
+          }.to raise_error(ArgumentError, %r{unable to find a puppet gem matching}i)
         end
       end
     end
@@ -174,7 +174,7 @@ describe PDK::Util::PuppetVersion do
         it 'raises an ArgumentError if no version can be found' do
           expect {
             described_class.find_gem_for('1.0.0')
-          }.to raise_error(ArgumentError, %r{unable to find a puppet version}i)
+          }.to raise_error(ArgumentError, %r{unable to find a puppet gem matching}i)
         end
       end
     end

--- a/spec/unit/pdk/util/puppet_version_spec.rb
+++ b/spec/unit/pdk/util/puppet_version_spec.rb
@@ -68,10 +68,32 @@ describe PDK::Util::PuppetVersion do
     context 'when running from a package install' do
       include_context 'is a package install'
 
-      it 'raises an ArgumentError if passed a non X.Y.Z version' do
-        expect {
-          described_class.find_gem_for('5')
-        }.to raise_error(ArgumentError, %r{not a valid version number}i)
+      context 'and passed an invalid version number' do
+        it 'raises an ArgumentError' do
+          expect {
+            described_class.find_gem_for('irving')
+          }.to raise_error(ArgumentError, %r{not a valid version number}i)
+        end
+      end
+
+      context 'and passed only a major version' do
+        it 'returns the latest version matching the major version' do
+          expected_result = {
+            gem_version:  Gem::Version.new('5.4.0'),
+            ruby_version: '2.4.3',
+          }
+          expect(described_class.find_gem_for('5')).to eq(expected_result)
+        end
+      end
+
+      context 'and passed only a major and minor version' do
+        it 'returns the latest patch version for the major and minor version' do
+          expected_result = {
+            gem_version:  Gem::Version.new('5.3.5'),
+            ruby_version: '2.4.3',
+          }
+          expect(described_class.find_gem_for('5.3')).to eq(expected_result)
+        end
       end
 
       it 'returns the specified version if it exists in the cache' do
@@ -82,7 +104,7 @@ describe PDK::Util::PuppetVersion do
         expect(described_class.find_gem_for('5.3.5')).to eq(expected_result)
       end
 
-      context 'when the specified version does not exist in the cache' do
+      context 'and the specified version does not exist in the cache' do
         it 'notifies the user that it is using the latest Z release instead' do
           expect(logger).to receive(:info).with(a_string_matching(%r{using 5\.3\.5 instead}i))
           described_class.find_gem_for('5.3.1')
@@ -115,17 +137,31 @@ describe PDK::Util::PuppetVersion do
         }
       end
 
-      it 'raises an ArgumentError if passed a non X.Y.Z version' do
-        expect {
-          described_class.find_gem_for('5')
-        }.to raise_error(ArgumentError, %r{not a valid version number}i)
+      context 'and passed an invalid version number' do
+        it 'raises an ArgumentError' do
+          expect {
+            described_class.find_gem_for('irving')
+          }.to raise_error(ArgumentError, %r{not a valid version number}i)
+        end
+      end
+
+      context 'and passed only a major version' do
+        it 'returns the latest version matching the major version' do
+          expect(described_class.find_gem_for('5')).to eq(result('5.4.0'))
+        end
+      end
+
+      context 'and passed only a major and minor version' do
+        it 'returns the latest patch version for the major and minor version' do
+          expect(described_class.find_gem_for('5.3')).to eq(result('5.3.5'))
+        end
       end
 
       it 'returns the specified version if it exists on Rubygems' do
         expect(described_class.find_gem_for('4.9.0')).to eq(result('4.9.0'))
       end
 
-      context 'when the specified version does not exist on Rubygems' do
+      context 'and the specified version does not exist on Rubygems' do
         it 'notifies the user that it is using the latest Z release instead' do
           expect(logger).to receive(:info).with(a_string_matching(%r{using 4\.10\.10 instead}i))
           described_class.find_gem_for('4.10.999')
@@ -155,37 +191,46 @@ describe PDK::Util::PuppetVersion do
         }
       end
 
-      it 'raises an ArgumentError if passed a non X.Y.Z version' do
-        expect {
-          described_class.from_pe_version('5')
-        }.to raise_error(ArgumentError, %r{not a valid version number}i)
+      context 'and passed an invalid version number' do
+        it 'raises an ArgumentError' do
+          expect {
+            described_class.from_pe_version('irving')
+          }.to raise_error(ArgumentError, %r{not a valid version number}i)
+        end
       end
 
       it 'returns the latest Puppet Z release for PE 2017.3.x' do
+        expect(described_class.from_pe_version('2017.3')).to eq(result('5.3.5', '2.4.3'))
         expect(described_class.from_pe_version('2017.3.1')).to eq(result('5.3.5', '2.4.3'))
       end
 
       it 'returns the latest Puppet Z release for PE 2017.2.x' do
+        expect(described_class.from_pe_version('2017.2')).to eq(result('4.10.10', '2.1.9'))
         expect(described_class.from_pe_version('2017.2.1')).to eq(result('4.10.10', '2.1.9'))
       end
 
       it 'returns the latest Puppet Z release for PE 2017.1.x' do
+        expect(described_class.from_pe_version('2017.1')).to eq(result('4.9.4', '2.1.9'))
         expect(described_class.from_pe_version('2017.1.1')).to eq(result('4.9.4', '2.1.9'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.5.x' do
+        expect(described_class.from_pe_version('2016.5')).to eq(result('4.8.1', '2.1.9'))
         expect(described_class.from_pe_version('2016.5.1')).to eq(result('4.8.1', '2.1.9'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.4.x' do
+        expect(described_class.from_pe_version('2016.4')).to eq(result('4.7.0', '2.1.9'))
         expect(described_class.from_pe_version('2016.4.1')).to eq(result('4.7.0', '2.1.9'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.2.x' do
+        expect(described_class.from_pe_version('2016.2')).to eq(result('4.5.3', '2.1.9'))
         expect(described_class.from_pe_version('2016.2.1')).to eq(result('4.5.3', '2.1.9'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.1.x' do
+        expect(described_class.from_pe_version('2016.1')).to eq(result('4.4.2', '2.1.9'))
         expect(described_class.from_pe_version('2016.1.1')).to eq(result('4.4.2', '2.1.9'))
       end
 
@@ -207,37 +252,46 @@ describe PDK::Util::PuppetVersion do
         }
       end
 
-      it 'raises an ArgumentError if passed a non X.Y.Z version' do
-        expect {
-          described_class.from_pe_version('5')
-        }.to raise_error(ArgumentError, %r{not a valid version number}i)
+      context 'and passed an invalid version number' do
+        it 'raises an ArgumentError' do
+          expect {
+            described_class.from_pe_version('irving')
+          }.to raise_error(ArgumentError, %r{not a valid version number}i)
+        end
       end
 
       it 'returns the latest Puppet Z release for PE 2017.3.x' do
+        expect(described_class.from_pe_version('2017.3')).to eq(result('5.3.2'))
         expect(described_class.from_pe_version('2017.3.1')).to eq(result('5.3.2'))
       end
 
       it 'returns the latest Puppet Z release for PE 2017.2.x' do
+        expect(described_class.from_pe_version('2017.2')).to eq(result('4.10.1'))
         expect(described_class.from_pe_version('2017.2.1')).to eq(result('4.10.1'))
       end
 
       it 'returns the latest Puppet Z release for PE 2017.1.x' do
+        expect(described_class.from_pe_version('2017.1')).to eq(result('4.9.4'))
         expect(described_class.from_pe_version('2017.1.1')).to eq(result('4.9.4'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.5.x' do
+        expect(described_class.from_pe_version('2016.5')).to eq(result('4.8.1'))
         expect(described_class.from_pe_version('2016.5.1')).to eq(result('4.8.1'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.4.x' do
+        expect(described_class.from_pe_version('2016.4')).to eq(result('4.7.0'))
         expect(described_class.from_pe_version('2016.4.1')).to eq(result('4.7.0'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.2.x' do
+        expect(described_class.from_pe_version('2016.2')).to eq(result('4.5.2'))
         expect(described_class.from_pe_version('2016.2.1')).to eq(result('4.5.2'))
       end
 
       it 'returns the latest Puppet Z release for PE 2016.1.x' do
+        expect(described_class.from_pe_version('2016.1')).to eq(result('4.4.1'))
         expect(described_class.from_pe_version('2016.1.1')).to eq(result('4.4.1'))
       end
 


### PR DESCRIPTION
@scotje as discussed in hipchat, this change will allow users to specify just major or major.minor versions which will be converted into the equivalent pessimistic version requirement.

e.g.
 * `5` => `~> 5.0`
 * `5.3` => `~> 5.3.0`