### PR TITLE
(PDK-1056) Update default ruby for packaged versions

### DIFF
--- a/lib/pdk/util/puppet_version.rb
+++ b/lib/pdk/util/puppet_version.rb
@@ -23,7 +23,7 @@ module PDK
       def puppet_dev_env
         {
           gem_version: 'file://%{path}' % { path: puppet_dev_path },
-          ruby_version: PDK::Util::RubyVersion.default_ruby_version,
+          ruby_version: PDK::Util::RubyVersion.latest_ruby_version,
         }
       end
 

--- a/lib/pdk/util/ruby_version.rb
+++ b/lib/pdk/util/ruby_version.rb
@@ -45,7 +45,14 @@ module PDK
         end
 
         def default_ruby_version
+          # For now, the packaged versions will be using default of 2.4.4.
+          return '2.4.4' if PDK::Util.package_install?
+
           # TODO: may not be a safe assumption that highest available version should be default
+          latest_ruby_version
+        end
+
+        def latest_ruby_version
           versions.keys.sort { |a, b| Gem::Version.new(b) <=> Gem::Version.new(a) }.first
         end
 

--- a/spec/support/packaged_install.rb
+++ b/spec/support/packaged_install.rb
@@ -6,6 +6,7 @@ RSpec.shared_context 'packaged install' do
     allow(File).to receive(:file?).with(%r{PDK_VERSION}).and_return(true)
     allow(File).to receive(:exist?).with(%r{bundle(\.bat)?$}).and_return(true)
     allow(PDK::Util).to receive(:package_cachedir).and_return(package_cachedir)
+    allow(PDK::Util::RubyVersion).to receive(:versions).and_return('2.4.4' => '2.4.0')
   end
 end
 

--- a/spec/unit/pdk/util/bundler_spec.rb
+++ b/spec/unit/pdk/util/bundler_spec.rb
@@ -447,6 +447,7 @@ RSpec.describe PDK::Util::Bundler do
         before(:each) do
           # package_cachedir comes from 'packaged install' context
           allow(File).to receive(:exist?).with("#{package_cachedir}/Gemfile.lock").and_return(true)
+          allow(PDK::Util::RubyVersion).to receive(:active_ruby_version).and_return('2.4.4')
           PDK::Util::RubyVersion.versions.keys.each do |ruby_version|
             lockfile = File.join(package_cachedir, "Gemfile-#{ruby_version}.lock")
             allow(File).to receive(:exist?).with(lockfile).and_return(true)

--- a/spec/unit/pdk/util/ruby_version_spec.rb
+++ b/spec/unit/pdk/util/ruby_version_spec.rb
@@ -15,7 +15,7 @@ describe PDK::Util::RubyVersion do
 
     let(:packaged_rubies) do
       {
-        '2.4.3' => '2.4.0',
+        '2.4.4' => '2.4.0',
         '2.1.9' => '2.1.0',
       }
     end
@@ -42,7 +42,7 @@ describe PDK::Util::RubyVersion do
     context 'when running from a package install' do
       include_context 'is a package install'
 
-      ['2.1.9', '2.4.3'].each do |ruby_version|
+      ['2.1.9', '2.4.4'].each do |ruby_version|
         context "when the active ruby version is #{ruby_version}" do
           let(:instance) { described_class.new(ruby_version) }
 
@@ -67,6 +67,11 @@ describe PDK::Util::RubyVersion do
 
     context 'when running from a package install' do
       include_context 'is a package install'
+
+      before(:each) do
+        allow(described_class).to receive(:versions).and_return(packaged_rubies)
+        allow(described_class).to receive(:default_ruby_version).and_return('2.4.4')
+      end
 
       it 'includes the path to the packaged ruby cachedir' do
         is_expected.to include(File.join(package_cachedir, 'ruby', described_class.versions[described_class.active_ruby_version]))
@@ -109,13 +114,13 @@ describe PDK::Util::RubyVersion do
 
       before(:each) do
         basedir = File.join('/', 'basedir')
-        ruby_dirs = ['2.1.9', '2.4.3'].map { |r| File.join(basedir, 'private', 'ruby', r) }
+        ruby_dirs = ['2.1.9', '2.4.4'].map { |r| File.join(basedir, 'private', 'ruby', r) }
         allow(PDK::Util).to receive(:pdk_package_basedir).and_return(basedir)
         allow(Dir).to receive(:[]).with(File.join(basedir, 'private', 'ruby', '*')).and_return(ruby_dirs)
       end
 
       it 'returns the Ruby versions included in the package' do
-        is_expected.to eq('2.1.9' => '2.1.0', '2.4.3' => '2.4.0')
+        is_expected.to eq('2.1.9' => '2.1.0', '2.4.4' => '2.4.0')
       end
     end
 


### PR DESCRIPTION
Simple change here to ensure that the packaged version of PDK will default to 2.4.4, but also adds a helper function to identify the newest version of Ruby in the package.