### PR TITLE
(MAINT) Bump beaker and beaker-hostgenerator for new platforms

### DIFF
--- a/package-testing/Gemfile
+++ b/package-testing/Gemfile
@@ -10,9 +10,9 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.21')
+gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.34')
 gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.2')
-gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '~> 0.3')
+gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '~> 1.1.8')
 gem 'rake', '~> 10.1'
 
 group :development do

--- a/package-testing/pre/000_install_package.rb
+++ b/package-testing/pre/000_install_package.rb
@@ -29,6 +29,13 @@ test_name 'Install pdk package on workstation host' do
       if ENV['LOCAL_PKG']
         workstation.install_local_package(pkg)
       else
+        # It looks like Ubuntu Bionic changed the default behavior for
+        # unsigned repositories from warn to error.
+        if workstation['platform'] =~ %r{18\.04}
+          on(workstation, "echo 'Acquire::AllowInsecureRepositories \"true\";' >> /etc/apt/apt.conf.d/99allow-insecure-repos")
+          on(workstation, "echo 'Acquire::AllowDowngradeToInsecureRepositories \"true\";' >> /etc/apt/apt.conf.d/99allow-insecure-repos")
+        end
+
         install_puppetlabs_dev_repo(workstation, 'pdk', ENV['SHA'], 'repo-config')
         workstation.install_package(pkg)
       end


### PR DESCRIPTION
Beaker and beaker-hostgenerator needed to be aware of Ubuntu Bionic and macOS High Sierra.