### PR TITLE
(PDK-956) Remove empty array values from metadata.json when rendering

### DIFF
--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -70,7 +70,10 @@ module PDK
       end
 
       def to_json
-        JSON.pretty_generate(@data.dup.delete_if { |_key, value| value.nil? })
+        data_to_render = @data.dup.delete_if do |_key, value|
+          value.nil? || (value.is_a?(Array) && value.empty?)
+        end
+        JSON.pretty_generate(data_to_render)
       end
 
       def write!(path)

--- a/spec/unit/pdk/module/convert_spec.rb
+++ b/spec/unit/pdk/module/convert_spec.rb
@@ -390,8 +390,8 @@ describe PDK::Module::Convert do
             )
           end
 
-          it 'creates an empty dependencies array' do
-            expect(updated_metadata).to include('dependencies' => [])
+          it 'does not include an empty dependencies array' do
+            expect(updated_metadata).not_to have_key('dependencies')
           end
 
           context 'but contains invalid JSON' do

--- a/spec/unit/pdk/module/metadata_spec.rb
+++ b/spec/unit/pdk/module/metadata_spec.rb
@@ -206,4 +206,30 @@ describe PDK::Module::Metadata do
       end
     end
   end
+
+  describe '#to_json' do
+    subject { JSON.parse(described_class.new(values).to_json) }
+
+    context 'when there are dependencies' do
+      let(:values) do
+        {
+          'dependencies' => [
+            { 'name' => 'puppetlabs/stdlib', 'version_requirement' => '> 0' },
+          ],
+        }
+      end
+
+      it { is_expected.to include('dependencies' => [include('name' => 'puppetlabs/stdlib')]) }
+    end
+
+    context 'when there are no dependencies' do
+      let(:values) do
+        {
+          'dependencies' => [],
+        }
+      end
+
+      it { is_expected.not_to have_key('dependencies') }
+    end
+  end
 end


### PR DESCRIPTION
Just like we remove `nil` values before rendering. In the reverse direction, these values will automatically be converted back to empty arrays as `.from_file` populates the object with the defaults merged with the values read from the file.