### PR TITLE
(maint) Allow module name to contain underscores when verifying

### DIFF
--- a/lib/pdk/generate/module.rb
+++ b/lib/pdk/generate/module.rb
@@ -286,7 +286,7 @@ module PDK
         if opts[:only_ask]
           questions.reject! do |question|
             if %w[module_name forge_username].include?(question[:name])
-              metadata.data['name'] && metadata.data['name'] =~ %r{\A[a-z0-9]+-[a-z0-9]+\Z}i
+              metadata.data['name'] && metadata.data['name'] =~ %r{\A[a-z0-9]+-[a-z][a-z0-9_]*\Z}i
             else
               !opts[:only_ask].include?(question[:name])
             end

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -304,6 +304,23 @@ describe PDK::Generate::Module do
 
         expect(interview_metadata).to eq(expected_metadata)
       end
+
+      context 'and the module name contains underscores' do
+        let(:default_metadata) do
+          {
+            'name' => 'test-long_module_name',
+          }
+        end
+
+        it 'does not reinterview for the module name' do
+          allow($stdout).to receive(:puts).with(a_string_matching(%r{update the metadata\.json.+1 question}m))
+
+          expected_metadata = PDK::Module::Metadata.new.update!(default_metadata).data.dup
+          expected_metadata['source'] = 'https://something'
+
+          expect(interview_metadata).to eq(expected_metadata)
+        end
+      end
     end
 
     context 'with --full-interview' do


### PR DESCRIPTION
This change prevents the metadata interview from re-asking for the module name if the module name contains underscores.