### PR TITLE
(PDK-1041) Improve handling of errors from PDK::Module::TemplateDir

### DIFF
--- a/lib/pdk/generate/puppet_object.rb
+++ b/lib/pdk/generate/puppet_object.rb
@@ -224,6 +224,8 @@ module PDK
             end
           end
         end
+      rescue ArgumentError => e
+        raise PDK::CLI::ExitWithError, e
       end
 
       # Provides the possible template directory locations in the order in

--- a/lib/pdk/module/convert.rb
+++ b/lib/pdk/module/convert.rb
@@ -94,6 +94,8 @@ module PDK
             end
           end
         end
+      rescue ArgumentError => e
+        raise PDK::CLI::ExitWithError, e
       end
 
       def update_manager

--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -185,18 +185,23 @@ module PDK
       #
       # @api private
       def validate_module_template!
+        # rubocop:disable Style/GuardClause
         unless File.directory?(@path)
-          raise ArgumentError, _("The specified template '%{path}' is not a directory.") % { path: @path }
+          if PDK::Util.package_install? && File.fnmatch?(File.join(PDK::Util.package_cachedir, '*'), @path)
+            raise ArgumentError, _('The built-in template has substantially changed. Please run "pdk convert" on your module to continue.')
+          else
+            raise ArgumentError, _("The specified template '%{path}' is not a directory.") % { path: @path }
+          end
         end
 
         unless File.directory?(@moduleroot_dir)
           raise ArgumentError, _("The template at '%{path}' does not contain a 'moduleroot/' directory.") % { path: @path }
         end
 
-        unless File.directory?(@moduleroot_init) # rubocop:disable Style/GuardClause
+        unless File.directory?(@moduleroot_init)
           # rubocop:disable Metrics/LineLength
           raise ArgumentError, _("The template at '%{path}' does not contain a 'moduleroot_init/' directory, which indicates you are using an older style of template. Before continuing please use the --template-url flag when running the pdk new commands to pass a new style template.") % { path: @path }
-          # rubocop:enable Metrics/LineLength
+          # rubocop:enable Metrics/LineLength Style/GuardClause
         end
       end
 


### PR DESCRIPTION
 * Capture the `ArgumentError`s generated by `PDK::Module::TemplateDir` during convert and expose them nicely via the CLI.
 * Add a special case to the template validation logic to detect if the user is trying to update a module that was generated using a built-in template that no longer exists.