### PR TITLE
(PDK-1096, PDK-1097, PDK-1098) Add puppet-dev flag to validate and test unit

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -55,6 +55,12 @@ module PDK::CLI
     dsl.option nil, 'pe-version', _('Puppet Enterprise version to run tests or validations against.'), argument: :required
   end
 
+  def self.puppet_dev_option(dsl)
+    dsl.option nil,
+               'puppet-dev',
+               _('When specified, PDK will validate or test against the current Puppet source from github.com. To use this option, you must have network access to https://github.com.')
+  end
+
   @base_cmd = Cri::Command.define do
     name 'pdk'
     usage _('pdk command [options]')

--- a/lib/pdk/cli/test/unit.rb
+++ b/lib/pdk/cli/test/unit.rb
@@ -8,6 +8,7 @@ module PDK::CLI
     summary _('Run unit tests.')
 
     PDK::CLI.puppet_version_options(self)
+    PDK::CLI.puppet_dev_option(self)
     flag nil, :list, _('List all available unit test files.')
     flag nil, :parallel, _('Run unit tests in parallel.')
     flag :v, :verbose, _('More verbose --list output. Displays a list of examples in each unit test file.')

--- a/lib/pdk/cli/test/unit.rb
+++ b/lib/pdk/cli/test/unit.rb
@@ -68,6 +68,7 @@ module PDK::CLI
 
         # Ensure that the bundled gems are up to date and correct Ruby is activated before running tests.
         puppet_env = PDK::CLI::Util.puppet_from_opts_or_env(opts)
+        PDK::Util::PuppetVersion.fetch_puppet_dev if opts.key?(:'puppet-dev')
         PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
         PDK::Util::Bundler.ensure_bundle!(puppet_env[:gemset])
 

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -90,7 +90,6 @@ module PDK
         begin
           puppet_env =
             if use_puppet_dev
-              PDK::Util::PuppetVersion.fetch_puppet_dev
               PDK::Util::PuppetVersion.puppet_dev_env
             elsif desired_puppet_version
               PDK::Util::PuppetVersion.find_gem_for(desired_puppet_version)

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -132,6 +132,21 @@ module PDK
         pe_ver_specs << '--pe-version option' if opts[:'pe-version']
         pe_ver_specs << 'PDK_PE_VERSION environment variable' if ENV['PDK_PE_VERSION'] && !ENV['PDK_PE_VERSION'].empty?
 
+        puppet_dev_specs = []
+        puppet_dev_specs << '--puppet-dev flag' if opts[:'puppet-dev']
+        puppet_dev_specs << 'PDK_PUPPET_DEV environment variable' if ENV['PDK_PUPPET_DEV'] && !ENV['PDK_PUPPET_DEV'].empty?
+
+        puppet_dev_specs.each do |pup_dev_spec|
+          [puppet_ver_specs, pe_ver_specs].each do |offending|
+            next if offending.empty?
+
+            raise PDK::CLI::ExitWithError, _('You cannot specify a %{first} and %{second} at the same time') % {
+              first: pup_dev_spec,
+              second: offending.first,
+            }
+          end
+        end
+
         puppet_ver_specs.each do |pup_ver_spec|
           next if pe_ver_specs.empty?
 
@@ -143,7 +158,15 @@ module PDK
           }
         end
 
-        if puppet_ver_specs.size == 2
+        if puppet_dev_specs.size == 2
+          warning_str = 'Puppet dev flag from command line: "--puppet-dev" '
+          warning_str += 'overrides value from environment: "PDK_PUPPET_DEV=true". You should not specify both.'
+
+          PDK.logger.warn(_(warning_str) % {
+            pup_ver_opt: opts[:'puppet-dev'],
+            pup_ver_env: ENV['PDK_PUPPET_DEV'],
+          })
+        elsif puppet_ver_specs.size == 2
           warning_str = 'Puppet version option from command line: "--puppet-version=%{pup_ver_opt}" '
           warning_str += 'overrides value from environment: "PDK_PUPPET_VERSION=%{pup_ver_env}". You should not specify both.'
 

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -83,12 +83,16 @@ module PDK
       module_function :module_version_check
 
       def puppet_from_opts_or_env(opts)
+        use_puppet_dev = (opts || {})[:'puppet-dev'] || ENV['PDK_PUPPET_DEV']
         desired_puppet_version = (opts || {})[:'puppet-version'] || ENV['PDK_PUPPET_VERSION']
         desired_pe_version = (opts || {})[:'pe-version'] || ENV['PDK_PE_VERSION']
 
         begin
           puppet_env =
-            if desired_puppet_version
+            if use_puppet_dev
+              PDK::Util::PuppetVersion.fetch_puppet_dev
+              PDK::Util::PuppetVersion.puppet_dev_env
+            elsif desired_puppet_version
               PDK::Util::PuppetVersion.find_gem_for(desired_puppet_version)
             elsif desired_pe_version
               PDK::Util::PuppetVersion.from_pe_version(desired_pe_version)

--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -88,6 +88,7 @@ module PDK::CLI
 
       # Ensure that the bundled gems are up to date and correct Ruby is activated before running any validations.
       puppet_env = PDK::CLI::Util.puppet_from_opts_or_env(opts)
+      PDK::Util::PuppetVersion.fetch_puppet_dev if opts.key?(:'puppet-dev')
       PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
       PDK::Util::Bundler.ensure_bundle!(puppet_env[:gemset])
 

--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -14,6 +14,7 @@ module PDK::CLI
     )
 
     PDK::CLI.puppet_version_options(self)
+    PDK::CLI.puppet_dev_option(self)
     flag nil, :list, _('List all available validators.')
     flag :a, 'auto-correct', _('Automatically correct problems where possible.')
     flag nil, :parallel, _('Run validations in parallel.')

--- a/lib/pdk/util/puppet_version.rb
+++ b/lib/pdk/util/puppet_version.rb
@@ -52,12 +52,12 @@ module PDK
           raise PDK::CLI::FatalError, _("Unable to clone git repository at '%{repo}'.") % { repo: DEFAULT_PUPPET_DEV_URL }
         end
 
-        fetch_result = PDK::Util::Git.git('fetch', '--quiet', puppet_dev_path)
+        fetch_result = PDK::Util::Git.git('--git-dir', File.join(puppet_dev_path, '.git'), 'pull', '--ff-only')
         return if fetch_result[:exit_code].zero?
 
         PDK.logger.error fetch_result[:stdout]
         PDK.logger.error fetch_result[:stderr]
-        raise PDK::CLI::FatalError, _("Unable to fetch updates for git repository at '%{cachedir}'.") % { repo: puppet_dev_path }
+        raise PDK::CLI::FatalError, _("Unable to pull updates for git repository at '%{cachedir}'.") % { repo: puppet_dev_path }
       end
 
       def find_gem_for(version_str)

--- a/lib/pdk/util/puppet_version.rb
+++ b/lib/pdk/util/puppet_version.rb
@@ -28,7 +28,7 @@ module PDK
       end
 
       def puppet_dev_path
-        '%{cache}/src/puppet' % { cache: PDK::Util.cachedir }
+        File.join(PDK::Util.cachedir, 'src', 'puppet')
       end
 
       def latest_available
@@ -45,11 +45,11 @@ module PDK
         unless PDK::Util::Git.remote_repo? puppet_dev_path
           FileUtils.mkdir_p puppet_dev_path
           clone_result = PDK::Util::Git.git('clone', DEFAULT_PUPPET_DEV_URL, puppet_dev_path)
-          unless clone_result[:exit_code].zero?
-            PDK.logger.error clone_result[:stdout]
-            PDK.logger.error clone_result[:stderr]
-            raise PDK::CLI::FatalError, _("Unable to clone git repository at '%{repo}'.") % { repo: DEFAULT_PUPPET_DEV_URL }
-          end
+          return if clone_result[:exit_code].zero?
+
+          PDK.logger.error clone_result[:stdout]
+          PDK.logger.error clone_result[:stderr]
+          raise PDK::CLI::FatalError, _("Unable to clone git repository at '%{repo}'.") % { repo: DEFAULT_PUPPET_DEV_URL }
         end
 
         fetch_result = PDK::Util::Git.git('fetch', '--quiet', puppet_dev_path)

--- a/spec/acceptance/version_changer_spec.rb
+++ b/spec/acceptance/version_changer_spec.rb
@@ -25,5 +25,10 @@ describe 'puppet version selection' do
         its(:content) { is_expected.to match(%r{^\s+puppet \(#{Regexp.escape(puppet_version)}(\)|-)}im) }
       end
     end
+
+    describe command('pdk validate --puppet-dev') do
+      its(:stderr) { is_expected.to match(%r{Using Puppet file://}i) }
+      its(:exit_status) { is_expected.to eq(0) }
+    end
   end
 end

--- a/spec/unit/pdk/cli/test/unit_spec.rb
+++ b/spec/unit/pdk/cli/test/unit_spec.rb
@@ -150,6 +150,38 @@ describe '`pdk test unit`' do
     end
   end
 
+  context 'with --puppet-dev' do
+    let(:puppet_env) do
+      {
+        ruby_version: '2.4.3',
+        gemset: { puppet: 'file://path/to/puppet' },
+      }
+    end
+
+    before(:each) do
+      allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env).with(hash_including(:'puppet-dev' => true)).and_return(puppet_env)
+      allow(PDK::Util::PuppetVersion).to receive(:fetch_puppet_dev).and_return(nil)
+      allow(PDK::Test::Unit).to receive(:invoke).and_return(0)
+      allow(PDK::CLI::Util).to receive(:module_version_check)
+    end
+
+    it 'activates puppet github source' do
+      expect(PDK::Util::Bundler).to receive(:ensure_bundle!).with(puppet_env[:gemset])
+
+      expect {
+        test_unit_cmd.run_this(['--puppet-dev'])
+      }.to exit_zero
+    end
+
+    it 'activates resolved ruby version' do
+      expect(PDK::Util::RubyVersion).to receive(:use).with(puppet_env[:ruby_version])
+
+      expect {
+        test_unit_cmd.run_this(['--puppet-dev'])
+      }.to exit_zero
+    end
+  end
+
   context 'when --puppet-version and --pe-version are specified' do
     it 'exits with an error' do
       expect(logger).to receive(:error).with(a_string_matching(%r{cannot specify.*--pe-version.*and.*--puppet-version}i))

--- a/spec/unit/pdk/cli/validate_spec.rb
+++ b/spec/unit/pdk/cli/validate_spec.rb
@@ -221,4 +221,32 @@ describe 'Running `pdk validate` in a module' do
       }.to exit_zero
     end
   end
+
+  context 'with --puppet-dev' do
+    it 'activates resolved puppet version' do
+      expect {
+        PDK::CLI.run(['validate', '--puppet-dev'])
+      }.to exit_zero
+    end
+  end
+
+  context 'with both --puppet-version and --puppet-dev' do
+    it 'exits with an error' do
+      expect(logger).to receive(:error).with(a_string_matching(%r{cannot specify.*--puppet-dev.*and.*--puppet-version}i))
+
+      expect {
+        PDK::CLI.run(%w[validate --puppet-version 4.10.10 --puppet-dev])
+      }.to exit_nonzero
+    end
+  end
+
+  context 'with both --pe-version and --puppet-dev' do
+    it 'exits with an error' do
+      expect(logger).to receive(:error).with(a_string_matching(%r{cannot specify.*--puppet-dev.*and.*--pe-version}i))
+
+      expect {
+        PDK::CLI.run(%w[validate --pe-version 2018.1 --puppet-dev])
+      }.to exit_nonzero
+    end
+  end
 end

--- a/spec/unit/pdk/util/puppet_version_spec.rb
+++ b/spec/unit/pdk/util/puppet_version_spec.rb
@@ -150,7 +150,7 @@ describe PDK::Util::PuppetVersion do
       end
 
       context 'and fails to connect to github' do
-        let(:fetch_results) do
+        let(:pull_results) do
           {
             stdout: 'foo',
             stderr: 'bar',
@@ -160,7 +160,7 @@ describe PDK::Util::PuppetVersion do
 
         before(:each) do
           allow(PDK::Util).to receive(:cachedir).and_return('/path/to/')
-          allow(PDK::Util::Git).to receive(:git).with('fetch', anything, anything).and_return(fetch_results)
+          allow(PDK::Util::Git).to receive(:git).with('--git-dir', anything, 'pull', '--ff-only').and_return(pull_results)
         end
 
         it 'raises an error' do
@@ -168,12 +168,12 @@ describe PDK::Util::PuppetVersion do
           expect(logger).to receive(:error).with(a_string_matching(%r{bar}))
           expect {
             described_class.fetch_puppet_dev
-          }.to raise_error(PDK::CLI::FatalError, a_string_matching(%r{Unable to fetch updates for git repository}i))
+          }.to raise_error(PDK::CLI::FatalError, a_string_matching(%r{Unable to pull updates for git repository}i))
         end
       end
 
       context 'and successfully connects to github' do
-        let(:clone_results) do
+        let(:pull_results) do
           {
             stdout: 'foo',
             stderr: 'bar',
@@ -183,7 +183,7 @@ describe PDK::Util::PuppetVersion do
 
         before(:each) do
           allow(PDK::Util).to receive(:cachedir).and_return('/path/to/')
-          allow(PDK::Util::Git).to receive(:git).with('fetch', anything, anything).and_return(clone_results)
+          allow(PDK::Util::Git).to receive(:git).with('--git-dir', anything, 'pull', '--ff-only').and_return(pull_results)
         end
 
         it 'exits cleanly' do


### PR DESCRIPTION
Adds the `--puppet-dev` flag to `validate` and `test unit`. This flag will allow users to get Puppet from github source.