### PR TITLE
(MAINT) Fix package tests for version selection and airgapped usage

### DIFF
--- a/package-testing/config/options.rb
+++ b/package-testing/config/options.rb
@@ -6,4 +6,5 @@
   ssh: {
     keys: ['~/.ssh/id_rsa-acceptance'],
   },
+  preserve_hosts: 'onfail',
 }

--- a/package-testing/lib/pdk/pdk_helper.rb
+++ b/package-testing/lib/pdk/pdk_helper.rb
@@ -15,11 +15,22 @@ def pdk_git_bin_dir(host)
 end
 
 # Common way to just invoke 'pdk' on each platform
-def pdk_command(host, command)
+def pdk_command(host, command, env = {})
+  env ||= {}
+  env_str = ''
+
   if host.platform =~ %r{windows}
+    env.each do |var, val|
+      env_str += "\\$env:#{var}='#{val}'; "
+    end
+
     # Pass the command to powershell and exit powershell with pdk's exit code
-    "powershell -Command 'pdk #{command.tr("'", "\'")}; exit $LASTEXITCODE'"
+    "powershell -Command \"#{env_str.tr('"', '\"').strip} pdk #{command.tr('"', '\"')}; exit $LASTEXITCODE\""
   else
-    "/bin/bash -lc \"pdk #{command}\""
+    env.each do |var, val|
+      env_str += "#{var}=#{val} "
+    end
+
+    "/bin/bash -lc \"#{env_str} pdk #{command}\""
   end
 end

--- a/package-testing/tests/airgapped_usage.rb
+++ b/package-testing/tests/airgapped_usage.rb
@@ -1,0 +1,39 @@
+test_name 'Basic usage in an air-gapped environment (no network access to rubygems.org)' do
+  require 'pdk/pdk_helper.rb'
+
+  module_name = 'airgapped_module'
+  hosts_file = (workstation.platform =~ %r{windows}) ? '/cygdrive/c/Windows/System32/Drivers/etc/hosts' : '/etc/hosts'
+
+  teardown do
+    on(workstation, "rm -rf #{module_name}") if module_name
+    on(workstation, "cp #{hosts_file}.bak #{hosts_file}", accept_all_exit_codes: true)
+  end
+
+  step 'Disable access to rubygems.org' do
+    on(workstation, "cp #{hosts_file} #{hosts_file}.bak", accept_all_exit_codes: true)
+    on(workstation, "echo \"127.0.0.1 rubygems.org\" >> #{hosts_file}", accept_all_exit_codes: true)
+  end
+
+  step 'Create module' do
+    on(workstation, pdk_command(workstation, "new module #{module_name} --skip-interview")) do
+      on(workstation, %(cat #{module_name}/metadata.json | egrep '"template-url":'), accept_all_exit_codes: true) do |template_result|
+        assert_match(%r{"file://.*pdk-templates\.git",?$}, template_result.stdout.strip, "New module's metadata should refer to vendored pdk-templates repo")
+      end
+    end
+  end
+
+  step 'Validate the module' do
+    on(workstation, "cd #{module_name} && #{pdk_command(workstation, 'validate --debug')}", accept_all_exit_codes: true) do |outcome|
+      assert_equal(0, outcome.exit_code,
+                   "Validate on a new module should return 0. stderr was: #{outcome.stderr}")
+
+      on(workstation, "test -f #{module_name}/Gemfile.lock", accept_all_exit_codes: true) do |lock_check_outcome|
+        assert_equal(0, lock_check_outcome.exit_code, 'pdk validate should have caused a Gemfile.lock file to be created')
+      end
+
+      on(workstation, "diff #{install_dir(workstation)}/share/cache/Gemfile.lock #{module_name}/Gemfile.lock", accept_all_exit_codes: true) do |gemfile_cmp|
+        assert_equal(0, gemfile_cmp.exit_code, "newly created Gemfile.lock should match vendored Gemfile.lock but it had differences: #{gemfile_cmp.stdout}")
+      end
+    end
+  end
+end

--- a/package-testing/tests/version_selection.rb
+++ b/package-testing/tests/version_selection.rb
@@ -12,10 +12,10 @@ test_name 'Test puppet & ruby version selection' do
   end
 
   test_cases = [
-    { envvar: 'PDK_PUPPET_VERSION', version: '5.5.0', expected_puppet: '5.3.2', expected_ruby: '2.4.3' },
-    { envvar: 'PDK_PUPPET_VERSION', version: '4.10.1', expected_puppet: '4.10.1', expected_ruby: '2.1.9' },
-    { envvar: 'PDK_PE_VERSION', version: '2017.3.1', expected_puppet: '5.3.2', expected_ruby: '2.4.3' },
-    { envvar: 'PDK_PE_VERSION', version: '2017.2.1', expected_puppet: '4.10.1', expected_ruby: '2.1.9' },
+    { envvar: 'PDK_PUPPET_VERSION', version: '5.5.0', expected_puppet: '5.5', expected_ruby: '2.4.3' },
+    { envvar: 'PDK_PUPPET_VERSION', version: '4.10.10', expected_puppet: '4.10', expected_ruby: '2.1.9' },
+    { envvar: 'PDK_PE_VERSION', version: '2017.3', expected_puppet: '5.3', expected_ruby: '2.4.3' },
+    { envvar: 'PDK_PE_VERSION', version: '2017.2', expected_puppet: '4.10', expected_ruby: '2.1.9' },
   ]
 
   commands = {
@@ -27,20 +27,19 @@ test_name 'Test puppet & ruby version selection' do
     slug = (test_case[:envvar] == 'PDK_PE_VERSION') ? 'PE' : 'Puppet'
 
     step "Select #{slug} #{test_case[:version]}" do
-      on_opts = {
-        accept_all_exit_codes: true,
-        environment:           {
-          test_case[:envvar] => test_case[:version],
-        },
-      }
+      env = { test_case[:envvar] => test_case[:version] }
 
-      on(workstation, "cd #{module_name} && #{pdk_command(workstation, commands[:puppet])}", on_opts) do |outcome|
-        assert_match(%r{^#{Regexp.escape(test_case[:expected_puppet])}$}m, outcome.stderr,
-                     "Should be using Puppet #{test_case[:expected_puppet]}. stderr was: #{outcome.stderr}")
+      gemspecs = on(workstation, "find #{install_dir(workstation)} -name 'puppet-#{test_case[:expected_puppet]}.*.gemspec'")
+      puppet_versions = gemspecs.stdout.lines.map { |r| r[%r{puppet-([\d\.]+)(-.+?)?\.gemspec\Z}, 1] }
+      expected_puppet_regex = puppet_versions.map { |r| Regexp.escape(r) }.join('|')
+
+      on(workstation, "pushd #{module_name} && #{pdk_command(workstation, commands[:puppet], env)} && popd", accept_all_exit_codes: true) do |outcome|
+        assert_match(%r{using puppet (#{expected_puppet_regex})}im, outcome.stderr,
+                     "Should be using Puppet /(#{expected_puppet_regex})/. stderr was: #{outcome.stderr}")
       end
 
-      on(workstation, "cd #{module_name} && #{pdk_command(workstation, commands[:ruby])}", on_opts) do |outcome|
-        assert_match(%r{^ruby #{Regexp.escape(test_case[:expected_ruby])}}im, outcome.stderr,
+      on(workstation, "pushd #{module_name} && #{pdk_command(workstation, commands[:ruby], env)} && popd", accept_all_exit_codes: true) do |outcome|
+        assert_match(%r{using ruby #{Regexp.escape(test_case[:expected_ruby])}}im, outcome.stderr,
                      "Should be using Ruby #{test_case[:expected_ruby]}. stderr was: #{outcome.stderr}")
       end
     end


### PR DESCRIPTION
Incorporates Tim's fixes to the version selection tests to make them more dynamic, adds the "airgapped usage" tests that I was working on, and fixes ENV management for Windows tests.