### PR TITLE
(maint) Remove static PE version map from PDK::Util::PuppetVersion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,7 +55,6 @@ RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests. A necessary evil in acceptance testing.
   Exclude:
     - 'spec/acceptance/**/*.rb'
-    - 'spec/unit/pdk/util/puppet_version_spec.rb'
 
 RSpec/DescribeClass:
   Description: This cop does not account for rspec-puppet, and beaker-rspec usage.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,7 @@ RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests. A necessary evil in acceptance testing.
   Exclude:
     - 'spec/acceptance/**/*.rb'
+    - 'spec/unit/pdk/util/puppet_version_spec.rb'
 
 RSpec/DescribeClass:
   Description: This cop does not account for rspec-puppet, and beaker-rspec usage.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,13 @@ install:
       ElseIf ($ENV:USE_CYGWIN) {
         $ENV:PATH = "C:\Ruby${ENV:RUBY_VERSION}\bin;C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;" + $ENV:PATH
       }
+  - ps: |
+      $CACertFile = Join-Path -Path $ENV:AppData -ChildPath "RubyCACert.pem"
+      If (-Not (Test-Path -Path $CACertFile)) {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-WebRequest -Uri "https://curl.haxx.se/ca/cacert.pem" -UseBasicParsing -OutFile $CACertFile | Out-Null
+      }
+      $ENV:SSL_CERT_FILE = $CACertFile
   - echo %PATH%
   - bundle install --jobs 4 --retry 2 --without development
 

--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -3,6 +3,7 @@ require 'tempfile'
 
 require 'pdk/util/version'
 require 'pdk/util/windows'
+require 'pdk/util/vendored_file'
 
 module PDK
   module Util

--- a/lib/pdk/util/puppet_version.rb
+++ b/lib/pdk/util/puppet_version.rb
@@ -15,6 +15,8 @@ module PDK
         end
       end
 
+      PE_VERSIONS_URL = 'https://forgeapi.puppet.com/private/versions/pe'.freeze
+
       def latest_available
         latest = find_gem(Gem::Requirement.create('>= 0'))
 
@@ -115,20 +117,14 @@ module PDK
         end
       end
 
-      # TODO: Replace this with a cached forge lookup like we do for the task
-      # metadata schema (PDK-828)
       def fetch_pe_version_map
-        [
-          { 'name' => '2017.3.x', 'puppet_range' => '5.3.x',  'puppet' => '5.3.2'  },
-          { 'name' => '2017.2.x', 'puppet_range' => '4.10.x', 'puppet' => '4.10.1' },
-          { 'name' => '2017.1.x', 'puppet_range' => '4.9.x',  'puppet' => '4.9.4'  },
-          { 'name' => '2016.5.x', 'puppet_range' => '4.8.x',  'puppet' => '4.8.1'  },
-          { 'name' => '2016.4.x', 'puppet_range' => '4.7.x',  'puppet' => '4.7.0'  },
-          { 'name' => '2016.2.x', 'puppet_range' => '4.5.x',  'puppet' => '4.5.2'  },
-          { 'name' => '2016.1.x', 'puppet_range' => '4.4.x',  'puppet' => '4.4.1'  },
-          { 'name' => '2015.3.x', 'puppet_range' => '4.3.x',  'puppet' => '4.3.2'  },
-          { 'name' => '2015.2.x', 'puppet_range' => '4.2.x',  'puppet' => '4.2.3'  },
-        ]
+        map = PDK::Util::VendoredFile.new('pe_versions.json', PE_VERSIONS_URL).read
+
+        JSON.parse(map)
+      rescue PDK::Util::VendoredFile::DownloadError => e
+        raise PDK::CLI::FatalError, e.message
+      rescue JSON::ParserError
+        raise PDK::CLI::FatalError, _('Failed to parse Puppet Enterprise version map file.')
       end
 
       def requirement_from_forge_range(range_str)

--- a/lib/pdk/util/vendored_file.rb
+++ b/lib/pdk/util/vendored_file.rb
@@ -1,0 +1,83 @@
+require 'pdk/util'
+require 'net/https'
+require 'openssl'
+require 'fileutils'
+
+module PDK
+  module Util
+    class VendoredFile
+      class DownloadError < StandardError; end
+
+      HTTP_ERRORS = [
+        EOFError,
+        Errno::ECONNRESET,
+        Errno::EINVAL,
+        Errno::ECONNREFUSED,
+        Net::HTTPBadResponse,
+        Net::HTTPHeaderSyntaxError,
+        Net::ProtocolError,
+        Timeout::Error,
+      ].freeze
+
+      attr_reader :file_name
+      attr_reader :url
+
+      def initialize(file_name, url)
+        @file_name = file_name
+        @url = url
+      end
+
+      def read
+        return File.read(package_vendored_path) if PDK::Util.package_install?
+        return File.read(gem_vendored_path) if File.file?(gem_vendored_path)
+
+        content = download_file
+        FileUtils.mkdir_p(File.dirname(gem_vendored_path))
+        File.open(gem_vendored_path, 'w') do |fd|
+          fd.write(content)
+        end
+        content
+      end
+
+      private
+
+      def download_file
+        PDK.logger.debug _('%{file_name} was not found in the cache, downloading it from %{url}.') % {
+          file_name: file_name,
+          url:       url,
+        }
+
+        uri = URI.parse(url)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        # TODO: Get rid of this, possible workaround:
+        # https://github.com/glennsarti/dev-tools/blob/master/RubyCerts.ps1
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE if Gem.win_platform?
+        request = Net::HTTP::Get.new(uri.request_uri)
+        response = http.request(request)
+
+        unless response.code == '200'
+          raise DownloadError, _('Unable to download %{url}. %{code}: %{message}.') % {
+            url:     url,
+            code:    response.code,
+            message: response.message,
+          }
+        end
+
+        response.body
+      rescue *HTTP_ERRORS => e
+        raise DownloadError, _('Unable to download %{url}. Check internet connectivity and try again. %{error}') % {
+          error: e,
+        }
+      end
+
+      def package_vendored_path
+        @package_vendored_path ||= File.join(PDK::Util.package_cachedir, file_name)
+      end
+
+      def gem_vendored_path
+        @gem_vendored_path ||= File.join(PDK::Util.cachedir, PDK::VERSION, file_name)
+      end
+    end
+  end
+end

--- a/lib/pdk/util/vendored_file.rb
+++ b/lib/pdk/util/vendored_file.rb
@@ -32,6 +32,9 @@ module PDK
         return File.read(gem_vendored_path) if File.file?(gem_vendored_path)
 
         content = download_file
+
+        # TODO: should only write if it's valid JSON
+        # TODO: need a way to invalidate if out of date
         FileUtils.mkdir_p(File.dirname(gem_vendored_path))
         File.open(gem_vendored_path, 'w') do |fd|
           fd.write(content)
@@ -67,6 +70,7 @@ module PDK
         response.body
       rescue *HTTP_ERRORS => e
         raise DownloadError, _('Unable to download %{url}. Check internet connectivity and try again. %{error}') % {
+          url: url,
           error: e,
         }
       end

--- a/spec/fixtures/pe_versions.json
+++ b/spec/fixtures/pe_versions.json
@@ -1,0 +1,203 @@
+[
+  {
+    "release": "2017.3.x",
+    "lts": false,
+    "puppet_range": "5.3.x",
+    "latest": "2017.3.5",
+    "versions": [
+      {
+        "version": "2017.3.5",
+        "release_date": "2018-02-21",
+        "agent": "5.3.5",
+        "puppet": "5.3.5",
+        "ruby": "2.4.3"
+      },
+      {
+        "version": "2017.3.4",
+        "release_date": "2018-02-05",
+        "agent": "5.3.4",
+        "puppet": "5.3.4",
+        "ruby": "2.4.3"
+      },
+      {
+        "version": "2017.3.2",
+        "release_date": "2017-11-07",
+        "agent": "5.3.3",
+        "puppet": "5.3.3",
+        "ruby": "2.4.2"
+      },
+      {
+        "version": "2017.3.1",
+        "release_date": "2017-10-17",
+        "agent": "5.3.2",
+        "puppet": "5.3.2",
+        "ruby": "2.4.1"
+      },
+      {
+        "version": "2017.3.0",
+        "release_date": "2017-10-11",
+        "agent": "5.3.2",
+        "puppet": "5.3.2",
+        "ruby": "2.4.1"
+      }
+    ]
+  },
+  {
+    "release": "2017.2.x",
+    "lts": false,
+    "puppet_range": "4.10.x",
+    "latest": "2017.2.5",
+    "versions": [
+      {
+        "version": "2017.2.5",
+        "release_date": "2017-11-07",
+        "agent": "1.10.9",
+        "puppet": "4.10.9",
+        "ruby": "2.1.9"
+      },
+      {
+        "version": "2017.2.4",
+        "release_date": "2017-09-21",
+        "agent": "1.10.8",
+        "puppet": "4.10.8",
+        "ruby": "2.1.9"
+      },
+      {
+        "version": "2017.2.3",
+        "release_date": "2017-08-08",
+        "agent": "1.10.5",
+        "puppet": "4.10.5",
+        "ruby": "2.1.9"
+      },
+      {
+        "version": "2017.2.2",
+        "release_date": "2017-06-22",
+        "agent": "1.10.4",
+        "puppet": "4.10.4",
+        "ruby": "2.1.9"
+      },
+      {
+        "version": "2017.2.1",
+        "release_date": "2017-05-11",
+        "agent": "1.10.1",
+        "puppet": "4.10.1",
+        "ruby": "2.1.9"
+      }
+    ]
+  },
+  {
+    "release": "2017.1.x",
+    "lts": false,
+    "puppet_range": "4.9.x",
+    "latest": "2017.1.1",
+    "versions": [
+      {
+        "version": "2017.1.1",
+        "release_date": "2017-03-20",
+        "agent": "1.9.3",
+        "puppet": "4.9.4",
+        "ruby": "2.1.9"
+      },
+      {
+        "version": "2017.1.0",
+        "release_date": "2017-03-14",
+        "agent": "1.9.3",
+        "puppet": "4.9.4",
+        "ruby": "2.1.9"
+      }
+    ]
+  },
+  {
+    "release": "2016.5.x",
+    "lts": false,
+    "puppet_range": "4.8.x",
+    "latest": "2016.5.2",
+    "versions": [
+      {
+        "version": "2016.5.2",
+        "release_date": "2017-02-07",
+        "agent": "1.8.3",
+        "puppet": "4.8.2",
+        "ruby": "2.1.9"
+      },
+      {
+        "version": "2016.5.1",
+        "release_date": "2016-12-13",
+        "agent": "1.8.2",
+        "puppet": "4.8.1",
+        "ruby": "2.1.9"
+      }
+    ]
+  },
+  {
+    "release": "2016.4.x",
+    "lts": true,
+    "puppet_range": ">=4.7.0 <5.0.0",
+    "latest": "2016.4.10",
+    "versions": [
+      {
+        "version": "2016.4.10",
+        "release_date": "2018-02-05",
+        "agent": "1.10.10",
+        "puppet": "4.10.10",
+        "ruby": "2.1.9"
+      },
+      {
+        "version": "2016.4.9",
+        "release_date": "2017-11-07",
+        "agent": "1.10.9",
+        "puppet": "4.10.9",
+        "ruby": "2.1.9"
+      },
+      {
+        "version": "2016.4.8",
+        "release_date": "2017-09-21",
+        "agent": "1.10.8",
+        "puppet": "4.10.8",
+        "ruby": "2.1.9"
+      },
+      {
+        "version": "2016.4.7",
+        "release_date": "2017-08-08",
+        "agent": "1.10.5",
+        "puppet": "4.10.5",
+        "ruby": "2.1.9"
+      },
+      {
+        "version": "2016.4.6",
+        "release_date": "2017-06-22",
+        "agent": "1.10.4",
+        "puppet": "4.10.4",
+        "ruby": "2.1.9"
+      },
+      {
+        "version": "2016.4.5",
+        "release_date": "2017-05-11",
+        "agent": "1.10.1",
+        "puppet": "4.10.1",
+        "ruby": "2.1.9"
+      },
+      {
+        "version": "2016.4.3",
+        "release_date": "2017-02-07",
+        "agent": "1.7.2",
+        "puppet": "4.7.1",
+        "ruby": "2.1.9"
+      },
+      {
+        "version": "2016.4.2",
+        "release_date": "2016-11-03",
+        "agent": "1.7.1",
+        "puppet": "4.7.0",
+        "ruby": "2.1.9"
+      },
+      {
+        "version": "2016.4.0",
+        "release_date": "2016-10-20",
+        "agent": "1.7.1",
+        "puppet": "4.7.0",
+        "ruby": "2.1.9"
+      }
+    ]
+  }
+]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,6 +54,9 @@ RSpec.configure do |c|
   c.before(:each) do
     allow(Gem::SpecFetcher).to receive(:fetcher).and_raise('Unmocked call to Gem::SpecFetcher.fetcher!')
   end
+
+  c.add_setting :root
+  c.root = File.dirname(__FILE__)
 end
 
 RSpec.shared_context :validators do

--- a/spec/unit/pdk/util/vendored_file_spec.rb
+++ b/spec/unit/pdk/util/vendored_file_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+require 'net/https'
+
+describe PDK::Util::VendoredFile do
+  describe '#read' do
+    subject(:vendored_file_read) { described_class.new(file_name, url).read }
+
+    let(:url) { 'https://test.com/test_file' }
+    let(:file_name) { 'test_file' }
+
+    let(:package_cachedir) { File.join('/', 'path', 'to', 'package', 'cachedir') }
+    let(:package_vendored_path) { File.join(package_cachedir, file_name) }
+    let(:package_vendored_content) { 'package file content' }
+
+    let(:cachedir) { File.join('/', 'path', 'to', 'pdk', 'cachedir') }
+    let(:gem_vendored_path) { File.join(cachedir, PDK::VERSION, file_name) }
+    let(:gem_vendored_content) { 'gem file content' }
+
+    before(:each) do
+      allow(PDK::Util).to receive(:package_cachedir).and_return(package_cachedir)
+      allow(PDK::Util).to receive(:cachedir).and_return(cachedir)
+      allow(File).to receive(:read).with(package_vendored_path).and_return(package_vendored_content)
+      allow(File).to receive(:read).with(gem_vendored_path).and_return(gem_vendored_content)
+    end
+
+    context 'when running from a package install' do
+      before(:each) do
+        allow(PDK::Util).to receive(:package_install?).and_return(true)
+      end
+
+      it 'returns the content of the file vendored in the package' do
+        is_expected.to eq(package_vendored_content)
+      end
+    end
+
+    context 'when not running from a package install' do
+      before(:each) do
+        allow(PDK::Util).to receive(:package_install?).and_return(false)
+      end
+
+      context 'and the file has already been cached on disk' do
+        before(:each) do
+          allow(File).to receive(:file?).with(gem_vendored_path).and_return(true)
+        end
+
+        it 'returns the content of the vendored file' do
+          is_expected.to eq(gem_vendored_content)
+        end
+      end
+
+      context 'and the file has not already been cached on disk' do
+        before(:each) do
+          allow(File).to receive(:file?).with(gem_vendored_path).and_return(false)
+          allow(Net::HTTP::Get).to receive(:new).with(anything).and_return(mock_request)
+          allow(Net::HTTP).to receive(:new).with(any_args).and_return(mock_http)
+          allow(mock_http).to receive(:use_ssl=).with(anything)
+          allow(mock_http).to receive(:verify_mode=).with(anything)
+        end
+
+        let(:download_error) { PDK::Util::VendoredFile::DownloadError }
+        let(:mock_http) { instance_double(Net::HTTP) }
+        let(:mock_request) { instance_double(Net::HTTP::Get) }
+        let(:mock_response) { instance_double(Net::HTTPResponse) }
+
+        context 'and the download succeeded' do
+          before(:each) do
+            allow(mock_http).to receive(:request).with(mock_request).and_return(mock_response)
+            allow(mock_response).to receive(:code).and_return('200')
+            allow(mock_response).to receive(:body).and_return(gem_vendored_content)
+            allow(FileUtils).to receive(:mkdir_p).with(File.dirname(gem_vendored_path))
+            allow(File).to receive(:open).with(any_args).and_call_original
+            allow(File).to receive(:open).with(gem_vendored_path, 'w').and_yield(cached_file)
+          end
+
+          let(:cached_file) { StringIO.new }
+
+          it 'caches the download to disk' do
+            vendored_file_read
+
+            expect(cached_file.string).to eq(gem_vendored_content)
+          end
+
+          it 'returns the downloaded content' do
+            is_expected.to eq(gem_vendored_content)
+          end
+        end
+
+        context 'and the download failed' do
+          before(:each) do
+            allow(mock_http).to receive(:request).with(anything).and_return(mock_response)
+            allow(mock_response).to receive(:code).and_return('404')
+            allow(mock_response).to receive(:message).and_return('file not found')
+          end
+
+          it 'raises a DownloadError' do
+            expect {
+              vendored_file_read
+            }.to raise_error(download_error, %r{unable to download.+\. 404: file not found}i)
+          end
+        end
+
+        context 'and the connection to the remote server failed' do
+          before(:each) do
+            allow(mock_http).to receive(:request).with(anything).and_raise(Errno::ECONNREFUSED, 'some error')
+          end
+
+          it 'raises a DownloadError' do
+            expect {
+              vendored_file_read
+            }.to raise_error(download_error, %r{check internet connectivity}i)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This ended up an uglier change than I expected as the format of the JSON object from the forge API changed between the initial implementation and now. I've tried to keep the changes logically separated by commit though for easier reviewing.