### PR TITLE
(PDK-585) Unify metadata defaults with/without interview

### DIFF
--- a/lib/pdk/generate/module.rb
+++ b/lib/pdk/generate/module.rb
@@ -113,13 +113,7 @@ module PDK
       def self.prepare_metadata(opts = {})
         opts[:username] = (opts[:username] || PDK.answers['forge_username'] || username_from_login).downcase
 
-        defaults = {
-          'version'      => '0.1.0',
-          'dependencies' => [],
-          'requirements' => [
-            { 'name' => 'puppet', 'version_requirement' => '>= 4.7.0 < 6.0.0' },
-          ],
-        }
+        defaults = PDK::Module::Metadata::DEFAULTS.dup
 
         defaults['name'] = "#{opts[:username]}-#{opts[:module_name]}" unless opts[:module_name].nil?
         defaults['author'] = PDK.answers['author'] unless PDK.answers['author'].nil?
@@ -199,57 +193,11 @@ module PDK
             question: _('What operating systems does this module support?'),
             help:     _('Use the up and down keys to move between the choices, space to select and enter to continue.'),
             required: true,
-            choices:  {
-              'RedHat based Linux' => [
-                {
-                  'operatingsystem'        => 'CentOS',
-                  'operatingsystemrelease' => ['7'],
-                },
-                {
-                  'operatingsystem'        => 'OracleLinux',
-                  'operatingsystemrelease' => ['7'],
-                },
-                {
-                  'operatingsystem'        => 'RedHat',
-                  'operatingsystemrelease' => ['7'],
-                },
-                {
-                  'operatingsystem'        => 'Scientific',
-                  'operatingsystemrelease' => ['7'],
-                },
-              ],
-              'Debian based Linux' => [
-                {
-                  'operatingsystem'        => 'Debian',
-                  'operatingsystemrelease' => ['8'],
-                },
-                {
-                  'operatingsystem'        => 'Ubuntu',
-                  'operatingsystemrelease' => ['16.04'],
-                },
-              ],
-              'Fedora' => {
-                'operatingsystem'        => 'Fedora',
-                'operatingsystemrelease' => ['25'],
-              },
-              'OSX' => {
-                'operatingsystem'        => 'Darwin',
-                'operatingsystemrelease' => ['16'],
-              },
-              'SLES' => {
-                'operatingsystem'        => 'SLES',
-                'operatingsystemrelease' => ['12'],
-              },
-              'Solaris' => {
-                'operatingsystem'        => 'Solaris',
-                'operatingsystemrelease' => ['11'],
-              },
-              'Windows' => {
-                'operatingsystem'        => 'windows',
-                'operatingsystemrelease' => ['2008 R2', '2012 R2', '10'],
-              },
-            },
-            default: [1, 2, 7],
+            choices:  PDK::Module::Metadata::OPERATING_SYSTEMS,
+            default:  PDK::Module::Metadata::DEFAULT_OPERATING_SYSTEMS.map do |os_name|
+              # tty-prompt uses a 1-index
+              PDK::Module::Metadata::OPERATING_SYSTEMS.keys.index(os_name) + 1
+            end,
           },
           {
             name:       'summary',

--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -5,6 +5,63 @@ module PDK
     class Metadata
       attr_accessor :data
 
+      OPERATING_SYSTEMS = {
+        'RedHat based Linux' => [
+          {
+            'operatingsystem'        => 'CentOS',
+            'operatingsystemrelease' => ['7'],
+          },
+          {
+            'operatingsystem'        => 'OracleLinux',
+            'operatingsystemrelease' => ['7'],
+          },
+          {
+            'operatingsystem'        => 'RedHat',
+            'operatingsystemrelease' => ['7'],
+          },
+          {
+            'operatingsystem'        => 'Scientific',
+            'operatingsystemrelease' => ['7'],
+          },
+        ],
+        'Debian based Linux' => [
+          {
+            'operatingsystem'        => 'Debian',
+            'operatingsystemrelease' => ['8'],
+          },
+          {
+            'operatingsystem'        => 'Ubuntu',
+            'operatingsystemrelease' => ['16.04'],
+          },
+        ],
+        'Fedora' => {
+          'operatingsystem'        => 'Fedora',
+          'operatingsystemrelease' => ['25'],
+        },
+        'OSX' => {
+          'operatingsystem'        => 'Darwin',
+          'operatingsystemrelease' => ['16'],
+        },
+        'SLES' => {
+          'operatingsystem'        => 'SLES',
+          'operatingsystemrelease' => ['12'],
+        },
+        'Solaris' => {
+          'operatingsystem'        => 'Solaris',
+          'operatingsystemrelease' => ['11'],
+        },
+        'Windows' => {
+          'operatingsystem'        => 'windows',
+          'operatingsystemrelease' => ['2008 R2', '2012 R2', '10'],
+        },
+      }.freeze
+
+      DEFAULT_OPERATING_SYSTEMS = [
+        'RedHat based Linux',
+        'Debian based Linux',
+        'Windows',
+      ].freeze
+
       DEFAULTS = {
         'name'          => nil,
         'version'       => '0.1.0',
@@ -16,24 +73,9 @@ module PDK
         'issues_url'    => nil,
         'dependencies'  => [],
         'data_provider' => nil,
-        'operatingsystem_support' => [
-          {
-            'operatingsystem' => 'Debian',
-            'operatingsystemrelease' => ['8'],
-          },
-          {
-            'operatingsystem' => 'RedHat',
-            'operatingsystemrelease' => ['7.0'],
-          },
-          {
-            'operatingsystem' => 'Ubuntu',
-            'operatingsystemrelease' => ['16.04'],
-          },
-          {
-            'operatingsystem' => 'windows',
-            'operatingsystemrelease' => ['2012 R2'],
-          },
-        ],
+        'operatingsystem_support' => DEFAULT_OPERATING_SYSTEMS.map { |os_name|
+          OPERATING_SYSTEMS[os_name]
+        }.flatten,
         'requirements' => [
           { 'name' => 'puppet', 'version_requirement' => '>= 4.7.0 < 6.0.0' },
         ],

--- a/spec/acceptance/test_unit_spec.rb
+++ b/spec/acceptance/test_unit_spec.rb
@@ -60,13 +60,13 @@ describe 'Running unit tests' do
     describe command('pdk test unit') do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to match(%r{preparing to run the unit tests}i) }
-      its(:stderr) { is_expected.to match(%r{running unit tests.*4 tests.*0 failures}im) }
+      its(:stderr) { is_expected.to match(%r{running unit tests.*8 tests.*0 failures}im) }
     end
 
     describe command('pdk test unit --parallel') do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to match(%r{preparing to run the unit tests}i) }
-      its(:stderr) { is_expected.to match(%r{running unit tests in parallel.*4 tests.*0 failures}im) }
+      its(:stderr) { is_expected.to match(%r{running unit tests in parallel.*8 tests.*0 failures}im) }
     end
   end
 
@@ -195,12 +195,12 @@ describe 'Running unit tests' do
 
     describe command('pdk test unit') do
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stderr) { is_expected.to match(%r{running unit tests.*8 tests.*0 failures}im) }
+      its(:stderr) { is_expected.to match(%r{running unit tests.*16 tests.*0 failures}im) }
     end
 
     describe command('pdk test unit --parallel') do
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stderr) { is_expected.to match(%r{running unit tests in parallel.*8 tests.*0 failures}im) }
+      its(:stderr) { is_expected.to match(%r{running unit tests in parallel.*16 tests.*0 failures}im) }
     end
   end
 


### PR DESCRIPTION
Dedupes the default metadata so that it only exists in one place now (PDK::Module::Metadata), which also means that generating a new module and skipping the interview will now generate the same metadata as spamming enter to accept the default values from the interview.