### PR TITLE
(PDK-1088) Remove unnecessary file enumeration loop during PDK build

### DIFF
--- a/lib/pdk/module/build.rb
+++ b/lib/pdk/module/build.rb
@@ -199,22 +199,24 @@ module PDK
       #
       # @return [PathSpec] The populated ignore path matcher.
       def ignored_files
-        @ignored_files ||= if ignore_file.nil?
-                             PathSpec.new
-                           else
-                             fd = File.open(ignore_file, 'rb:UTF-8')
-                             data = fd.read
-                             fd.close
+        @ignored_files ||=
+          begin
+            ignored = if ignore_file.nil?
+                        PathSpec.new
+                      else
+                        fd = File.open(ignore_file, 'rb:UTF-8')
+                        data = fd.read
+                        fd.close
 
-                             PathSpec.new(data)
-                           end
+                        PathSpec.new(data)
+                      end
 
-        # Also ignore the target directory if it is in the module dir and not already ignored
-        if Find.find(@module_dir).include?(target_dir) && !@ignored_files.match(File.basename(target_dir) + '/')
-          @ignored_files = @ignored_files.add("\/#{File.basename(target_dir)}\/")
-        end
+            if File.realdirpath(target_dir).start_with?(File.realdirpath(module_dir))
+              ignored = ignored.add("\/#{File.basename(target_dir)}\/")
+            end
 
-        @ignored_files
+            ignored
+          end
       end
     end
   end

--- a/spec/unit/pdk/module/build_spec.rb
+++ b/spec/unit/pdk/module/build_spec.rb
@@ -315,9 +315,12 @@ describe PDK::Module::Build do
     let(:module_dir) { File.join(root_dir, 'tmp', 'my-module') }
     let(:instance) { described_class.new(module_dir: module_dir) }
 
+    before(:each) do
+      allow(File).to receive(:realdirpath) { |path| path }
+    end
+
     context 'when no ignore file is present in the module' do
       before(:each) do
-        allow(Find).to receive(:find).with(module_dir).and_return([File.join(module_dir, 'pkg')])
         allow(instance).to receive(:ignore_file).and_return(nil)
       end
 
@@ -335,7 +338,6 @@ describe PDK::Module::Build do
 
         allow(instance).to receive(:ignore_file).and_return(ignore_file_path)
         allow(File).to receive(:open).with(ignore_file_path, 'rb:UTF-8').and_return(ignore_file_content)
-        allow(Find).to receive(:find).with(module_dir).and_return([File.join(module_dir, 'pkg')])
       end
 
       it 'returns a PathSpec object populated by the ignore file' do


### PR DESCRIPTION
Prior to this change, every call to PDK::Module::Build#ignored_files
resulted in a Find.find enumeration of the entire module tree to test
whether or not the target_dir should be added to the ignored_files
PathSpec.

The fundamental issue was that this enumeration happened on
every call when it should have been cached after the first call, but I
also refactored the check itself to use File.realdirpath and simple
string comparisons.

Before:

```
PS>Measure-Command { bundle exec pdk build --force | Out-Default }
pdk (INFO): Building puppetlabs-windows version 5.0.0
[*] Cleaning up after running unit tests.
pdk (INFO): Build of puppetlabs-windows has completed successfully. Built package can be found here: C:/Users/pdk-dev/sandbox/puppetlabs-windows/pkg/puppetlabs-windows-5.0.0.tar.gz


Days              : 0
Hours             : 0
Minutes           : 1
Seconds           : 21
Milliseconds      : 272
Ticks             : 812723994
TotalDays         : 0.000940652770833333
TotalHours        : 0.0225756665
TotalMinutes      : 1.35453999
TotalSeconds      : 81.2723994
TotalMilliseconds : 81272.3994
```

After:

```
PS>Measure-Command { bundle exec pdk build --force | Out-Default }
pdk (INFO): Building puppetlabs-windows version 5.0.0
[*] Cleaning up after running unit tests.
pdk (INFO): Build of puppetlabs-windows has completed successfully. Built package can be found here: C:/Users/pdk-dev/sandbox/puppetlabs-windows/pkg/puppetlabs-windows-5.0.0.tar.gz


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 15
Milliseconds      : 444
Ticks             : 154443436
TotalDays         : 0.000178753976851852
TotalHours        : 0.00429009544444444
TotalMinutes      : 0.257405726666667
TotalSeconds      : 15.4443436
TotalMilliseconds : 15444.3436
```