### PR TITLE
Allow use hieradata and manifests folders in tpl

### DIFF
--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -221,7 +221,7 @@ module PDK
         end
         template_paths = Hash[temp_paths.zip dirlocs]
         delete_paths = ['.', 'spec', 'spec/.', 'hieradata', 'hieradata/.', 'manifests', 'manifests/.']
-        for path in delete_paths do
+        delete_paths.each do |path|
           template_paths.delete(path)
         end
         template_paths

--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -220,7 +220,7 @@ module PDK
           end
         end
         template_paths = Hash[temp_paths.zip dirlocs]
-        delete_paths = ['.', 'spec/.', 'hieradata', 'hieradata/.', 'manifests', 'manifests/.']
+        delete_paths = ['.', 'spec', 'spec/.', 'hieradata', 'hieradata/.', 'manifests', 'manifests/.']
         for path in delete_paths do
           template_paths.delete(path)
         end


### PR DESCRIPTION
To allow add a default manifest & hieradata folders in custom "pdk-module-template", and also allows to add default configuration files in these folders.