### PR TITLE
(PDK-949) Add merge options to the .sync.yml

### DIFF
--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -244,8 +244,10 @@ module PDK
         if @config.nil?
           conf_defaults = read_config(config_path)
           sync_config = read_config(sync_config_path) unless sync_config_path.nil?
+          merge_options = sync_config.delete('merge_options') || {} unless sync_config.nil?
+          merge_options = merge_options.each_with_object({}) { |(k, v), memo| memo[k.to_sym] = v; } unless merge_options.nil?
           @config = conf_defaults
-          @config.deep_merge!(sync_config) unless sync_config.nil?
+          @config.deep_merge!(sync_config, merge_options) unless sync_config.nil?
         end
         file_config = @config.fetch(:global, {})
         file_config['module_metadata'] = @module_metadata


### PR DESCRIPTION
Prior to this PR the `config_defaults.yml` and `.sync.yml` were deep
merged without any options. This commit adds in the ability to pass in a
`merge_options` hash in the `.sync.yml` to specify options for merging
the hashes. The main use case for this is to add a knockout prefix for
removing some of the `config_defaults.yml` in the template.

The options available are listed in the deep_merge docs: <https://github.com/danielsdeleo/deep_merge#options>

Syntax:

~~~
# .sync.yml
merge_options:
  knockout_prefix: "---"
~~~

