### PR TITLE
(PDK-842) Wire puppet-version and pe-version options into subcommands

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -51,13 +51,8 @@ module PDK::CLI
   end
 
   def self.puppet_version_options(dsl)
-    dsl.option nil, 'puppet-version', _('Puppet version to run tests or validations against.'), argument: :required do |value|
-      PDK::Util::PuppetVersion.find_gem_for(value)
-    end
-
-    dsl.option nil, 'pe-version', _('Puppet Enterprise version to run tests or validations against.'), argument: :required do |value|
-      PDK::Util::PuppetVersion.from_pe_version(value)
-    end
+    dsl.option nil, 'puppet-version', _('Puppet version to run tests or validations against.'), argument: :required
+    dsl.option nil, 'pe-version', _('Puppet Enterprise version to run tests or validations against.'), argument: :required
   end
 
   @base_cmd = Cri::Command.define do

--- a/lib/pdk/cli/bundle.rb
+++ b/lib/pdk/cli/bundle.rb
@@ -18,6 +18,13 @@ EOF
         message: _('`pdk bundle` can only be run from inside a valid module directory.'),
       )
 
+      PDK::CLI::Util.validate_puppet_version_opts({})
+
+      # Ensure that the bundled gems are up to date and correct Ruby is activated before running commend.
+      puppet_env = PDK::CLI::Util.puppet_from_opts_or_env({})
+      PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
+      PDK::Util::Bundler.ensure_bundle!(puppet_env[:gemset])
+
       command = PDK::CLI::Exec::Command.new(PDK::CLI::Exec.bundle_bin, *args).tap do |c|
         c.context = :module
       end

--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -42,17 +42,24 @@ module PDK
 
       def self.try_vendored_bin(vendored_bin_path, fallback)
         unless PDK::Util.package_install?
-          PDK.logger.debug(_("PDK package installation not found. Trying '%{fallback}' from the system PATH instead.") % { fallback: fallback })
+          PDK.logger.debug(_("PDK package installation not found. Trying '%{fallback}' from the system PATH instead.") % {
+            fallback: fallback,
+          })
           return fallback
         end
 
-        if File.exist?(File.join(PDK::Util.pdk_package_basedir, vendored_bin_path))
-          PDK.logger.debug(_("Using '%{vendored_bin_path}' from PDK package.") % { vendored_bin_path: vendored_bin_path })
-          File.join(PDK::Util.pdk_package_basedir, vendored_bin_path)
-        else
-          PDK.logger.debug(_("Could not find '%{vendored_bin_path}' in PDK package. Trying '%{fallback}' from the system PATH instead.") % { fallback: fallback, vendored_bin_path: vendored_bin_path })
-          fallback
+        vendored_bin_full_path = File.join(PDK::Util.pdk_package_basedir, vendored_bin_path)
+
+        unless File.exist?(vendored_bin_full_path)
+          PDK.logger.debug(_("Could not find '%{vendored_bin}' in PDK package. Trying '%{fallback}' from the system PATH instead.") % {
+            fallback: fallback,
+            vendored_bin: vendored_bin_full_path,
+          })
+          return fallback
         end
+
+        PDK.logger.debug(_("Using '%{vendored_bin}' from PDK package.") % { vendored_bin: vendored_bin_full_path })
+        vendored_bin_full_path
       end
 
       # TODO: decide how/when to connect stdin to child process for things like pry

--- a/lib/pdk/cli/test/unit.rb
+++ b/lib/pdk/cli/test/unit.rb
@@ -22,9 +22,7 @@ module PDK::CLI
     run do |opts, _args, _cmd|
       require 'pdk/tests/unit'
 
-      if opts[:'puppet-version'] && opts[:'pe-version']
-        raise PDK::CLI::ExitWithError, _('You can not specify both --puppet-version and --pe-version at the same time.')
-      end
+      PDK::CLI::Util.validate_puppet_version_opts(opts)
 
       PDK::CLI::Util.ensure_in_module!(
         message:   _('Unit tests can only be run from inside a valid module directory.'),
@@ -65,7 +63,7 @@ module PDK::CLI
                          end
 
         # Ensure that the bundled gems are up to date and correct Ruby is activated before running tests.
-        puppet_env = PDK::CLI::Util.puppet_env_from_opts(opts)
+        puppet_env = PDK::CLI::Util.puppet_from_opts_or_env(opts)
         PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
         PDK::Util::Bundler.ensure_bundle!(puppet_env[:gemset])
 

--- a/lib/pdk/cli/test/unit.rb
+++ b/lib/pdk/cli/test/unit.rb
@@ -64,6 +64,11 @@ module PDK::CLI
                            }]
                          end
 
+        # Ensure that the bundled gems are up to date and correct Ruby is activated before running tests.
+        puppet_env = PDK::CLI::Util.puppet_env_from_opts(opts)
+        PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
+        PDK::Util::Bundler.ensure_bundle!(puppet_env[:gemset])
+
         exit_code = PDK::Test::Unit.invoke(report, opts)
 
         report_formats.each do |format|

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -82,12 +82,15 @@ module PDK
       end
       module_function :module_version_check
 
-      def puppet_env_from_opts(opts)
+      def puppet_from_opts_or_env(opts)
+        desired_puppet_version = (opts || {})[:'puppet-version'] || ENV['PDK_PUPPET_VERSION']
+        desired_pe_version = (opts || {})[:'pe-version'] || ENV['PDK_PE_VERSION']
+
         puppet_env =
-          if opts && opts.key?(:'puppet-version')
-            PDK::Util::PuppetVersion.find_gem_for(opts[:'puppet-version'])
-          elsif opts && opts.key?(:'pe-version')
-            PDK::Util::PuppetVersion.from_pe_version(opts[:'pe-version'])
+          if desired_puppet_version
+            PDK::Util::PuppetVersion.find_gem_for(desired_puppet_version)
+          elsif desired_pe_version
+            PDK::Util::PuppetVersion.from_pe_version(desired_pe_version)
           else
             PDK::Util::PuppetVersion.from_module_metadata || PDK::Util::PuppetVersion.latest_available
           end
@@ -114,7 +117,45 @@ module PDK
           ruby_version: puppet_env[:ruby_version],
         }
       end
-      module_function :puppet_env_from_opts
+      module_function :puppet_from_opts_or_env
+
+      def validate_puppet_version_opts(opts)
+        puppet_ver_specs = []
+        puppet_ver_specs << '--puppet-version option' if opts[:'puppet-version']
+        puppet_ver_specs << 'PDK_PUPPET_VERSION environment variable' if ENV['PDK_PUPPET_VERSION'] && !ENV['PDK_PUPPET_VERSION'].empty?
+
+        pe_ver_specs = []
+        pe_ver_specs << '--pe-version option' if opts[:'pe-version']
+        pe_ver_specs << 'PDK_PE_VERSION environment variable' if ENV['PDK_PE_VERSION'] && !ENV['PDK_PE_VERSION'].empty?
+
+        puppet_ver_specs.each do |pup_ver_spec|
+          next if pe_ver_specs.empty?
+
+          raise PDK::CLI::ExitWithError, _('You cannot specify a %{pup_ver_spec} and %{pe_ver_spec} at the same time.') % {
+            pup_ver_spec: pup_ver_spec,
+            pe_ver_spec: pe_ver_specs[0],
+          }
+        end
+
+        if puppet_ver_specs.size == 2
+          warning_str = 'Puppet version option from command line: "--puppet-version=%{pup_ver_opt}" \
+            overrides value from environment: "PDK_PUPPET_VERSION=%{pup_ver_env}". You should not specify both.'
+
+          PDK.logger.warn(_(warning_str) % {
+            pup_ver_opt: opts[:'puppet-version'],
+            pup_ver_env: ENV['PDK_PUPPET_VERSION'],
+          })
+        elsif pe_ver_specs.size == 2
+          warning_str = 'Puppet Enterprise version option from command line: "--pe-version=%{pe_ver_opt}" \
+            overrides value from environment: "PDK_PE_VERSION=%{pe_ver_env}". You should not specify both.'
+
+          PDK.logger.warn(_(warning_str) % {
+            pup_ver_opt: opts[:'pe-version'],
+            pup_ver_env: ENV['PDK_PE_VERSION'],
+          })
+        end
+      end
+      module_function :validate_puppet_version_opts
     end
   end
 end

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -86,14 +86,18 @@ module PDK
         desired_puppet_version = (opts || {})[:'puppet-version'] || ENV['PDK_PUPPET_VERSION']
         desired_pe_version = (opts || {})[:'pe-version'] || ENV['PDK_PE_VERSION']
 
-        puppet_env =
-          if desired_puppet_version
-            PDK::Util::PuppetVersion.find_gem_for(desired_puppet_version)
-          elsif desired_pe_version
-            PDK::Util::PuppetVersion.from_pe_version(desired_pe_version)
-          else
-            PDK::Util::PuppetVersion.from_module_metadata || PDK::Util::PuppetVersion.latest_available
-          end
+        begin
+          puppet_env =
+            if desired_puppet_version
+              PDK::Util::PuppetVersion.find_gem_for(desired_puppet_version)
+            elsif desired_pe_version
+              PDK::Util::PuppetVersion.from_pe_version(desired_pe_version)
+            else
+              PDK::Util::PuppetVersion.from_module_metadata || PDK::Util::PuppetVersion.latest_available
+            end
+        rescue ArgumentError => e
+          raise PDK::CLI::ExitWithError, e.message
+        end
 
         # Notify user of what Ruby version will be used.
         PDK.logger.info(_('Using Ruby %{version}') % {

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -135,23 +135,25 @@ module PDK
         puppet_ver_specs.each do |pup_ver_spec|
           next if pe_ver_specs.empty?
 
-          raise PDK::CLI::ExitWithError, _('You cannot specify a %{pup_ver_spec} and %{pe_ver_spec} at the same time.') % {
-            pup_ver_spec: pup_ver_spec,
-            pe_ver_spec: pe_ver_specs[0],
+          offending = [pup_ver_spec, pe_ver_specs[0]].sort
+
+          raise PDK::CLI::ExitWithError, _('You cannot specify a %{first} and %{second} at the same time.') % {
+            first: offending[0],
+            second: offending[1],
           }
         end
 
         if puppet_ver_specs.size == 2
-          warning_str = 'Puppet version option from command line: "--puppet-version=%{pup_ver_opt}" \
-            overrides value from environment: "PDK_PUPPET_VERSION=%{pup_ver_env}". You should not specify both.'
+          warning_str = 'Puppet version option from command line: "--puppet-version=%{pup_ver_opt}" '
+          warning_str += 'overrides value from environment: "PDK_PUPPET_VERSION=%{pup_ver_env}". You should not specify both.'
 
           PDK.logger.warn(_(warning_str) % {
             pup_ver_opt: opts[:'puppet-version'],
             pup_ver_env: ENV['PDK_PUPPET_VERSION'],
           })
         elsif pe_ver_specs.size == 2
-          warning_str = 'Puppet Enterprise version option from command line: "--pe-version=%{pe_ver_opt}" \
-            overrides value from environment: "PDK_PE_VERSION=%{pe_ver_env}". You should not specify both.'
+          warning_str = 'Puppet Enterprise version option from command line: "--pe-version=%{pe_ver_opt}" '
+          warning_str += 'overrides value from environment: "PDK_PE_VERSION=%{pe_ver_env}". You should not specify both.'
 
           PDK.logger.warn(_(warning_str) % {
             pup_ver_opt: opts[:'pe-version'],

--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -87,8 +87,10 @@ module PDK::CLI
       options = targets.empty? ? {} : { targets: targets }
       options[:auto_correct] = true if opts.key?(:'auto-correct')
 
-      # Ensure that the bundle is installed and tools are available before running any validations.
-      PDK::Util::Bundler.ensure_bundle!
+      # Ensure that the bundled gems are up to date and correct Ruby is activated before running any validations.
+      puppet_env = PDK::CLI::Util.puppet_env_from_opts(opts)
+      PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
+      PDK::Util::Bundler.ensure_bundle!(puppet_env[:gemset])
 
       exit_code = 0
       if opts[:parallel]

--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -33,9 +33,7 @@ module PDK::CLI
         exit 0
       end
 
-      if opts[:'puppet-version'] && opts[:'pe-version']
-        raise PDK::CLI::ExitWithError, _('You can not specify both --puppet-version and --pe-version at the same time.')
-      end
+      PDK::CLI::Util.validate_puppet_version_opts(opts)
 
       PDK::CLI::Util.ensure_in_module!(
         message:   _('Code validation can only be run from inside a valid module directory'),
@@ -88,7 +86,7 @@ module PDK::CLI
       options[:auto_correct] = true if opts.key?(:'auto-correct')
 
       # Ensure that the bundled gems are up to date and correct Ruby is activated before running any validations.
-      puppet_env = PDK::CLI::Util.puppet_env_from_opts(opts)
+      puppet_env = PDK::CLI::Util.puppet_from_opts_or_env(opts)
       PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
       PDK::Util::Bundler.ensure_bundle!(puppet_env[:gemset])
 

--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -62,7 +62,6 @@ module PDK
       end
 
       def self.invoke(report, options = {})
-        PDK::Util::Bundler.ensure_bundle!
         PDK::Util::Bundler.ensure_binstubs!('rake')
 
         setup
@@ -181,7 +180,6 @@ module PDK
 
       # @return array of { :id, :full_description }
       def self.list
-        PDK::Util::Bundler.ensure_bundle!
         PDK::Util::Bundler.ensure_binstubs!('rake')
 
         command_argv = [File.join(PDK::Util.module_root, 'bin', 'rake'), 'spec_list_json']

--- a/lib/pdk/util/ruby_version.rb
+++ b/lib/pdk/util/ruby_version.rb
@@ -38,10 +38,10 @@ module PDK
 
         def scan_for_packaged_rubies
           ruby_basedir = File.join(PDK::Util.pdk_package_basedir, 'private', 'ruby', '*')
-          Dir[ruby_basedir].map { |ruby_dir|
+          Dir[ruby_basedir].sort.map { |ruby_dir|
             version = File.basename(ruby_dir)
             [version, version.split('.').take(2).concat(['0']).join('.')]
-          }.to_h
+          }.reverse.to_h
         end
 
         def default_ruby_version
@@ -78,6 +78,7 @@ module PDK
           # installed with the package. We also include the separate gem path
           # where our packaged multi-puppet installations live.
           [
+            File.join(PDK::Util.pdk_package_basedir, 'private', 'ruby', ruby_version, 'lib', 'ruby', 'gems', versions[ruby_version]),
             File.join(PDK::Util.package_cachedir, 'ruby', versions[ruby_version]),
             File.join(PDK::Util.pdk_package_basedir, 'private', 'puppet', 'ruby', versions[ruby_version]),
           ].join(File::PATH_SEPARATOR)
@@ -85,7 +86,7 @@ module PDK
           # This allows the subprocess to find the 'bundler' gem, which isn't
           # in GEM_HOME for gem installs.
           # TODO: There must be a better way to do this than shelling out to
-          # gem...
+          # gem... Perhaps can be replaced with "Gem.path"?
           File.absolute_path(File.join(`gem which bundler`, '..', '..', '..', '..'))
         end
       end

--- a/package-testing/tests/version_selection.rb
+++ b/package-testing/tests/version_selection.rb
@@ -1,0 +1,48 @@
+test_name 'Test puppet & ruby version selection' do
+  require 'pdk/pdk_helper.rb'
+
+  module_name = 'version_selection'
+
+  teardown do
+    on(workstation, "rm -rf #{module_name}") if module_name
+  end
+
+  step 'Create a module' do
+    on(workstation, pdk_command(workstation, "new module #{module_name} --skip-interview"))
+  end
+
+  test_cases = [
+    { envvar: 'PDK_PUPPET_VERSION', version: '5.5.0', expected_puppet: '5.3.2', expected_ruby: '2.4.3' },
+    { envvar: 'PDK_PUPPET_VERSION', version: '4.10.1', expected_puppet: '4.10.1', expected_ruby: '2.1.9' },
+    { envvar: 'PDK_PE_VERSION', version: '2017.3.1', expected_puppet: '5.3.2', expected_ruby: '2.4.3' },
+    { envvar: 'PDK_PE_VERSION', version: '2017.2.1', expected_puppet: '4.10.1', expected_ruby: '2.1.9' },
+  ]
+
+  commands = {
+    puppet: 'bundle exec puppet --version',
+    ruby:   'bundle exec ruby --version',
+  }
+
+  test_cases.each do |test_case|
+    slug = (test_case[:envvar] == 'PDK_PE_VERSION') ? 'PE' : 'Puppet'
+
+    step "Select #{slug} #{test_case[:version]}" do
+      on_opts = {
+        accept_all_exit_codes: true,
+        environment:           {
+          test_case[:envvar] => test_case[:version],
+        },
+      }
+
+      on(workstation, "cd #{module_name} && #{pdk_command(workstation, commands[:puppet])}", on_opts) do |outcome|
+        assert_match(%r{^#{Regexp.escape(test_case[:expected_puppet])}$}m, outcome.stderr,
+                     "Should be using Puppet #{test_case[:expected_puppet]}. stderr was: #{outcome.stderr}")
+      end
+
+      on(workstation, "cd #{module_name} && #{pdk_command(workstation, commands[:ruby])}", on_opts) do |outcome|
+        assert_match(%r{^ruby #{Regexp.escape(test_case[:expected_ruby])}}im, outcome.stderr,
+                     "Should be using Ruby #{test_case[:expected_ruby]}. stderr was: #{outcome.stderr}")
+      end
+    end
+  end
+end

--- a/spec/acceptance/new_provider_spec.rb
+++ b/spec/acceptance/new_provider_spec.rb
@@ -67,7 +67,8 @@ SYNC
       context 'when validating the generated code' do
         describe command('pdk validate ruby') do
           its(:stdout) { is_expected.to be_empty }
-          its(:stderr) { is_expected.to be_empty }
+          its(:stderr) { is_expected.to match(%r{using ruby \d+\.\d+\.\d+}i) }
+          its(:stderr) { is_expected.to match(%r{using puppet \d+\.\d+\.\d+}i) }
           its(:exit_status) { is_expected.to eq(0) }
         end
       end

--- a/spec/acceptance/report_spec.rb
+++ b/spec/acceptance/report_spec.rb
@@ -60,7 +60,8 @@ class foo { }
     context 'when not run interactively' do
       describe command('pdk validate puppet manifests/init.pp') do
         its(:exit_status) { is_expected.to eq(0) }
-        its(:stderr) { is_expected.to match(%r{\A\Z}) }
+        its(:stderr) { is_expected.to match(%r{using ruby \d+\.\d+\.\d+}i) }
+        its(:stderr) { is_expected.to match(%r{using puppet \d+\.\d+\.\d+}i) }
         its(:stdout) { is_expected.to match(%r{^warning:.*#{Regexp.escape(init_pp)}.*class not documented}) }
       end
     end

--- a/spec/acceptance/version_changer_spec.rb
+++ b/spec/acceptance/version_changer_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper_acceptance'
+
+describe 'puppet version selection' do
+  context 'in a new module' do
+    include_context 'in a new module', 'version_select'
+
+    %w[5.5.0 4.10.10].each do |puppet_version|
+      describe command("pdk validate --puppet-version #{puppet_version}") do
+        its(:exit_status) { is_expected.to eq(0) }
+      end
+
+      describe file('Gemfile.lock') do
+        it { is_expected.to exist }
+        its(:content) { is_expected.to match(%r{^\s+puppet \(#{Regexp.escape(puppet_version)}(\)|-)}im) }
+      end
+    end
+
+    { '2017.3.1' => '5.3.2', '2017.2.1' => '4.10.1' }.each do |pe_version, puppet_version|
+      describe command("pdk validate --pe-version #{pe_version}") do
+        its(:exit_status) { is_expected.to eq(0) }
+      end
+
+      describe file('Gemfile.lock') do
+        it { is_expected.to exist }
+        its(:content) { is_expected.to match(%r{^\s+puppet \(#{Regexp.escape(puppet_version)}(\)|-)}im) }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,11 @@ RSpec.configure do |c|
   end
 
   c.include_context :stubbed_logger
+
+  # This should catch any tests where we are not mocking out the actual calls to Rubygems.org
+  c.before(:each) do
+    allow(Gem::SpecFetcher).to receive(:fetcher).and_raise('Unmocked call to Gem::SpecFetcher.fetcher!')
+  end
 end
 
 RSpec.shared_context :validators do

--- a/spec/unit/pdk/cli/test/unit_spec.rb
+++ b/spec/unit/pdk/cli/test/unit_spec.rb
@@ -135,7 +135,7 @@ describe '`pdk test unit`' do
 
   context 'when --puppet-version and --pe-version are specified' do
     it 'exits with an error' do
-      expect(logger).to receive(:error).with(a_string_matching(%r{cannot specify.*--puppet-version.*and.*--pe-version}i))
+      expect(logger).to receive(:error).with(a_string_matching(%r{cannot specify.*--pe-version.*and.*--puppet-version}i))
 
       expect {
         PDK::CLI.run(%w[test unit --puppet-version 4.10.10 --pe-version 2018.1.1])
@@ -175,7 +175,7 @@ describe '`pdk test unit`' do
     end
   end
 
-  context 'when --pe-version is specified' do
+  context 'with --pe-version' do
     let(:pe_version) { '2017.2' }
     let(:puppet_env) do
       {

--- a/spec/unit/pdk/cli/test/unit_spec.rb
+++ b/spec/unit/pdk/cli/test/unit_spec.rb
@@ -7,7 +7,7 @@ describe '`pdk test unit`' do
   it { is_expected.not_to be_nil }
 
   before(:each) do
-    allow(PDK::CLI::Util).to receive(:puppet_env_from_opts).and_return(ruby_version: '2.4.3', gemset: { puppet: '5.4.0' })
+    allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env).and_return(ruby_version: '2.4.3', gemset: { puppet: '5.4.0' })
     allow(PDK::Util::RubyVersion).to receive(:use)
     allow(PDK::Util::Bundler).to receive(:ensure_bundle!).with(hash_including(:puppet))
   end
@@ -135,7 +135,7 @@ describe '`pdk test unit`' do
 
   context 'when --puppet-version and --pe-version are specified' do
     it 'exits with an error' do
-      expect(logger).to receive(:error).with(a_string_matching(%r{both --puppet-version and --pe-version}i))
+      expect(logger).to receive(:error).with(a_string_matching(%r{cannot specify.*--puppet-version.*and.*--pe-version}i))
 
       expect {
         PDK::CLI.run(%w[test unit --puppet-version 4.10.10 --pe-version 2018.1.1])
@@ -153,7 +153,7 @@ describe '`pdk test unit`' do
     end
 
     before(:each) do
-      allow(PDK::CLI::Util).to receive(:puppet_env_from_opts).with(hash_including(:'puppet-version' => puppet_version)).and_return(puppet_env)
+      allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env).with(hash_including(:'puppet-version' => puppet_version)).and_return(puppet_env)
       allow(PDK::Test::Unit).to receive(:invoke).and_return(0)
       allow(PDK::CLI::Util).to receive(:module_version_check)
     end
@@ -185,7 +185,7 @@ describe '`pdk test unit`' do
     end
 
     before(:each) do
-      allow(PDK::CLI::Util).to receive(:puppet_env_from_opts).with(hash_including(:'pe-version' => pe_version)).and_return(puppet_env)
+      allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env).with(hash_including(:'pe-version' => pe_version)).and_return(puppet_env)
       allow(PDK::Test::Unit).to receive(:invoke).and_return(0)
       allow(PDK::CLI::Util).to receive(:module_version_check)
     end

--- a/spec/unit/pdk/cli/util_spec.rb
+++ b/spec/unit/pdk/cli/util_spec.rb
@@ -235,5 +235,33 @@ describe PDK::CLI::Util do
         it_behaves_like 'it returns a puppet environment'
       end
     end
+
+    context 'when puppet-version is unmappable' do
+      let(:options) { { :'puppet-version' => '99.99.0' } }
+      let(:ruby_version) { '2.1.9' }
+      let(:puppet_version) { '99.99.0' }
+
+      before(:each) do
+        allow(PDK::Util::PuppetVersion).to receive(:find_gem_for).with(anything).and_raise(ArgumentError, 'error msg')
+      end
+
+      it 'raises a PDK::CLI::ExitWithError' do
+        expect { puppet_env }.to raise_error(PDK::CLI::ExitWithError, 'error msg')
+      end
+    end
+
+    context 'when pe-version is unmappable' do
+      let(:options) { { :'pe-version' => '99.99.0' } }
+      let(:ruby_version) { '2.1.9' }
+      let(:pe_version) { '99.99.0' }
+
+      before(:each) do
+        allow(PDK::Util::PuppetVersion).to receive(:from_pe_version).with(anything).and_raise(ArgumentError, 'error msg')
+      end
+
+      it 'raises a PDK::CLI::ExitWithError' do
+        expect { puppet_env }.to raise_error(PDK::CLI::ExitWithError, 'error msg')
+      end
+    end
   end
 end

--- a/spec/unit/pdk/cli/util_spec.rb
+++ b/spec/unit/pdk/cli/util_spec.rb
@@ -173,8 +173,8 @@ describe PDK::CLI::Util do
     end
   end
 
-  describe '.puppet_env_from_opts' do
-    subject(:puppet_env) { described_class.puppet_env_from_opts(options) }
+  describe '.puppet_from_opts_or_env' do
+    subject(:puppet_env) { described_class.puppet_from_opts_or_env(options) }
 
     let(:version_result) do
       { ruby_version: ruby_version, gem_version: Gem::Version.new(puppet_version) }

--- a/spec/unit/pdk/cli/validate_spec.rb
+++ b/spec/unit/pdk/cli/validate_spec.rb
@@ -152,9 +152,9 @@ describe 'Running `pdk validate` in a module' do
     end
   end
 
-  context 'when both --puppet-version and --pe-version are specified' do
+  context 'with both --puppet-version and --pe-version' do
     it 'exits with an error' do
-      expect(logger).to receive(:error).with(a_string_matching(%r{cannot specify.*--puppet-version.*and.*--pe-version}i))
+      expect(logger).to receive(:error).with(a_string_matching(%r{cannot specify.*--pe-version.*and.*--puppet-version}i))
 
       expect {
         PDK::CLI.run(%w[validate --puppet-version 4.10.10 --pe-version 2018.1.1])
@@ -192,7 +192,7 @@ describe 'Running `pdk validate` in a module' do
     end
   end
 
-  context 'when --pe-version is specified' do
+  context 'with --pe-version' do
     let(:pe_version) { '2017.2' }
     let(:puppet_env) do
       {

--- a/spec/unit/pdk/cli/validate_spec.rb
+++ b/spec/unit/pdk/cli/validate_spec.rb
@@ -12,7 +12,7 @@ describe 'Running `pdk validate` in a module' do
   before(:each) do
     allow(Dir).to receive(:chdir) { |_dir, &block| block.call }
 
-    allow(PDK::CLI::Util).to receive(:puppet_env_from_opts).and_return(ruby_version: '2.4.3', gemset: { puppet: '5.4.0' })
+    allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env).and_return(ruby_version: '2.4.3', gemset: { puppet: '5.4.0' })
     allow(PDK::Util::RubyVersion).to receive(:use)
     allow(PDK::Util::Bundler).to receive(:ensure_bundle!).with(hash_including(:puppet))
 
@@ -154,7 +154,7 @@ describe 'Running `pdk validate` in a module' do
 
   context 'when both --puppet-version and --pe-version are specified' do
     it 'exits with an error' do
-      expect(logger).to receive(:error).with(a_string_matching(%r{both --puppet-version and --pe-version}i))
+      expect(logger).to receive(:error).with(a_string_matching(%r{cannot specify.*--puppet-version.*and.*--pe-version}i))
 
       expect {
         PDK::CLI.run(%w[validate --puppet-version 4.10.10 --pe-version 2018.1.1])
@@ -172,7 +172,7 @@ describe 'Running `pdk validate` in a module' do
     end
 
     before(:each) do
-      allow(PDK::CLI::Util).to receive(:puppet_env_from_opts).with(hash_including(:'puppet-version' => puppet_version)).and_return(puppet_env)
+      allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env).with(hash_including(:'puppet-version' => puppet_version)).and_return(puppet_env)
     end
 
     it 'activates resolved puppet version' do
@@ -202,7 +202,7 @@ describe 'Running `pdk validate` in a module' do
     end
 
     before(:each) do
-      allow(PDK::CLI::Util).to receive(:puppet_env_from_opts).with(hash_including(:'pe-version' => pe_version)).and_return(puppet_env)
+      allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env).with(hash_including(:'pe-version' => pe_version)).and_return(puppet_env)
     end
 
     it 'activates resolved puppet version' do

--- a/spec/unit/pdk/cli/validate_spec.rb
+++ b/spec/unit/pdk/cli/validate_spec.rb
@@ -11,7 +11,11 @@ describe 'Running `pdk validate` in a module' do
 
   before(:each) do
     allow(Dir).to receive(:chdir) { |_dir, &block| block.call }
-    allow(PDK::Util::Bundler).to receive(:ensure_bundle!)
+
+    allow(PDK::CLI::Util).to receive(:puppet_env_from_opts).and_return(ruby_version: '2.4.3', gemset: { puppet: '5.4.0' })
+    allow(PDK::Util::RubyVersion).to receive(:use)
+    allow(PDK::Util::Bundler).to receive(:ensure_bundle!).with(hash_including(:puppet))
+
     allow(PDK::Util).to receive(:module_root).and_return('/path/to/testmodule')
     allow(PDK::Report).to receive(:new).and_return(report)
     allow(PDK::Util).to receive(:module_pdk_version).and_return(PDK::VERSION)
@@ -148,18 +152,73 @@ describe 'Running `pdk validate` in a module' do
     end
   end
 
-  context 'when --puppet-version and --pe-version are specified' do
-    before(:each) do
-      allow(PDK::Util::PuppetVersion).to receive(:find_gem_for).with('4.10.10').and_return('4.10.10')
-      allow(PDK::Util::PuppetVersion).to receive(:from_pe_version).with('2018.1.1').and_return('4.10.10')
-    end
-
+  context 'when both --puppet-version and --pe-version are specified' do
     it 'exits with an error' do
       expect(logger).to receive(:error).with(a_string_matching(%r{both --puppet-version and --pe-version}i))
 
       expect {
         PDK::CLI.run(%w[validate --puppet-version 4.10.10 --pe-version 2018.1.1])
       }.to exit_nonzero
+    end
+  end
+
+  context 'with --puppet-version' do
+    let(:puppet_version) { '5.3' }
+    let(:puppet_env) do
+      {
+        ruby_version: '2.4.3',
+        gemset: { puppet: '5.3.5' },
+      }
+    end
+
+    before(:each) do
+      allow(PDK::CLI::Util).to receive(:puppet_env_from_opts).with(hash_including(:'puppet-version' => puppet_version)).and_return(puppet_env)
+    end
+
+    it 'activates resolved puppet version' do
+      expect(PDK::Util::Bundler).to receive(:ensure_bundle!).with(puppet_env[:gemset])
+
+      expect {
+        PDK::CLI.run(['validate', "--puppet-version=#{puppet_version}"])
+      }.to exit_zero
+    end
+
+    it 'activates resolved ruby version' do
+      expect(PDK::Util::RubyVersion).to receive(:use).with(puppet_env[:ruby_version])
+
+      expect {
+        PDK::CLI.run(['validate', "--puppet-version=#{puppet_version}"])
+      }.to exit_zero
+    end
+  end
+
+  context 'when --pe-version is specified' do
+    let(:pe_version) { '2017.2' }
+    let(:puppet_env) do
+      {
+        ruby_version: '2.1.9',
+        gemset: { puppet: '4.10.9' },
+      }
+    end
+
+    before(:each) do
+      allow(PDK::CLI::Util).to receive(:puppet_env_from_opts).with(hash_including(:'pe-version' => pe_version)).and_return(puppet_env)
+    end
+
+    it 'activates resolved puppet version' do
+      expect(PDK::Util::Bundler).to receive(:ensure_bundle!).with(puppet_env[:gemset])
+
+      expect {
+        PDK::CLI.run(['validate', "--pe-version=#{pe_version}"])
+      }.to exit_zero
+    end
+
+    it 'activates resolved ruby version' do
+      expect(PDK::Util::RubyVersion).to receive(:use).with(puppet_env[:ruby_version])
+
+      expect {
+        PDK::CLI.run(['validate', "--pe-version=#{pe_version}"])
+      }.to exit_zero
     end
   end
 end

--- a/spec/unit/pdk/util/puppet_version_spec.rb
+++ b/spec/unit/pdk/util/puppet_version_spec.rb
@@ -106,7 +106,7 @@ describe PDK::Util::PuppetVersion do
 
       context 'and the specified version does not exist in the cache' do
         it 'notifies the user that it is using the latest Z release instead' do
-          expect(logger).to receive(:info).with(a_string_matching(%r{using 5\.3\.5 instead}i))
+          expect(logger).to receive(:warn).with(a_string_matching(%r{activating 5\.3\.5 instead}i))
           described_class.find_gem_for('5.3.1')
         end
 
@@ -163,7 +163,7 @@ describe PDK::Util::PuppetVersion do
 
       context 'and the specified version does not exist on Rubygems' do
         it 'notifies the user that it is using the latest Z release instead' do
-          expect(logger).to receive(:info).with(a_string_matching(%r{using 4\.10\.10 instead}i))
+          expect(logger).to receive(:warn).with(a_string_matching(%r{activating 4\.10\.10 instead}i))
           described_class.find_gem_for('4.10.999')
         end
 

--- a/spec/unit/pdk/util/puppet_version_spec.rb
+++ b/spec/unit/pdk/util/puppet_version_spec.rb
@@ -64,6 +64,30 @@ describe PDK::Util::PuppetVersion do
     %w[5.4.0 5.3.5 4.10.10 4.8.1 4.9.4 4.7.0 4.5.3 4.4.2]
   end
 
+  describe '.latest_available' do
+    subject { described_class.latest_available }
+
+    let(:expected_version) do
+      versions.sort { |a, b| b <=> a }.first
+    end
+
+    context 'when running from a package install' do
+      include_context 'is a package install'
+      let(:versions) { PDK::Util::RubyVersion.available_puppet_versions }
+
+      it { is_expected.to include(gem_version: expected_version) }
+    end
+
+    context 'when not running from a package install' do
+      include_context 'is not a package install'
+      include_context 'with a mocked rubygems response'
+
+      let(:versions) { rubygems_versions.map { |r| Gem::Version.new(r) } }
+
+      it { is_expected.to include(gem_version: expected_version) }
+    end
+  end
+
   describe '.find_gem_for' do
     context 'when running from a package install' do
       include_context 'is a package install'


### PR DESCRIPTION
Unless otherwise stated, packaged install stuff requires packages built from the HEAD of master on pdk-vanagon.