### PR TITLE
(PDK-636) Make fixture cleaning optional

### DIFF
--- a/lib/pdk/cli/test/unit.rb
+++ b/lib/pdk/cli/test/unit.rb
@@ -11,6 +11,7 @@ module PDK::CLI
     flag nil, :list, _('List all available unit test files.')
     flag nil, :parallel, _('Run unit tests in parallel.')
     flag :v, :verbose, _('More verbose output. Displays examples in each unit test file.')
+    flag :c, 'clean-fixtures', _('Clean up downloaded fixtures after the test run.')
 
     option nil, :tests, _('Specify a comma-separated list of unit test files to run.'), argument: :required, default: '' do |values|
       PDK::CLI::Util::OptionValidator.comma_separated_list?(values)

--- a/lib/pdk/module/build.rb
+++ b/lib/pdk/module/build.rb
@@ -3,6 +3,7 @@ require 'minitar'
 require 'zlib'
 require 'pathspec'
 require 'find'
+require 'pdk/tests/unit'
 
 module PDK
   module Module
@@ -36,6 +37,7 @@ module PDK
       #
       # @return [String] The path to the built package file.
       def build
+        cleanup_module
         create_build_dir
 
         stage_module_in_build_dir
@@ -79,6 +81,14 @@ module PDK
       # @return nil.
       def cleanup_build_dir
         FileUtils.rm_rf(build_dir, secure: true)
+      end
+
+      # Clean up any files created during use of the PDK that shouldn't be part
+      # of the built module (e.g. test fixtures).
+      #
+      # @return nil
+      def cleanup_module
+        PDK::Test::Unit.tear_down
       end
 
       # Combine the module name and version into a Forge-compatible dash

--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -7,7 +7,7 @@ module PDK
   module Test
     class Unit
       def self.cmd(tests, opts = {})
-        rake_args = opts.key?(:parallel) ? 'parallel_spec' : 'spec'
+        rake_args = opts.key?(:parallel) ? 'parallel_spec_standalone' : 'spec_standalone'
         rake_args += "[#{tests}]" unless tests.nil?
         rake_args
       end
@@ -89,7 +89,7 @@ module PDK
 
         result[:exit_code]
       ensure
-        tear_down
+        tear_down if options[:'clean-fixtures']
       end
 
       def self.parse_output(report, json_data)

--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -57,6 +57,8 @@ module PDK
 
         return if result[:exit_code].zero?
 
+        tear_down
+
         PDK.logger.error(_('The spec_prep rake task failed with the following error(s):'))
         print_failure(result, _('Failed to prepare to run the unit tests.'))
       end

--- a/spec/acceptance/test_unit_spec.rb
+++ b/spec/acceptance/test_unit_spec.rb
@@ -18,7 +18,6 @@ describe 'Running unit tests' do
       its(:stderr) { is_expected.to match(%r{running unit tests}i) }
       its(:stderr) { is_expected.to match(%r{no examples found}i) }
       its(:stderr) { is_expected.to match(%r{evaluated 0 tests}i) }
-      its(:stderr) { is_expected.to match(%r{cleaning up after running unit tests}i) }
     end
 
     describe command('pdk test unit --parallel') do
@@ -27,7 +26,6 @@ describe 'Running unit tests' do
       its(:stderr) { is_expected.to match(%r{running unit tests in parallel}i) }
       its(:stderr) { is_expected.to match(%r{no examples found}i) }
       its(:stderr) { is_expected.to match(%r{evaluated 0 tests}i) }
-      its(:stderr) { is_expected.to match(%r{cleaning up after running unit tests}i) }
     end
   end
 
@@ -63,14 +61,12 @@ describe 'Running unit tests' do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to match(%r{preparing to run the unit tests}i) }
       its(:stderr) { is_expected.to match(%r{running unit tests.*4 tests.*0 failures}im) }
-      its(:stderr) { is_expected.to match(%r{cleaning up after running unit tests}i) }
     end
 
     describe command('pdk test unit --parallel') do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to match(%r{preparing to run the unit tests}i) }
       its(:stderr) { is_expected.to match(%r{running unit tests in parallel.*4 tests.*0 failures}im) }
-      its(:stderr) { is_expected.to match(%r{cleaning up after running unit tests}i) }
     end
   end
 

--- a/spec/unit/pdk/cli/test/unit_spec.rb
+++ b/spec/unit/pdk/cli/test/unit_spec.rb
@@ -89,6 +89,23 @@ describe '`pdk test unit`' do
         allow(PDK::Report).to receive(:new).and_return(reporter)
       end
 
+      context 'when passed --clean-fixtures' do
+        it 'invokes the command with :clean-fixtures => true' do
+          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, :tests => anything, :'clean-fixtures' => true).once.and_return(0)
+          expect {
+            test_unit_cmd.run_this(['--clean-fixtures'])
+          }.to exit_zero
+        end
+      end
+
+      context 'when not passed --clean-fixtures' do
+        it 'invokes the command without :clean-fixtures' do
+          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, tests: anything).once.and_return(0)
+          expect {
+            test_unit_cmd.run_this([])
+          }.to exit_zero
+        end
+      end
       context 'when tests pass' do
         before(:each) do
           expect(PDK::Test::Unit).to receive(:invoke).with(reporter, hash_including(:tests)).once.and_return(0)

--- a/spec/unit/pdk/module/build_spec.rb
+++ b/spec/unit/pdk/module/build_spec.rb
@@ -4,6 +4,10 @@ require 'pdk/module/build'
 describe PDK::Module::Build do
   subject { described_class.new(initialize_options) }
 
+  before(:each) do
+    allow(PDK::Test::Unit).to receive(:tear_down)
+  end
+
   let(:initialize_options) { {} }
   let(:root_dir) { Gem.win_platform? ? 'C:/' : '/' }
 

--- a/spec/unit/pdk/test/unit_spec.rb
+++ b/spec/unit/pdk/test/unit_spec.rb
@@ -79,6 +79,7 @@ describe PDK::Test::Unit do
         expect($stderr).to receive(:puts).with('some output')
         expect($stderr).to receive(:puts).with('some error')
         expect(logger).to receive(:error).with(a_string_matching(%r{spec_prep rake task failed}))
+        expect(described_class).to receive(:tear_down)
 
         expect {
           described_class.setup


### PR DESCRIPTION
To make the iterative workflow faster, this (along with puppetlabs/puppetlabs_spec_helper#242) changes the behaviour of `pdk test unit` so that it doesn't automatically remove the downloaded fixtures after the test run. For CI purposes (or if you really want to slow things down) `--clean-fixtures` can be passed to `pdk test unit` to restore the old behaviour.

```
semirhage :0: pdk/foo (git:master → origin U:2 ?:1!)$ rm -rf spec/fixtures/modules/
semirhage :0: pdk/foo (git:master → origin U:2 ?:1!)$ time ../bin/pdk test unit
pdk (INFO): Using Ruby 2.4.4
pdk (INFO): Using Puppet 5.5.1
[✔] Preparing to run the unit tests.
[✔] Running unit tests.
  Evaluated 4 tests in 0.149583489 seconds: 0 failures, 0 pending.

real	0m32.575s
user	0m8.906s
sys	0m1.328s
semirhage :0: pdk/foo (git:master → origin U:2 ?:1!)$ time ../bin/pdk test unit
pdk (INFO): Using Ruby 2.4.4
pdk (INFO): Using Puppet 5.5.1
[✔] Preparing to run the unit tests.
[✔] Running unit tests.
  Evaluated 4 tests in 0.147905862 seconds: 0 failures, 0 pending.

real	0m9.732s
user	0m6.779s
sys	0m0.782s
```