### PR TITLE
(PDK-979) Set path to Gemfile when invoking `bundle lock`

### DIFF
--- a/lib/pdk/util/bundler.rb
+++ b/lib/pdk/util/bundler.rb
@@ -156,7 +156,7 @@ module PDK
         def update_lock!(options = {})
           PDK.logger.debug(_('Updating Gemfile dependencies.'))
 
-          argv = ['lock', '--update']
+          argv = ['lock', "--lockfile=#{gemfile_lock}", '--update']
 
           overrides = nil
 
@@ -174,6 +174,7 @@ module PDK
           argv << '--conservative' if options && options[:conservative]
 
           cmd = bundle_command(*argv).tap do |c|
+            c.update_environment('BUNDLE_GEMFILE' => gemfile)
             c.update_environment(gemfile_env(overrides)) if overrides
           end
 

--- a/spec/unit/pdk/util/bundler_spec.rb
+++ b/spec/unit/pdk/util/bundler_spec.rb
@@ -260,8 +260,7 @@ RSpec.describe PDK::Util::Bundler do
         expect(cmd).to receive(:add_spinner).with(spinner_message, any_args)
       end
 
-      # TODO: it would be nice to update 'expect_command' to allow options in any order but
-      # that would probably require making this more specific to bundler commands
+      # TODO: it would be nice to update 'expect_command' to allow arguments in any order
       expect(PDK::CLI::Exec::Command).to receive(:new).with(*argv).and_return(cmd)
 
       cmd
@@ -408,7 +407,7 @@ RSpec.describe PDK::Util::Bundler do
 
     describe '#lock!' do
       before(:each) do
-        allow_command([bundle_regex, 'lock', '--update', 'json', '--local'], exit_code: 0)
+        allow_command([bundle_regex, 'lock', %r{--lockfile}, '--update', 'json', '--local'], exit_code: 0)
       end
 
       it 'invokes `bundle lock`' do
@@ -491,22 +490,23 @@ RSpec.describe PDK::Util::Bundler do
       let(:overridden_gems) { overrides.keys.map(&:to_s) }
 
       it 'updates env before invoking `bundle lock --update`' do
-        cmd_double = allow_command([bundle_regex, 'lock', '--update'], exit_code: 0)
+        cmd_double = allow_command([bundle_regex, 'lock', %r{--lockfile}, '--update'], exit_code: 0)
 
+        expect(cmd_double).to receive(:update_environment).with(hash_including('BUNDLE_GEMFILE'))
         expect(cmd_double).to receive(:update_environment).with(hash_including('PUPPET_GEM_VERSION' => '1.2.3'))
 
         instance.update_lock!(with: overrides)
       end
 
       it 'invokes `bundle lock --update`' do
-        expect_command([bundle_regex, 'lock', '--update'], exit_code: 0)
+        expect_command([bundle_regex, 'lock', %r{--lockfile}, '--update'], exit_code: 0)
 
         instance.update_lock!(with: overrides)
       end
 
       context 'when `bundle lock --update` exits non-zero' do
         before(:each) do
-          allow_command([bundle_regex, 'lock', '--update'], exit_code: 1, stderr: 'bundle lock update error message')
+          allow_command([bundle_regex, 'lock', %r{--lockfile}, '--update'], exit_code: 1, stderr: 'bundle lock update error message')
         end
 
         it 'logs a fatal message with output and raises FatalError' do
@@ -525,7 +525,7 @@ RSpec.describe PDK::Util::Bundler do
         end
 
         it 'includes all gem overrides in the command environment' do
-          cmd_double = allow_command([bundle_regex, 'lock', '--update'], exit_code: 0)
+          cmd_double = allow_command([bundle_regex, 'lock', %r{--lockfile}, '--update'], exit_code: 0)
 
           expect(cmd_double).to receive(:update_environment).with(hash_including(expected_environment))
 
@@ -537,7 +537,7 @@ RSpec.describe PDK::Util::Bundler do
         let(:options) { { local: true } }
 
         it 'includes \'--local\' in `bundle lock --update` invocation' do
-          expect_command([bundle_regex, 'lock', '--update', '--local'], exit_code: 0)
+          expect_command([bundle_regex, 'lock', %r{--lockfile}, '--update', '--local'], exit_code: 0)
 
           instance.update_lock!(options.merge(with: overrides))
         end
@@ -547,7 +547,7 @@ RSpec.describe PDK::Util::Bundler do
         let(:overrides) { {} }
 
         it 'does not update the command environment' do
-          cmd_double = allow_command([bundle_regex, 'lock', '--update'], exit_code: 0)
+          cmd_double = allow_command([bundle_regex, 'lock', %r{--lockfile}, '--update'], exit_code: 0)
 
           expect(cmd_double).to receive(:update_environment).with({})
 


### PR DESCRIPTION
`bundle lock` doesn't have a `--gemfile` option, but you can set `BUNDLE_GEMFILE`.

This commit also sets the target `Gemfile.lock` explicitly just to be safe.