### PR TITLE
(PDK-1067) Ensure rspec-core binstubs are created for `pdk test unit`

### DIFF
--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -64,7 +64,7 @@ module PDK
       end
 
       def self.invoke(report, options = {})
-        PDK::Util::Bundler.ensure_binstubs!('rake')
+        PDK::Util::Bundler.ensure_binstubs!('rake', 'rspec-core')
 
         setup
 

--- a/package-testing/spec/package/unit_test_a_new_module_spec.rb
+++ b/package-testing/spec/package/unit_test_a_new_module_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper_package'
+
+describe 'Generate a module for unit testing' do
+  module_name = 'unit_test_module'
+
+  context 'when creating a new module and new class' do
+    describe command("pdk new module #{module_name} --skip-interview") do
+      its(:exit_status) { is_expected.to eq(0) }
+    end
+
+    describe command("pdk new class #{module_name}") do
+      let(:cwd) { module_name }
+
+      its(:exit_status) { is_expected.to eq(0) }
+    end
+  end
+
+  context 'when unit testing' do
+    describe command('pdk test unit') do
+      let(:cwd) { module_name }
+
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stderr) { is_expected.to match(%r{evaluated 4 tests.*0 failures}im) }
+    end
+  end
+
+  context 'when unit testing in parallel' do
+    describe command('pdk test unit --parallel') do
+      let(:cwd) { module_name }
+
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stderr) { is_expected.to match(%r{evaluated 4 tests.*0 failures}im) }
+    end
+  end
+end

--- a/package-testing/spec/package/version_selection_spec.rb
+++ b/package-testing/spec/package/version_selection_spec.rb
@@ -26,7 +26,7 @@ describe 'Test puppet & ruby version selection' do
         puppet_versions.map { |r| Regexp.escape(r) }.join('|')
       end
 
-      describe command('pdk bundle update') do
+      describe command('pdk bundle update --local') do
         its(:exit_status) { is_expected.to eq(0) }
       end
 

--- a/package-testing/spec/spec_helper_package.rb
+++ b/package-testing/spec/spec_helper_package.rb
@@ -27,4 +27,15 @@ RSpec.configure do |c|
     RSpec.configuration.logger.log_level = :verbose
   end
   # rubocop:enable RSpec/BeforeAfterAll
+
+  c.after(:each) do
+    cmd = if windows_node?
+            command('rm -Recurse -Force $env:LOCALAPPDATA/PDK/Cache/ruby')
+          else
+            command('rm -rf ~/.pdk/cache/ruby')
+          end
+
+    # clear out any cached gems
+    cmd.run
+  end
 end


### PR DESCRIPTION
Because of the way the parallel_tests gem invokes rspec, we need to make
sure we have generated a binstub within the module for rspec. Otherwise
when a user invokes `pdk test unit --parallel`, parallel_tests will
attempt to invoke rspec outside of the PDK-managed Ruby environment.