### PR TITLE
(PDK-802) Work around OpenSSL multi-threading errors when needed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,15 +7,19 @@ environment:
     # - RUBY_VERSION: 25-x64
     #   USE_MSYS: true
     #   SUITES: "spec"
+    #   BUNDLE_JOBS: 4
     - RUBY_VERSION: 24-x64
       USE_MSYS: true
       SUITES: "spec acceptance:local"
+      BUNDLE_JOBS: 4
     - RUBY_VERSION: 23-x64
       USE_CYGWIN: true
       SUITES: "spec"
+      BUNDLE_JOBS: 1
     - RUBY_VERSION: 21-x64
       USE_CYGWIN: true
       SUITES: "spec"
+      BUNDLE_JOBS: 1
 
 install:
   - ps: |
@@ -36,7 +40,7 @@ install:
       }
       $ENV:SSL_CERT_FILE = $CACertFile
   - echo %PATH%
-  - bundle install --jobs 4 --retry 2 --without development
+  - bundle install --retry 2 --without development
 
 build: off
 

--- a/lib/pdk/util/bundler.rb
+++ b/lib/pdk/util/bundler.rb
@@ -188,7 +188,8 @@ module PDK
         end
 
         def install!(gem_overrides = {})
-          argv = ['install', "--gemfile=#{gemfile}", '-j4']
+          argv = ['install', "--gemfile=#{gemfile}"]
+          argv << '-j4' unless Gem.win_platform? && Gem::Version.new(PDK::Util::RubyVersion.active_ruby_version) < Gem::Version.new('2.3.5')
           argv << "--path=#{bundle_cachedir}" unless PDK::Util.package_install?
 
           cmd = bundle_command(*argv).tap do |c|


### PR DESCRIPTION
For post-1.5.0 bug bashing consideration.

See https://bugs.ruby-lang.org/issues/11033 for background.

I think this is the cause of our "cert already in hash table" transients in Appveyor as well as some of the issues @glennsarti was encountering in https://tickets.puppetlabs.com/browse/PDK-802

Ruby issue linked above was backported to Ruby 2.3 branch and released in 2.3.5, however Appveyor is still on 2.3.3 for Ruby23.

Inside PDK packages it should only be an issue on the 2.1.9 bundler invocations.