### PR TITLE
(PDK-1051) Expose rspec-puppet coverage results to PDK

### DIFF
--- a/lib/pdk/report.rb
+++ b/lib/pdk/report.rb
@@ -93,13 +93,19 @@ module PDK
     def write_text(target = self.class.default_target)
       # Open a File Object for IO if target is a string containing a filename or path
       target = File.open(target, 'w') if target.is_a? String
+      coverage_report = nil
 
       events.each do |_tool, tool_events|
         tool_events.each do |event|
-          target.puts(event.to_text) unless event.pass?
+          if event.rspec_puppet_coverage?
+            coverage_report = event.to_text
+          else
+            target.puts(event.to_text) unless event.pass?
+          end
         end
       end
     ensure
+      target.puts "\n#{coverage_report}" if coverage_report
       target.close if target.is_a? File
     end
   end

--- a/lib/pdk/report/event.rb
+++ b/lib/pdk/report/event.rb
@@ -88,10 +88,26 @@ module PDK
         state == :skipped
       end
 
+      # Checks if the event stores the result of an rspec-puppet coverage
+      # check.
+      #
+      # Due to the implementation details of this check, the `file` value for
+      # this event will always point to the coverage.rb file in rspec-puppet,
+      # making it easy to filter out.
+      #
+      # @return [Boolean] true if the event contains rspec-puppet coverage
+      #   results.
+      def rspec_puppet_coverage?
+        @rspec_puppet_coverage_pattern ||= File.join('**', 'lib', 'rspec-puppet', 'coverage.rb')
+        source == 'rspec' && File.fnmatch?(@rspec_puppet_coverage_pattern, File.expand_path(file))
+      end
+
       # Renders the event in a clang style text format.
       #
       # @return [String] The rendered event.
       def to_text
+        return message if rspec_puppet_coverage?
+
         location = [file, line, column].compact.join(':')
         location = nil if location.empty?
 

--- a/spec/unit/pdk/report_spec.rb
+++ b/spec/unit/pdk/report_spec.rb
@@ -25,9 +25,15 @@ describe PDK::Report do
   context 'when adding events to the report' do
     subject(:report) do
       r = described_class.new
-      r.add_event(source: 'puppet-lint', state: :failure, file: 'testfile.pp')
-      r.add_event(source: 'rubocop', state: :passed, file: 'testfile.rb')
+      events.each { |event| r.add_event(event) }
       r
+    end
+
+    let(:events) do
+      [
+        { source: 'puppet-lint', state: :failure, file: 'testfile.pp' },
+        { source: 'rubocop', state: :passed, file: 'testfile.rb' },
+      ]
     end
 
     it 'stores the events in the report by source' do
@@ -58,6 +64,29 @@ describe PDK::Report do
 
       it 'finishes with a trailing newline' do
         expect(text_report[-1]).to eq("\n")
+      end
+
+      context 'and the report contains an rspec-puppet coverage report' do
+        let(:events) do
+          [
+            {
+              source:  'rspec',
+              state:   :passed,
+              file:    "#{File.expand_path(Dir.pwd)}/private/cache/ruby/lib/rspec-puppet/coverage.rb",
+              message: 'coverage report text',
+            },
+            {
+              source:  'rspec',
+              state:   :failure,
+              file:    'spec/classes/foo_spec.rb',
+              message: 'some failure happened',
+            },
+          ]
+        end
+
+        it 'prints the coverage report last' do
+          expect(text_report.split("\n")[-1]).to eq('coverage report text')
+        end
       end
     end
 


### PR DESCRIPTION
This change won't have any noticeable effect until https://github.com/rodjek/rspec-puppet/pull/706 is merged and released in 2.6.14, but is backwards compatible for safe merging.