### PR TITLE
(PDK-831, PDK-832) Fix ability to unmanage/delete files via .sync.yml 

### DIFF
--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -1,15 +1,6 @@
 module PDK
   module CLI
     module Util
-      MODULE_FOLDERS = %w[
-        manifests
-        lib
-        tasks
-        facts.d
-        functions
-        types
-      ].freeze
-
       # Ensures the calling code is being run from inside a module directory.
       #
       # @param opts [Hash] options to change the behavior of the check logic.
@@ -21,7 +12,7 @@ module PDK
       #   contain a Puppet module.
       def ensure_in_module!(opts = {})
         return unless PDK::Util.module_root.nil?
-        return if opts[:check_module_layout] && PDK::CLI::Util::MODULE_FOLDERS.any? { |dir| File.directory?(dir) }
+        return if opts[:check_module_layout] && PDK::Util.in_module_root?
 
         message = opts.fetch(:message, _('This command must be run from inside a valid module (no metadata.json found).'))
         raise PDK::CLI::ExitWithError.new(message, opts)

--- a/lib/pdk/module/convert.rb
+++ b/lib/pdk/module/convert.rb
@@ -80,11 +80,17 @@ module PDK
             update_manager.add_file(metadata_path, new_metadata.to_json)
           end
 
-          templates.render do |file_path, file_content|
-            if File.exist? file_path
-              update_manager.modify_file(file_path, file_content)
-            else
-              update_manager.add_file(file_path, file_content)
+          templates.render do |file_path, file_content, file_status|
+            if file_status == :unmanage
+              PDK.logger.debug(_("skipping '%{path}'") % { path: file_path })
+            elsif file_status == :delete
+              update_manager.remove_file(file_path)
+            elsif file_status == :manage
+              if File.exist? file_path
+                update_manager.modify_file(file_path, file_content)
+              else
+                update_manager.add_file(file_path, file_content)
+              end
             end
           end
         end

--- a/lib/pdk/module/convert.rb
+++ b/lib/pdk/module/convert.rb
@@ -66,15 +66,18 @@ module PDK
       end
 
       def stage_changes!
+        metadata_path = 'metadata.json'
+
         PDK::Module::TemplateDir.new(template_url, nil, false) do |templates|
-          new_metadata = update_metadata('metadata.json', templates.metadata)
+          new_metadata = update_metadata(metadata_path, templates.metadata)
+          templates.module_metadata = new_metadata.data unless new_metadata.nil?
 
           if options[:noop] && new_metadata.nil?
-            update_manager.add_file('metadata.json', '')
-          elsif File.file?('metadata.json')
-            update_manager.modify_file('metadata.json', new_metadata)
+            update_manager.add_file(metadata_path, '')
+          elsif File.file?(metadata_path)
+            update_manager.modify_file(metadata_path, new_metadata.to_json)
           else
-            update_manager.add_file('metadata.json', new_metadata)
+            update_manager.add_file(metadata_path, new_metadata.to_json)
           end
 
           templates.render do |file_path, file_content|
@@ -126,7 +129,7 @@ module PDK
         end
 
         metadata.update!(template_metadata)
-        metadata.to_json
+        metadata
       end
 
       def summary

--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -8,6 +8,8 @@ require 'pdk/template_file'
 module PDK
   module Module
     class TemplateDir
+      attr_accessor :module_metadata
+
       # Initialises the TemplateDir object with the path or URL to the template
       # and the block of code to run to be run while the template is available.
       #

--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -108,16 +108,26 @@ module PDK
           template_file = template_file.to_s
           PDK.logger.debug(_("Rendering '%{template}'...") % { template: template_file })
           dest_path = template_file.sub(%r{\.erb\Z}, '')
-          begin
-            dest_content = PDK::TemplateFile.new(File.join(template_loc, template_file), configs: config_for(dest_path)).render
-          rescue => e
-            error_msg = _(
-              "Failed to render template '%{template}'\n" \
-              '%{exception}: %{message}',
-            ) % { template: template_file, exception: e.class, message: e.message }
-            raise PDK::CLI::FatalError, error_msg
+          config = config_for(dest_path)
+          dest_status = :manage
+
+          if config['unmanaged']
+            dest_status = :unmanage
+          elsif config['delete']
+            dest_status = :delete
+          else
+            begin
+              dest_content = PDK::TemplateFile.new(File.join(template_loc, template_file), configs: config).render
+            rescue => e
+              error_msg = _(
+                "Failed to render template '%{template}'\n" \
+                '%{exception}: %{message}',
+              ) % { template: template_file, exception: e.class, message: e.message }
+              raise PDK::CLI::FatalError, error_msg
+            end
           end
-          yield dest_path, dest_content
+
+          yield dest_path, dest_content, dest_status
         end
       end
 

--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -6,6 +6,15 @@ require 'pdk/util/windows'
 
 module PDK
   module Util
+    MODULE_FOLDERS = %w[
+      manifests
+      lib
+      tasks
+      facts.d
+      functions
+      types
+    ].freeze
+
     # Searches upwards from current working directory for the given target file.
     #
     # @param target [String] Name of file to search for.
@@ -102,11 +111,23 @@ module PDK
       metadata_path = find_upwards('metadata.json')
       if metadata_path
         File.dirname(metadata_path)
+      elsif in_module_root?
+        Dir.pwd
       else
         nil
       end
     end
     module_function :module_root
+
+    # Returns true or false depending on if any of the common directories in a module
+    # are found in the current directory
+    #
+    # @return [boolean] True if any folders from MODULE_FOLDERS are found in the current dir,
+    #   false otherwise.
+    def in_module_root?
+      PDK::Util::MODULE_FOLDERS.any? { |dir| File.directory?(dir) }
+    end
+    module_function :in_module_root?
 
     # Iterate through possible JSON documents until we find one that is valid.
     #

--- a/spec/acceptance/convert_spec.rb
+++ b/spec/acceptance/convert_spec.rb
@@ -27,6 +27,13 @@ describe 'pdk convert', module_command: true do
 
     before(:all) do
       FileUtils.rm_f 'metadata.json'
+      File.open('.sync.yml', 'w') do |f|
+        f.puts <<-EOS
+---
+.project:
+  unmanaged: true
+        EOS
+      end
     end
 
     describe command('pdk convert --noop --skip-interview') do
@@ -44,11 +51,18 @@ describe 'pdk convert', module_command: true do
     end
   end
 
-  context 'when a file is missing' do
+  context 'when metadata.json file is missing' do
     include_context 'in a new module', 'missing_file', template: template_repo
 
     before(:all) do
       FileUtils.rm_f 'metadata.json'
+      File.open('.sync.yml', 'w') do |f|
+        f.puts <<-EOS
+---
+.project:
+  unmanaged: true
+        EOS
+      end
     end
 
     describe command('pdk convert --force --skip-interview') do
@@ -64,6 +78,62 @@ describe 'pdk convert', module_command: true do
     describe file('metadata.json') do
       it { is_expected.to be_file }
       its(:content_as_json) { is_expected.to include('license' => anything) }
+    end
+  end
+
+  context 'when unmanaging a file' do
+    include_context 'in a new module', 'unmanaged_file', template: template_repo
+
+    before(:all) do
+      File.open('.sync.yml', 'w') do |f|
+        f.puts <<-EOS
+---
+.gitignore:
+  unmanaged: true
+        EOS
+      end
+
+      File.open('.gitignore', 'w') do |f|
+        f.puts 'not supposed to be here'
+      end
+    end
+
+    describe command('pdk convert --force --skip-interview') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stderr) { is_expected.to match(no_output) }
+      its(:stdout) { is_expected.to match(%r{No changes required}i) }
+    end
+
+    describe file('convert_report.txt') do
+      it { is_expected.not_to be_file }
+    end
+  end
+
+  context 'when deleting a file' do
+    include_context 'in a new module', 'deleted_file', template: template_repo
+
+    before(:all) do
+      File.open('.sync.yml', 'w') do |f|
+        f.puts <<-EOS
+---
+.project:
+  delete: true
+        EOS
+      end
+    end
+
+    describe command('pdk convert --force --skip-interview') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stderr) { is_expected.to match(no_output) }
+      its(:stdout) { is_expected.to match(%r{-+files to be removed-+\n\.project}mi) }
+    end
+
+    describe file('.project') do
+      it { is_expected.not_to be_file }
+    end
+
+    describe file('convert_report.txt') do
+      it { is_expected.not_to be_file }
     end
   end
 end

--- a/spec/unit/pdk/module/template_dir_spec.rb
+++ b/spec/unit/pdk/module/template_dir_spec.rb
@@ -206,6 +206,10 @@ describe PDK::Module::TemplateDir do
        foo:
          attr:
          - val: 3
+       .project:
+         delete: true
+       .gitlab-ci.yml:
+         unmanaged: true
        EOF
       end
       let(:yaml_hash) do
@@ -227,7 +231,9 @@ describe PDK::Module::TemplateDir do
         expect(template_dir.config_for(path_or_url)).to eq('module_metadata' => { 'name' => 'foo-bar', 'version' => '0.1.0' },
                                                            'appveyor.yml'    => { 'environment' => { 'PUPPET_GEM_VERSION' => '~> 5.0' } },
                                                            '.travis.yml'     => { 'extras' => [{ 'rvm' => '2.1.9' }] },
-                                                           'foo'             => { 'attr' => [{ 'val' => 1 }, { 'val' => 3 }] })
+                                                           'foo'             => { 'attr' => [{ 'val' => 1 }, { 'val' => 3 }] },
+                                                           '.project'        => { 'delete' => true },
+                                                           '.gitlab-ci.yml'  => { 'unmanaged' => true })
       end
     end
   end

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -265,18 +265,28 @@ describe PDK::Util do
 
     before(:each) do
       allow(described_class).to receive(:find_upwards).with('metadata.json').and_return(metadata_path)
+      allow(described_class).to receive(:in_module_root?).and_return(in_module_root)
     end
 
     context 'when a metadata.json file can be found upwards' do
       let(:metadata_path) { '/path/to/the/module/metadata.json' }
+      let(:in_module_root) { true }
 
       it 'returns the path to the directory containing the metadata.json file' do
         is_expected.to eq(File.dirname(metadata_path))
       end
     end
 
-    context 'when a metadata.json file could not be found' do
+    context 'when a metadata.json file could not be found but module dirs can' do
       let(:metadata_path) { nil }
+      let(:in_module_root) { true }
+
+      it { is_expected.to eq(Dir.pwd) }
+    end
+
+    context 'when a metadata.json file and module dirs could not be found' do
+      let(:metadata_path) { nil }
+      let(:in_module_root) { false }
 
       it { is_expected.to be_nil }
     end


### PR DESCRIPTION
Also includes:
- a fix for an unreported bug where .sync.yml wasn't being read if pdk convert was being performed on a module without a metadata.json.
- added accessor to update/set module_metadata in the TemplateDir.