### PR TITLE
(PDK-809) Exit early if the module is not PDK compatible

### DIFF
--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -62,12 +62,12 @@ module PDK
 
         # This means the module does not have a pdk-version tag in the metadata.json
         # and will require a pdk convert.
-        if module_pdk_ver.nil?
-          PDK.logger.warn _('This module is not PDK compatible. Run `pdk convert` to make it compatible with your version of PDK.')
+        raise PDK::CLI::ExitWithError, _('This module is not PDK compatible. Run `pdk convert` to make it compatible with your version of PDK.') if module_pdk_ver.nil?
+
         # This checks that the version of pdk in the module's metadata is older
         # than 1.3.1, which means the module will need to run pdk convert to the
         # new templates.
-        elsif Gem::Version.new(module_pdk_ver) < Gem::Version.new('1.3.1')
+        if Gem::Version.new(module_pdk_ver) < Gem::Version.new('1.3.1')
           PDK.logger.warn _('This module template is out of date. Run `pdk convert` to make it compatible with your version of PDK.')
         # This checks if the version of the installed PDK is older than the
         # version in the module's metadata, and advises the user to upgrade to

--- a/spec/unit/pdk/cli/util_spec.rb
+++ b/spec/unit/pdk/cli/util_spec.rb
@@ -107,12 +107,10 @@ describe PDK::CLI::Util do
     context 'if module doesn\'t have pdk-version in metadata' do
       let(:module_pdk_ver) { nil }
 
-      before(:each) do
-        expect(logger).to receive(:warn).with(a_string_matching(%r{This module is not PDK compatible. Run `pdk convert` to make it compatible with your version of PDK.}i))
-      end
-
       it 'does not raise an error' do
-        expect { module_version_check }.not_to raise_error
+        expect {
+          module_version_check
+        }.to raise_error(PDK::CLI::ExitWithError, %r{this module is not pdk compatible}i)
       end
     end
 


### PR DESCRIPTION
The current behaviour if you run `pdk validate` or `pdk test unit` on a module that hasn't been converted to be PDK compatible is to display a warning and attempt to continue anyway.

```
semirhage :0: pdk/foo (git:master → origin ↑10 ?:1!)$ ../bin/pdk validate
pdk (WARN): This module is not PDK compatible. Run `pdk convert` to make it compatible with your version of PDK.
pdk (INFO): Running all available validators...
pdk (INFO): Using Ruby 2.4.4
pdk (INFO): Using Puppet 5.5.1
[✔] Resolving default Gemfile dependencies.
[✔] Checking metadata syntax (metadata.json tasks/*.json).
[✔] Checking module metadata style (metadata.json).
[✔] Checking Ruby code style (**/**.rb).
info: task-metadata-lint: ./: Target does not contain any files to validate (tasks/*.json).
info: puppet-syntax: ./: Target does not contain any files to validate (**/**.pp).
info: puppet-lint: ./: Target does not contain any files to validate (**/*.pp).
```

With this change, the PDK will instead display the message and exit early.

```
semirhage :0: pdk/foo (git:pdk-809 U:2 ?:1!)$ ../bin/pdk validate
pdk (ERROR): This module is not PDK compatible. Run `pdk convert` to make it compatible with your version of PDK.
```