### PR TITLE
(PDK-904) Warns users of pdk version compatibility 

### DIFF
--- a/lib/pdk/cli/test/unit.rb
+++ b/lib/pdk/cli/test/unit.rb
@@ -31,6 +31,8 @@ module PDK::CLI
         log_level: :info,
       )
 
+      PDK::CLI::Util.module_version_check
+
       report = nil
 
       if opts[:list]

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -56,6 +56,31 @@ module PDK
         true
       end
       module_function :interactive?
+
+      def module_version_check
+        module_pdk_ver = PDK::Util.module_pdk_version
+
+        # This means the module does not have a pdk-version tag in the metadata.json
+        # and will require a pdk convert.
+        if module_pdk_ver.nil?
+          PDK.logger.warn _('This module is not PDK compatible. Run `pdk convert` to make it compatible with your version of PDK.')
+        # This checks that the version of pdk in the module's metadata is older
+        # than 1.3.1, which means the module will need to run pdk convert to the
+        # new templates.
+        elsif Gem::Version.new(module_pdk_ver) < Gem::Version.new('1.3.1')
+          PDK.logger.warn _('This module template is out of date. Run `pdk convert` to make it compatible with your version of PDK.')
+        # This checks if the version of the installed PDK is older than the
+        # version in the module's metadata, and advises the user to upgrade to
+        # their install of PDK.
+        elsif Gem::Version.new(PDK::VERSION) < Gem::Version.new(module_pdk_ver)
+          PDK.logger.warn _('This module is compatible with a newer version of PDK. Upgrade your version of PDK to ensure compatibility.')
+        # This checks if the version listed in the module's metadata is older
+        # than the installed PDK, and advises the user to run pdk update.
+        elsif Gem::Version.new(PDK::VERSION) > Gem::Version.new(module_pdk_ver)
+          PDK.logger.warn _('This module is compatible with an older version of PDK. Run `pdk update` to update it to your version of PDK.')
+        end
+      end
+      module_function :module_version_check
     end
   end
 end

--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -42,6 +42,8 @@ module PDK::CLI
         log_level: :info,
       )
 
+      PDK::CLI::Util.module_version_check
+
       if args[0]
         # This may be a single validator, a list of validators, or a target.
         if Util::OptionValidator.comma_separated_list?(args[0])

--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -251,5 +251,16 @@ module PDK
       ['pdk-version', 'template-url'].any? { |key| module_metadata.key?(key) }
     end
     module_function :module_pdk_compatible?
+
+    def module_pdk_version
+      metadata = module_metadata
+
+      if !metadata.nil? && metadata.include?('pdk-version')
+        metadata['pdk-version'].split.first
+      else
+        nil
+      end
+    end
+    module_function :module_pdk_version
   end
 end

--- a/spec/unit/pdk/cli/test/unit_spec.rb
+++ b/spec/unit/pdk/cli/test/unit_spec.rb
@@ -15,6 +15,7 @@ describe '`pdk test unit`' do
   context 'when executing' do
     before(:each) do
       expect(PDK::CLI::Util).to receive(:ensure_in_module!).with(any_args).once
+      expect(PDK::Util).to receive(:module_pdk_version).and_return(PDK::VERSION)
     end
 
     context 'when listing tests' do

--- a/spec/unit/pdk/cli/util_spec.rb
+++ b/spec/unit/pdk/cli/util_spec.rb
@@ -95,4 +95,61 @@ describe PDK::CLI::Util do
       it { is_expected.to be_falsey }
     end
   end
+
+  describe 'module_version_check' do
+    subject(:module_version_check) { described_class.module_version_check }
+
+    before(:each) do
+      stub_const('PDK::VERSION', '1.5.0')
+      allow(PDK::Util).to receive(:module_pdk_version).and_return(module_pdk_ver)
+    end
+
+    context 'if module doesn\'t have pdk-version in metadata' do
+      let(:module_pdk_ver) { nil }
+
+      before(:each) do
+        expect(logger).to receive(:warn).with(a_string_matching(%r{This module is not PDK compatible. Run `pdk convert` to make it compatible with your version of PDK.}i))
+      end
+
+      it 'does not raise an error' do
+        expect { module_version_check }.not_to raise_error
+      end
+    end
+
+    context 'if module version is older than 1.3.1' do
+      let(:module_pdk_ver) { '1.2.0' }
+
+      before(:each) do
+        expect(logger).to receive(:warn).with(a_string_matching(%r{This module template is out of date. Run `pdk convert` to make it compatible with your version of PDK.}i))
+      end
+
+      it 'does not raise an error' do
+        expect { module_version_check }.not_to raise_error
+      end
+    end
+
+    context 'if module version is newer than installed version' do
+      let(:module_pdk_ver) { '1.5.1' }
+
+      before(:each) do
+        expect(logger).to receive(:warn).with(a_string_matching(%r{This module is compatible with a newer version of PDK. Upgrade your version of PDK to ensure compatibility.}i))
+      end
+
+      it 'does not raise an error' do
+        expect { module_version_check }.not_to raise_error
+      end
+    end
+
+    context 'if module version is older than installed version' do
+      let(:module_pdk_ver) { '1.3.1' }
+
+      before(:each) do
+        expect(logger).to receive(:warn).with(a_string_matching(%r{This module is compatible with an older version of PDK. Run `pdk update` to update it to your version of PDK.}i))
+      end
+
+      it 'does not raise an error' do
+        expect { module_version_check }.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/unit/pdk/cli/validate_spec.rb
+++ b/spec/unit/pdk/cli/validate_spec.rb
@@ -14,6 +14,7 @@ describe 'Running `pdk validate` in a module' do
     allow(PDK::Util::Bundler).to receive(:ensure_bundle!)
     allow(PDK::Util).to receive(:module_root).and_return('/path/to/testmodule')
     allow(PDK::Report).to receive(:new).and_return(report)
+    allow(PDK::Util).to receive(:module_pdk_version).and_return(PDK::VERSION)
   end
 
   context 'when no arguments or options are provided' do


### PR DESCRIPTION
This will warn a user if their module requires a pdk update, pdk convert, or pdk installation upgrade based on a comparison of the version displayed in their module's metadata and the installed PDK version.