### PR TITLE
(PDK-1073) Fix gem bin paths for CLI::Exec managed subprocesses

### DIFF
--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -141,7 +141,7 @@ module PDK
             @process.environment['PATH'] = [
               PDK::Util::RubyVersion.bin_path,
               File.join(@process.environment['GEM_HOME'], 'bin'),
-              File.join(@process.environment['GEM_PATH'], 'bin'),
+              PDK::Util::RubyVersion.gem_paths_raw.map { |gem_path| File.join(gem_path, 'bin') },
               package_binpath,
               ENV['PATH'],
               PDK::Util.package_install? ? PDK::Util::Git.git_paths : nil,

--- a/lib/pdk/util/ruby_version.rb
+++ b/lib/pdk/util/ruby_version.rb
@@ -6,7 +6,7 @@ module PDK
       class << self
         extend Forwardable
 
-        def_delegators :instance, :gem_path, :gem_home, :available_puppet_versions, :bin_path
+        def_delegators :instance, :gem_path, :gem_paths_raw, :gem_home, :available_puppet_versions, :bin_path
 
         attr_reader :instance
 
@@ -72,7 +72,7 @@ module PDK
         end
       end
 
-      def gem_path
+      def gem_paths_raw
         if PDK::Util.package_install?
           # Subprocesses use their own set of gems which are managed by pdk or
           # installed with the package. We also include the separate gem path
@@ -81,14 +81,18 @@ module PDK
             File.join(PDK::Util.pdk_package_basedir, 'private', 'ruby', ruby_version, 'lib', 'ruby', 'gems', versions[ruby_version]),
             File.join(PDK::Util.package_cachedir, 'ruby', versions[ruby_version]),
             File.join(PDK::Util.pdk_package_basedir, 'private', 'puppet', 'ruby', versions[ruby_version]),
-          ].join(File::PATH_SEPARATOR)
+          ]
         else
           # This allows the subprocess to find the 'bundler' gem, which isn't
           # in GEM_HOME for gem installs.
           # TODO: There must be a better way to do this than shelling out to
           # gem... Perhaps can be replaced with "Gem.path"?
-          File.absolute_path(File.join(`gem which bundler`, '..', '..', '..', '..'))
+          [File.absolute_path(File.join(`gem which bundler`, '..', '..', '..', '..'))]
         end
+      end
+
+      def gem_path
+        gem_paths_raw.join(File::PATH_SEPARATOR)
       end
 
       def gem_home

--- a/spec/unit/pdk/cli/exec/command_spec.rb
+++ b/spec/unit/pdk/cli/exec/command_spec.rb
@@ -117,6 +117,17 @@ describe PDK::CLI::Exec::Command do
       end
 
       it { expect { command.execute! }.not_to raise_error }
+
+      it 'includes gem bin paths in PATH' do
+        command.execute!
+
+        expect(environment).to include('PATH')
+
+        path_array = environment['PATH'].split(File::PATH_SEPARATOR)
+
+        expect(path_array).to include(File.join(PDK::Util::RubyVersion.gem_home, 'bin'))
+        expect(path_array).to include(*PDK::Util::RubyVersion.gem_paths_raw.map { |gem_path| File.join(gem_path, 'bin') })
+      end
     end
   end
 end


### PR DESCRIPTION
Before we were appending 'bin' to the end of GEM_PATH but that did not
consider the case where GEM_PATH contains multiple paths.