### PR TITLE
(PDK-475) Set BUNDLE_IGNORE_CONFIG for all commands

### DIFF
--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -130,6 +130,8 @@ module PDK
             @process.environment[k] = v
           end
 
+          @process.environment['BUNDLE_IGNORE_CONFIG'] = '1'
+
           if context == :module
             @process.environment['GEM_HOME'] = PDK::Util::RubyVersion.gem_home
             @process.environment['GEM_PATH'] = PDK::Util::RubyVersion.gem_path

--- a/spec/unit/pdk/cli/exec/command_spec.rb
+++ b/spec/unit/pdk/cli/exec/command_spec.rb
@@ -98,6 +98,7 @@ describe PDK::CLI::Exec::Command do
         command.context = :system
         expect(process).to receive(:start).with(no_args)
         allow(process).to receive(:exit_code).and_return 0
+        allow(process).to receive(:environment).and_return({})
       end
 
       it { expect { command.execute! }.not_to raise_error }


### PR DESCRIPTION
This will prevent any `~/.bundle/config` or related config files that may exist from effecting how the PDK uses bundler.