### PR TITLE
Change Metadata.from_file to reliably raise

### DIFF
--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -45,7 +45,7 @@ module PDK
       end
 
       def self.from_file(metadata_json_path)
-        unless File.file?(metadata_json_path)
+        unless metadata_json_path && File.file?(metadata_json_path)
           raise ArgumentError, _("'%{file}' does not exist or is not a file.") % { file: metadata_json_path }
         end
 

--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -45,7 +45,11 @@ module PDK
       end
 
       def self.from_file(metadata_json_path)
-        unless metadata_json_path && File.file?(metadata_json_path)
+        if metadata_json_path.nil?
+          raise ArgumentError, _('Cannot read metadata from file: no path to file was given.')
+        end
+
+        unless File.file?(metadata_json_path)
           raise ArgumentError, _("'%{file}' does not exist or is not a file.") % { file: metadata_json_path }
         end
 

--- a/lib/pdk/util/puppet_version.rb
+++ b/lib/pdk/util/puppet_version.rb
@@ -83,7 +83,17 @@ module PDK
       end
 
       def from_module_metadata(metadata = nil)
-        metadata ||= PDK::Module::Metadata.from_file(PDK::Util.find_upwards('metadata.json'))
+        if metadata.nil?
+          metadata_file = PDK::Util.find_upwards('metadata.json')
+
+          unless metadata_file
+            PDK.logger.warn _('Unable to determine Puppet version for module: no metadata.json present in module.')
+            return nil
+          end
+
+          metadata = PDK::Module::Metadata.from_file(metadata_file)
+        end
+
         metadata.validate_puppet_version_requirement!
         metadata_requirement = metadata.puppet_requirement
 

--- a/spec/acceptance/convert_spec.rb
+++ b/spec/acceptance/convert_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper_acceptance'
 # avoid unnecessary changes in the metadata.json during convert (template-url
 # key).
 template_repo = 'https://github.com/puppetlabs/pdk-templates'
+pdk_convert_base = "pdk convert --template-url=#{template_repo}"
 
 describe 'pdk convert', module_command: true do
   let(:no_output) { %r{\A\Z} }
@@ -11,7 +12,7 @@ describe 'pdk convert', module_command: true do
   context 'with a fresh module' do
     include_context 'in a new module', 'clean_module', template: template_repo
 
-    describe command('pdk convert --force') do
+    describe command("#{pdk_convert_base} --force") do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to match(no_output) }
       its(:stdout) { is_expected.to match(%r{no changes required}i) }
@@ -36,7 +37,7 @@ describe 'pdk convert', module_command: true do
       end
     end
 
-    describe command('pdk convert --noop --skip-interview') do
+    describe command("#{pdk_convert_base} --noop --skip-interview") do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to match(no_output) }
       its(:stdout) { is_expected.to match(%r{-+files to be added-+\nmetadata\.json}mi) }
@@ -65,7 +66,7 @@ describe 'pdk convert', module_command: true do
       end
     end
 
-    describe command('pdk convert --force --skip-interview') do
+    describe command("#{pdk_convert_base} --force --skip-interview") do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to match(no_output) }
       its(:stdout) { is_expected.to match(%r{-+files to be added-+\nmetadata\.json}mi) }
@@ -98,7 +99,7 @@ describe 'pdk convert', module_command: true do
       end
     end
 
-    describe command('pdk convert --force --skip-interview') do
+    describe command("#{pdk_convert_base} --force --skip-interview") do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to match(no_output) }
       its(:stdout) { is_expected.to match(%r{No changes required}i) }
@@ -116,19 +117,19 @@ describe 'pdk convert', module_command: true do
       File.open('.sync.yml', 'w') do |f|
         f.puts <<-EOS
 ---
-.project:
+.travis.yml:
   delete: true
         EOS
       end
     end
 
-    describe command('pdk convert --force --skip-interview') do
+    describe command("#{pdk_convert_base} --force --skip-interview") do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to match(no_output) }
-      its(:stdout) { is_expected.to match(%r{-+files to be removed-+\n\.project}mi) }
+      its(:stdout) { is_expected.to match(%r{-+files to be removed-+\n\.travis.yml}mi) }
     end
 
-    describe file('.project') do
+    describe file('.travis.yml') do
       it { is_expected.not_to be_file }
     end
 

--- a/spec/unit/pdk/module/metadata_spec.rb
+++ b/spec/unit/pdk/module/metadata_spec.rb
@@ -18,6 +18,10 @@ describe PDK::Module::Metadata do
       expect(described_class.from_file(metadata_json_path).data).to include('name' => 'foo-bar', 'version' => '0.1.0')
     end
 
+    it 'raises an ArgumentError if passed nil' do
+      expect { described_class.from_file(nil) }.to raise_error(ArgumentError, %r{no path to file}i)
+    end
+
     it 'raises an ArgumentError if the file does not exist' do
       allow(File).to receive(:file?).with(metadata_json_path).and_return(false)
       expect { described_class.from_file(metadata_json_path) }.to raise_error(ArgumentError, %r{'#{metadata_json_path}'.*not exist})


### PR DESCRIPTION
When no `metadata.json` exists, `File.file?` can throw nasty exceptions:
```
david@davids:~/git/pdk$ ./bin/pdk bundle list
Traceback (most recent call last):
	11: from ./bin/pdk:29:in `<main>'
	10: from ./bin/pdk:29:in `load'
	 9: from /home/david/git/pdk/exe/pdk:6:in `<top (required)>'
	 8: from /home/david/git/pdk/lib/pdk/cli.rb:18:in `run'
	 7: from /home/david/gems/ruby/2.5.0/gems/cri-2.10.1/lib/cri/command.rb:287:in `run'
	 6: from /home/david/gems/ruby/2.5.0/gems/cri-2.10.1/lib/cri/command.rb:269:in `run'
	 5: from /home/david/gems/ruby/2.5.0/gems/cri-2.10.1/lib/cri/command.rb:329:in `run_this'
	 4: from /home/david/git/pdk/lib/pdk/cli/bundle.rb:24:in `block (2 levels) in <module:CLI>'
	 3: from /home/david/git/pdk/lib/pdk/cli/util.rb:96:in `puppet_from_opts_or_env'
	 2: from /home/david/git/pdk/lib/pdk/util/puppet_version.rb:86:in `from_module_metadata'
	 1: from /home/david/git/pdk/lib/pdk/module/metadata.rb:48:in `from_file'
/home/david/git/pdk/lib/pdk/module/metadata.rb:48:in `file?': no implicit conversion of nil into String (TypeError)
david@davids:~/git/pdk$ 
```