### PR TITLE
(PDK-949) Add a default knockout_prefix for options

### DIFF
--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -245,7 +245,7 @@ module PDK
           conf_defaults = read_config(config_path)
           sync_config = read_config(sync_config_path) unless sync_config_path.nil?
           @config = conf_defaults
-          @config.deep_merge!(sync_config) unless sync_config.nil?
+          @config.deep_merge!(sync_config, knockout_prefix: '---') unless sync_config.nil?
         end
         file_config = @config.fetch(:global, {})
         file_config['module_metadata'] = @module_metadata

--- a/spec/unit/pdk/module/template_dir_spec.rb
+++ b/spec/unit/pdk/module/template_dir_spec.rb
@@ -235,6 +235,55 @@ describe PDK::Module::TemplateDir do
                                                            '.project'        => { 'delete' => true },
                                                            '.gitlab-ci.yml'  => { 'unmanaged' => true })
       end
+      context 'contains a knockout prefix' do
+        let(:config_defaults) do
+          <<-EOS
+            appveyor.yml:
+              environment:
+                PUPPET_GEM_VERSION: "~> 4.0"
+            foo:
+              attr:
+                - val: 1
+              ko:
+                - valid
+                - removed
+          EOS
+        end
+        let(:yaml_text) do
+          <<-EOF
+         appveyor.yml:
+           environment:
+             PUPPET_GEM_VERSION: "~> 5.0"
+         .travis.yml:
+           extras:
+           - rvm: 2.1.9
+         foo:
+           attr:
+           - val: 3
+           ko:
+           - ---removed
+         .project:
+           delete: true
+         .gitlab-ci.yml:
+           unmanaged: true
+         EOF
+        end
+        let(:yaml_hash) do
+          YAML.load(yaml_text) # rubocop:disable Security/YAMLLoad
+        end
+        let(:config_hash) do
+          YAML.load(config_defaults) # rubocop:disable Security/YAMLLoad
+        end
+
+        it 'removes the knocked out options' do
+          expect(template_dir.config_for(path_or_url)).to eq('module_metadata' => module_metadata,
+                                                             'appveyor.yml'    => { 'environment' => { 'PUPPET_GEM_VERSION' => '~> 5.0' } },
+                                                             '.travis.yml'     => { 'extras' => [{ 'rvm' => '2.1.9' }] },
+                                                             'foo'             => { 'attr' => [{ 'val' => 1 }, { 'val' => 3 }], 'ko' => ['valid'] },
+                                                             '.project'        => { 'delete' => true },
+                                                             '.gitlab-ci.yml'  => { 'unmanaged' => true })
+        end
+      end
     end
 
     context 'when the module has an invalid .sync.yml file' do


### PR DESCRIPTION
Prior to this PR the config_defaults.yml and .sync.yml were deep
merged without any options. This commit adds in the ability to use a
knockout_prefix of '---' for any config_defaults.yml options.
The main use case for this is to remove items from the
`config_defaults.yml` in the template.

I am happy to change the default knockout_prefix from '---' to anything else. Let me know if you would prefer a different one. 