### PR TITLE
(PDK-1077) Expand the package acceptance test suite

### DIFF
--- a/package-testing/Rakefile
+++ b/package-testing/Rakefile
@@ -85,6 +85,16 @@ namespace :acceptance do
     t.pattern = 'spec/package/**/*_spec.rb'
   end
   task package: [:hostgen]
+
+  RSpec::Core::RakeTask.new(:testenv) do |t|
+    t.rspec_opts = ['--format progress']
+    t.pattern = 'spec/package/pdk_help_spec.rb'
+  end
+  task testenv: [:hostgen, :no_destroy]
+
+  task :no_destroy do
+    ENV['BEAKER_destroy'] = 'no'
+  end
 end
 
 task acceptance: ['acceptance:package']

--- a/package-testing/Rakefile
+++ b/package-testing/Rakefile
@@ -87,8 +87,8 @@ namespace :acceptance do
   task package: [:hostgen]
 
   RSpec::Core::RakeTask.new(:testenv) do |t|
-    t.rspec_opts = ['--format progress']
-    t.pattern = 'spec/package/pdk_help_spec.rb'
+    t.rspec_opts = ['--format progress', "--out #{File::NULL}"]
+    t.pattern = 'lib/testenv.rb'
   end
   task testenv: [:hostgen, :no_destroy]
 

--- a/package-testing/lib/testenv.rb
+++ b/package-testing/lib/testenv.rb
@@ -1,0 +1,14 @@
+require 'spec_helper_package'
+
+RSpec.configure do |c|
+  c.after(:suite) do
+    puts "\nTarget host successfully provisioned with PDK:"
+    puts "\n#{hosts.first.hostname}\n"
+  end
+end
+
+describe 'validate PDK was successfully installed' do
+  describe command('pdk --version') do
+    its(:exit_status) { is_expected.to eq(0) }
+  end
+end

--- a/package-testing/spec/package/support/spec_utils.rb
+++ b/package-testing/spec/package/support/spec_utils.rb
@@ -11,8 +11,19 @@ module SpecUtils
     end
   end
 
+  def home_dir(cygpath = false)
+    return '/root' unless windows_node?
+
+    cygpath ? '/home/Administrator' : 'c:/cygwin64/home/Administrator'
+  end
+
   def windows_node?
     get_working_node.platform =~ %r{windows}
   end
   module_function :windows_node?
+
+  def git_bin
+    path = File.join(install_dir, 'private', 'git')
+    windows_node? ? "& '#{File.join(path, 'cmd', 'git.exe')}'" : File.join(path, 'bin', 'git')
+  end
 end

--- a/package-testing/spec/package/unit_test_a_new_module_spec.rb
+++ b/package-testing/spec/package/unit_test_a_new_module_spec.rb
@@ -13,6 +13,12 @@ describe 'Generate a module for unit testing' do
 
       its(:exit_status) { is_expected.to eq(0) }
     end
+
+    describe command('pdk new defined_type test_define') do
+      let(:cwd) { module_name }
+
+      its(:exit_status) { is_expected.to eq(0) }
+    end
   end
 
   context 'when unit testing' do
@@ -20,7 +26,7 @@ describe 'Generate a module for unit testing' do
       let(:cwd) { module_name }
 
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stderr) { is_expected.to match(%r{evaluated 4 tests.*0 failures}im) }
+      its(:stderr) { is_expected.to match(%r{evaluated 8 tests.*0 failures}im) }
     end
   end
 
@@ -29,7 +35,7 @@ describe 'Generate a module for unit testing' do
       let(:cwd) { module_name }
 
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stderr) { is_expected.to match(%r{evaluated 4 tests.*0 failures}im) }
+      its(:stderr) { is_expected.to match(%r{evaluated 8 tests.*0 failures}im) }
     end
   end
 end

--- a/package-testing/spec/package/update_module_spec.rb
+++ b/package-testing/spec/package/update_module_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper_package'
+require 'open-uri'
+require 'json'
+
+modules = [
+  'puppetlabs/puppetlabs-motd',
+  'puppetlabs/puppetlabs-concat',
+  'puppetlabs/puppetlabs-inifile',
+]
+
+describe 'Updating an existing module' do
+  modules.each do |mod|
+    context "when updating #{mod}" do
+      metadata = JSON.parse(open("https://raw.githubusercontent.com/#{mod}/master/metadata.json").read)
+      metadata['template-url'] = "file://#{File.join(install_dir, 'share', 'cache', 'pdk-templates.git')}"
+      repo_dir = File.join(home_dir, metadata['name'])
+
+      describe command("#{git_bin} clone https://github.com/#{mod} #{repo_dir}") do
+        its(:exit_status) { is_expected.to eq(0) }
+      end
+
+      describe command('pdk update --force') do
+        before(:all) do
+          module_dir = File.join(home_dir(true), metadata['name'])
+          create_remote_file(get_working_node, File.join(module_dir, 'metadata.json'), metadata.to_json)
+
+          sync_yaml = YAML.safe_load(open("https://raw.githubusercontent.com/#{mod}/master/.sync.yml").read)
+          sync_yaml['Gemfile']['required'][':system_tests'] << { 'gem' => 'nokogiri', 'version' => '1.8.2' }
+          create_remote_file(get_working_node, File.join(module_dir, '.sync.yml'), sync_yaml.to_yaml)
+        end
+        let(:cwd) { repo_dir }
+
+        its(:exit_status) { is_expected.to eq(0) }
+      end
+
+      describe command('pdk validate') do
+        let(:cwd) { repo_dir }
+
+        its(:exit_status) { is_expected.to eq(0).or eq(1) }
+
+        context 'stdout lines' do
+          subject { super().stdout.split("\n") }
+
+          it 'does not output any unexpected errors' do
+            is_expected.to all(match(%r{^(?:info|warning|error): (?:puppet-lint|rubocop|task-metadata-lint)}))
+          end
+        end
+      end
+
+      describe command('pdk test unit') do
+        let(:cwd) { repo_dir }
+
+        its(:exit_status) { is_expected.to eq(0) }
+        its(:stderr) { is_expected.to match(%r{0 failures}m) }
+      end
+
+      describe command('pdk test unit --parallel') do
+        let(:cwd) { repo_dir }
+
+        its(:exit_status) { is_expected.to eq(0) }
+        its(:stderr) { is_expected.to match(%r{0 failures}m) }
+      end
+
+      describe command('pdk build --force') do
+        let(:cwd) { repo_dir }
+
+        its(:exit_status) { is_expected.to eq(0) }
+      end
+
+      describe file(File.join(repo_dir, 'pkg', "#{metadata['name']}-#{metadata['version']}.tar.gz")) do
+        it { is_expected.to be_file }
+      end
+    end
+  end
+end


### PR DESCRIPTION
To cover the manual tests that we run on packages leading up to a release.

Also, this adds a `acceptance:testenv` rake task that quickly spins up an environment on vmpooler with PDK pre-installed.