### PR TITLE
(PDK-926) Read rspec event context relative to module root

### DIFF
--- a/lib/pdk/report/event.rb
+++ b/lib/pdk/report/event.rb
@@ -326,7 +326,10 @@ module PDK
       def context_lines(max_num_lines = 5)
         return if file.nil? || line.nil?
 
-        file_content = File.read(file).split("\n")
+        file_path = [file, File.join(PDK::Util.module_root, file)].find { |r| File.file?(r) }
+        return if file_path.nil?
+
+        file_content = File.read(file_path).split("\n")
         delta = (max_num_lines - 1) / 2
         min = [0, (line - 1) - delta].max
         max = [(line - 1) + delta, file_content.length].min

--- a/spec/unit/pdk/report/event_spec.rb
+++ b/spec/unit/pdk/report/event_spec.rb
@@ -390,9 +390,9 @@ describe PDK::Report::Event do
       context 'it includes a snippet of the file for rspec events' do
         let(:data) do
           {
-            line:    4,
-            source:  'rspec',
-            message: 'test message',
+            line:     4,
+            source:   'rspec',
+            message:  'test message',
             severity: 'failure',
             test:     'spec description',
             state:    :failure,
@@ -424,10 +424,19 @@ describe PDK::Report::Event do
 
         before(:each) do
           allow(File).to receive(:read).with('testfile.rb').and_return(file_content)
+          allow(File).to receive(:file?).with('testfile.rb').and_return(true)
+          allow(PDK::Util).to receive(:module_root).and_return(File.join('my', 'module_root'))
         end
 
         it 'renders the event with context' do
           expect(text_event).to eq(expected_text)
+        end
+
+        it 'falls back to using the path to the spec file relative to the module root' do
+          allow(File).to receive(:file?).with('testfile.rb').and_return(false)
+          expect(File).to receive(:file?).with(File.join('my', 'module_root', 'testfile.rb')).and_return(nil)
+
+          text_event
         end
       end
     end


### PR DESCRIPTION
When reading the spec file to provide context around an rspec failure,
first attempt to read the path given for the event, and if that fails
try the same path but relative to the module root.