### PR TITLE
(PDK-1061) Ensure rake binstub when building module

### DIFF
--- a/lib/pdk/module/build.rb
+++ b/lib/pdk/module/build.rb
@@ -88,6 +88,9 @@ module PDK
       #
       # @return nil
       def cleanup_module
+        PDK::Util::Bundler.ensure_bundle!
+        PDK::Util::Bundler.ensure_binstubs!('rake')
+
         PDK::Test::Unit.tear_down
       end
 

--- a/spec/unit/pdk/module/build_spec.rb
+++ b/spec/unit/pdk/module/build_spec.rb
@@ -344,4 +344,20 @@ describe PDK::Module::Build do
       end
     end
   end
+
+  describe '#cleanup_module' do
+    subject(:instance) { described_class.new(module_dir: module_dir) }
+
+    let(:module_dir) { File.join(root_dir, 'tmp', 'my-module') }
+
+    after(:each) do
+      instance.cleanup_module
+    end
+
+    it 'ensures the rake binstub is present before cleaning up spec fixtures' do
+      expect(PDK::Util::Bundler).to receive(:ensure_bundle!).ordered
+      expect(PDK::Util::Bundler).to receive(:ensure_binstubs!).with('rake').ordered
+      expect(PDK::Test::Unit).to receive(:tear_down).ordered
+    end
+  end
 end


### PR DESCRIPTION
Before building a module package, we first call
`PDK::Test::Unit.tear_down` to make sure that there are no artifacts
left over from possible test runs. This method depends on the `rake`
binstub being present which is ensured when running `pdk test unit`,
however when the user is running `pdk build` on a clean clone of
a module this binstub is not present and the build fails.