### PR TITLE
(PDK-645) Support generation of namespaced tasks

### DIFF
--- a/lib/pdk/cli/util/option_validator.rb
+++ b/lib/pdk/cli/util/option_validator.rb
@@ -22,7 +22,6 @@ module PDK
         def self.valid_module_name?(string)
           !(string =~ %r{\A[a-z][a-z0-9_]*\Z}).nil?
         end
-        singleton_class.send(:alias_method, :valid_task_name?, :valid_module_name?)
 
         # https://puppet.com/docs/puppet/5.3/custom_types.html#creating-a-type only says the name has to be a ruby symbol.
         # Let's assume that only strings similar to module names can actually be resolved by the puppet language.
@@ -38,6 +37,7 @@ module PDK
 
         singleton_class.send(:alias_method, :valid_class_name?, :valid_namespace?)
         singleton_class.send(:alias_method, :valid_defined_type_name?, :valid_namespace?)
+        singleton_class.send(:alias_method, :valid_task_name?, :valid_namespace?)
 
         # Validate that a class/defined type parameter matches the regular
         # expression in the documentation: https://docs.puppet.com/puppet/4.10/lang_reserved.html#parameters

--- a/lib/pdk/generate/puppet_object.rb
+++ b/lib/pdk/generate/puppet_object.rb
@@ -33,15 +33,14 @@ module PDK
         @options = options
         @object_name = object_name
 
-        if [:class, :defined_type].include?(object_type) # rubocop:disable Style/GuardClause
-          object_name_parts = object_name.split('::')
+        return unless [:class, :defined_type, :task].include?(object_type)
 
-          @object_name = if object_name_parts.first == module_name
-                           object_name
-                         else
-                           [module_name, object_name].join('::')
-                         end
-        end
+        object_name_parts = object_name.split('::')
+        @object_name = if object_name_parts.first == module_name
+                         object_name
+                       else
+                         [module_name, object_name].join('::')
+                       end
       end
 
       # @abstract Subclass and implement {#template_data} to provide data to

--- a/spec/acceptance/new_task_spec.rb
+++ b/spec/acceptance/new_task_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper_acceptance'
+
+describe 'pdk new task', module_command: true do
+  context 'in a new module' do
+    include_context 'in a new module', 'new_task'
+
+    describe command('pdk new task foo::bar') do
+      its(:stderr) { is_expected.to match(%r{creating .* from template}i) }
+      its(:stderr) { is_expected.not_to match(%r{WARN|ERR}) }
+      its(:stdout) { is_expected.to match(%r{\A\Z}) }
+      its(:exit_status) { is_expected.to eq(0) }
+    end
+
+    describe file(File.join('tasks', 'foo', 'bar.sh')) do
+      it { is_expected.to be_file }
+    end
+
+    describe file(File.join('tasks', 'foo', 'bar.json')) do
+      it { is_expected.to be_file }
+    end
+  end
+end


### PR DESCRIPTION
Tasks can now be namespaced like Puppet manifests (e.g. `<module>::foo::bar::baz`).