### PR TITLE
(PDK-1045) Send validation targets as relative file paths

### DIFF
--- a/lib/pdk/validate/puppet/puppet_syntax.rb
+++ b/lib/pdk/validate/puppet/puppet_syntax.rb
@@ -63,7 +63,7 @@ module PDK
         # puppet parser validate does not include files without problems in its
         # output, so we need to go through the list of targets and add passing
         # events to the report for any target not listed in the output.
-        targets.reject { |target| results_data.any? { |j| j[:file] == target } }.each do |target|
+        targets.reject { |target| results_data.any? { |j| j[:file] =~ %r{#{target}} } }.each do |target|
           report.add_event(
             file:     target,
             source:   name,

--- a/spec/acceptance/validate_puppet_spec.rb
+++ b/spec/acceptance/validate_puppet_spec.rb
@@ -157,6 +157,24 @@ class foo {
     end
   end
 
+  context 'with lots of files' do
+    include_context 'in a new module', 'file_dump'
+
+    before(:all) do
+      FileUtils.mkdir_p(File.join('manifests', 'dump'))
+      (1..5000).each do |num|
+        File.open(File.join('manifests', 'dump', "file#{num}.pp"), 'w') do |f|
+          f.puts "# file#{num}\nclass file_dump::dump::file#{num} { }"
+        end
+      end
+    end
+
+    describe command('pdk validate puppet') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stdout) { is_expected.to match(empty_string) }
+    end
+  end
+
   context 'with a parsable file and some style warnings' do
     include_context 'in a new module', 'foo'
 

--- a/spec/acceptance/validate_ruby_spec.rb
+++ b/spec/acceptance/validate_ruby_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'pdk validate ruby', module_command: true do
+  let(:empty_string) { %r{\A\Z} }
   let(:junit_xsd) { File.join(RSpec.configuration.fixtures_path, 'JUnit.xsd') }
 
   include_context 'with a fake TTY'
@@ -100,6 +101,24 @@ describe 'pdk validate ruby', module_command: true do
     describe command('pdk validate ruby') do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stdout) { is_expected.to match(%r{\A\Z}) }
+    end
+  end
+
+  context 'with lots of files' do
+    include_context 'in a new module', 'file_dump'
+
+    before(:all) do
+      FileUtils.mkdir_p(File.join('spec', 'unit'))
+      (1..5000).each do |num|
+        File.open(File.join('spec', 'unit', "test#{num}.rb"), 'w') do |f|
+          f.puts "puts({ 'a' => 'b' }.inspect)"
+        end
+      end
+    end
+
+    describe command('pdk validate ruby') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stdout) { is_expected.to match(empty_string) }
     end
   end
 end

--- a/spec/support/it_accepts_metadata_json_targets.rb
+++ b/spec/support/it_accepts_metadata_json_targets.rb
@@ -24,7 +24,7 @@ RSpec.shared_examples_for 'it accepts metadata.json targets' do
         end
 
         it 'returns the path to metadata.json in the module' do
-          expect(parsed_targets.first).to eq([module_metadata_json])
+          expect(parsed_targets.first).to eq(['metadata.json'])
         end
       end
 

--- a/spec/support/it_accepts_pp_targets.rb
+++ b/spec/support/it_accepts_pp_targets.rb
@@ -14,15 +14,17 @@ RSpec.shared_examples_for 'it accepts .pp targets' do
       let(:targets) { [] }
 
       context 'and the module contains .pp files' do
-        let(:globbed_files) do
+        let(:files) do
           [
-            File.join(module_root, 'manifests', 'init.pp'),
-            File.join(module_root, 'manifests', 'params.pp'),
+            File.join('manifests', 'init.pp'),
+            File.join('manifests', 'params.pp'),
           ]
         end
 
+        let(:globbed_files) { files.map { |file| File.join(module_root, file) } }
+
         it 'returns the paths to all the .pp files in the module' do
-          expect(parsed_targets.first).to eq(globbed_files)
+          expect(parsed_targets.first).to eq(files)
         end
       end
 

--- a/spec/unit/pdk/validate/base_validator_spec.rb
+++ b/spec/unit/pdk/validate/base_validator_spec.rb
@@ -84,11 +84,8 @@ describe PDK::Validate::BaseValidator do
     context 'when given no targets' do
       let(:targets) { [] }
       let(:glob_pattern) { File.join(module_root, described_class.pattern) }
-      let(:globbed_files) do
-        [
-          File.join(module_root, 'manifests', 'init.pp'),
-        ]
-      end
+      let(:files) { [File.join('manifests', 'init.pp')] }
+      let(:globbed_files) { files.map { |file| File.join(module_root, file) } }
 
       before(:each) do
         allow(File).to receive(:directory?).and_return(true)
@@ -97,13 +94,14 @@ describe PDK::Validate::BaseValidator do
       end
 
       it 'returns the module root' do
-        expect(target_files[0]).to eq(globbed_files)
+        expect(target_files[0]).to eq(files)
       end
     end
 
     context 'when the globbed files include spec/fixtures files' do
       let(:targets) { [] }
       let(:glob_pattern) { File.join(module_root, described_class.pattern) }
+      let(:files) { [File.join('manifests', 'init.pp')] }
       let(:fixture_file) { File.join(module_root, 'spec', 'fixtures', 'test', 'manifests', 'init.pp') }
       let(:globbed_files) do
         [
@@ -126,12 +124,8 @@ describe PDK::Validate::BaseValidator do
     context 'when given specific targets' do
       let(:targets) { ['target1.pp', 'target2/'] }
       let(:glob_pattern) { File.join(module_root, described_class.pattern) }
-
-      let(:globbed_target2) do
-        [
-          File.join(module_root, 'target2', 'target.pp'),
-        ]
-      end
+      let(:targets2) { [File.join('target2', 'target.pp')] }
+      let(:globbed_target2) { targets2.map { |target| File.join(module_root, target) } }
 
       before(:each) do
         allow(Dir).to receive(:glob).with(glob_pattern).and_return(globbed_target2)
@@ -149,7 +143,7 @@ describe PDK::Validate::BaseValidator do
       end
 
       it 'returns the targets' do
-        expect(target_files[0]).to eq(globbed_target2)
+        expect(target_files[0]).to eq(targets2)
         expect(target_files[1]).to eq(['target1.pp'])
         expect(target_files[2]).to be_empty
       end

--- a/spec/unit/pdk/validate/rubocop_spec.rb
+++ b/spec/unit/pdk/validate/rubocop_spec.rb
@@ -42,27 +42,24 @@ describe PDK::Validate::Rubocop do
     context 'when given no targets' do
       let(:targets) { [] }
 
-      let(:globbed_files) do
-        [
-          File.join(module_root, 'spec', 'spec_helper.rb'),
-        ]
-      end
+      let(:files) { [File.join('spec', 'spec_helper.rb')] }
+      let(:globbed_files) { files.map { |file| File.join(module_root, file) } }
 
       before(:each) do
         allow(Dir).to receive(:glob).with(glob_pattern).and_return(globbed_files)
       end
 
       it 'returns the module root' do
-        expect(target_files.first).to eq(globbed_files)
+        expect(target_files.first).to eq(files)
       end
     end
 
     context 'when given specific targets' do
       let(:targets) { ['target1.rb', 'target2/'] }
-
+      let(:target2) { File.join('target2', 'target.rb') }
       let(:globbed_target2) do
         [
-          File.join(module_root, 'target2', 'target.rb'),
+          File.join(module_root, target2),
         ]
       end
 
@@ -82,7 +79,7 @@ describe PDK::Validate::Rubocop do
       end
 
       it 'returns the targets' do
-        expect(target_files[0]).to eq(globbed_target2)
+        expect(target_files[0]).to eq([target2])
         expect(target_files[1]).to eq(['target1.rb'])
         expect(target_files[2]).to be_empty
       end


### PR DESCRIPTION
Update the validator to parse targets and return results as file paths
relative to the module root. This is to cut down on the character length
of the command string, since the full path of the module directory is
unnecessary and long module_root paths may end up hitting the maximum
character limit on Windows.