### PR TITLE
(maint) Update package tests for ruby 2.5.1 as the new default

### DIFF
--- a/package-testing/spec/package/airgapped_usage_spec.rb
+++ b/package-testing/spec/package/airgapped_usage_spec.rb
@@ -52,7 +52,8 @@ describe 'Basic usage in an air-gapped environment' do
           subject { super().content }
 
           it 'is identical to the vendored lockfile' do
-            vendored_lockfile = File.join(install_dir, 'share', 'cache', 'Gemfile.lock')
+            # TODO: Need to find a better way to get 'latest_ruby' programmatically so we can use the correct vendored gemfile.
+            vendored_lockfile = File.join(install_dir, 'share', 'cache', 'Gemfile-2.5.1.lock')
             is_expected.to eq(file(vendored_lockfile).content)
           end
         end

--- a/package-testing/spec/package/validate_a_new_module_spec.rb
+++ b/package-testing/spec/package/validate_a_new_module_spec.rb
@@ -34,7 +34,8 @@ describe 'C100321 - Generate a module and validate it (i.e. ensure bundle instal
         subject { super().content }
 
         it 'is identical to the vendored lockfile' do
-          vendored_lockfile = File.join(install_dir, 'share', 'cache', 'Gemfile.lock')
+          # TODO: Need to find a better way to get 'latest_ruby' programmatically so we can use the correct vendored gemfile.
+          vendored_lockfile = File.join(install_dir, 'share', 'cache', 'Gemfile-2.5.1.lock')
           is_expected.to eq(file(vendored_lockfile).content)
         end
       end


### PR DESCRIPTION
With Puppet 6 and Ruby 2.5.1 going out soon, the new 'default' for a base package installation of PDK will be Puppet 6.0.0 and Ruby 2.5.1. This will update the package tests to expect the 2.5.1 version of the vendored lockfile.