### PR TITLE
fix templating deep directory structure

### DIFF
--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -104,8 +104,8 @@ module PDK
       #
       # @api public
       def render
-        PDK::Module::TemplateDir.files_in_template(@dirs).each do |template_file, template_loc|
-          template_file = template_file.to_s
+        PDK::Module::TemplateDir.files_in_template(@dirs).each do |template_path|
+          template_dir, template_file = File.split(template_path)
           PDK.logger.debug(_("Rendering '%{template}'...") % { template: template_file })
           dest_path = template_file.sub(%r{\.erb\Z}, '')
           config = config_for(dest_path)
@@ -117,7 +117,7 @@ module PDK
             dest_status = :delete
           else
             begin
-              dest_content = PDK::TemplateFile.new(File.join(template_loc, template_file), configs: config).render
+              dest_content = PDK::TemplateFile.new(File.join(template_dir, template_file), configs: config).render
             rescue => e
               error_msg = _(
                 "Failed to render template '%{template}'\n" \
@@ -202,28 +202,17 @@ module PDK
 
       # Get a list of template files in the template directory.
       #
-      # @return [Hash{String=>String}] A hash of key file names and
-      # value locations.
+      # @return [String] An Array of File paths
       #
       # @api public
       def self.files_in_template(dirs)
-        temp_paths = []
-        dirlocs = []
-        dirs.each do |dir|
+        temp_paths_per_dir = dirs.map do |dir|
           raise ArgumentError, _("The directory '%{dir}' doesn't exist") % { dir: dir } unless Dir.exist?(dir)
-          temp_paths += Dir.glob(File.join(dir, '**', '*'), File::FNM_DOTMATCH).select do |template_path|
+          Dir.glob(File.join(dir, '**', '*'), File::FNM_DOTMATCH).select do |template_path|
             File.file?(template_path) && !File.symlink?(template_path)
-            dirlocs << dir
-          end
-          temp_paths.map do |template_path|
-            template_path.sub!(%r{\A#{Regexp.escape(dir)}#{Regexp.escape(File::SEPARATOR)}}, '')
           end
         end
-        template_paths = Hash[temp_paths.zip dirlocs]
-        template_paths.delete('.')
-        template_paths.delete('spec')
-        template_paths.delete('spec/.')
-        template_paths
+        temp_paths_per_dir.flatten
       end
 
       # Generate a hash of data to be used when rendering the specified

--- a/spec/unit/pdk/module/template_dir_spec.rb
+++ b/spec/unit/pdk/module/template_dir_spec.rb
@@ -57,7 +57,7 @@ describe PDK::Module::TemplateDir do
         allow(Dir).to receive(:exist?).with('/the/file/is/here').and_return true
       end
       it 'returns an empty list' do
-        expect(described_class.files_in_template(dirs)).to eq({})
+        expect(described_class.files_in_template(dirs)).to eq([])
       end
     end
 
@@ -81,7 +81,7 @@ describe PDK::Module::TemplateDir do
         allow(Dir).to receive(:glob).with('/here/moduleroot/**/*', File::FNM_DOTMATCH).and_return ['/here/moduleroot/filename']
       end
       it 'returns the file name' do
-        expect(described_class.files_in_template(dirs)).to eq('filename' => '/here/moduleroot')
+        expect(described_class.files_in_template(dirs)).to eq(['/here/moduleroot/filename'])
       end
     end
 
@@ -95,7 +95,7 @@ describe PDK::Module::TemplateDir do
         allow(Dir).to receive(:glob).with('/here/moduleroot/**/*', File::FNM_DOTMATCH).and_return ['/here/moduleroot/filename', '/here/moduleroot/filename2']
       end
       it 'returns both the file names' do
-        expect(described_class.files_in_template(dirs)).to eq('filename' => '/here/moduleroot', 'filename2' => '/here/moduleroot')
+        expect(described_class.files_in_template(dirs)).to eq(['/here/moduleroot/filename', '/here/moduleroot/filename2'])
       end
     end
 
@@ -106,7 +106,7 @@ describe PDK::Module::TemplateDir do
         allow(Dir).to receive(:exist?).with('/path/to/templates').and_return true
         allow(Dir).to receive(:exist?).with('/path/to/templates/moduleroot').and_return true
         allow(Dir).to receive(:exist?).with('/path/to/templates/moduleroot_init').and_return true
-        allow(File).to receive(:file?).with('/path/to/templates/moduleroot/.').and_return true
+        allow(File).to receive(:file?).with('/path/to/templates/moduleroot/.').and_return false
         allow(File).to receive(:file?).with('/path/to/templates/moduleroot/filename').and_return true
         allow(File).to receive(:file?).with('/path/to/templates/moduleroot_init/filename2').and_return true
         allow(Dir).to receive(:glob).with('/path/to/templates/moduleroot/**/*', File::FNM_DOTMATCH).and_return ['/path/to/templates/moduleroot/.', '/path/to/templates/moduleroot/filename']
@@ -114,8 +114,8 @@ describe PDK::Module::TemplateDir do
       end
 
       it 'returns the file names from both directories' do
-        expect(described_class.files_in_template(dirs)).to eq('filename' => '/path/to/templates/moduleroot',
-                                                              'filename2' => '/path/to/templates/moduleroot_init')
+        expect(described_class.files_in_template(dirs)).to eq(['/path/to/templates/moduleroot/filename',
+                                                               '/path/to/templates/moduleroot_init/filename2'])
       end
     end
   end


### PR DESCRIPTION
This refactors `files_in_templates` to fix an ordering bug with the file
enumeration that caused directories to be unintentionally be included.  This
allows arbitrary subdirectory structures to be templated as expected.