### PR TITLE
(maint) Update PDK metadata defaults to include Puppet 6

### DIFF
--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -77,7 +77,7 @@ module PDK
           OPERATING_SYSTEMS[os_name]
         }.flatten,
         'requirements' => [
-          { 'name' => 'puppet', 'version_requirement' => '>= 4.7.0 < 6.0.0' },
+          { 'name' => 'puppet', 'version_requirement' => '>= 4.7.0 < 7.0.0' },
         ],
       }.freeze
 

--- a/spec/unit/pdk/module/convert_spec.rb
+++ b/spec/unit/pdk/module/convert_spec.rb
@@ -398,7 +398,7 @@ describe PDK::Module::Convert do
           it 'creates a requirements array with a puppet requirement' do
             expect(updated_metadata).to include(
               'requirements' => [
-                { 'name' => 'puppet', 'version_requirement' => '>= 4.7.0 < 6.0.0' },
+                { 'name' => 'puppet', 'version_requirement' => '>= 4.7.0 < 7.0.0' },
               ],
             )
           end

--- a/spec/unit/pdk/util/puppet_version_spec.rb
+++ b/spec/unit/pdk/util/puppet_version_spec.rb
@@ -484,7 +484,7 @@ describe PDK::Util::PuppetVersion do
 
     context 'with default metadata' do
       it 'searches for a Puppet gem >= 4.7.0 < 6.0.0' do
-        requirement = Gem::Requirement.create(['>= 4.7.0', '< 6.0.0'])
+        requirement = Gem::Requirement.create(['>= 4.7.0', '< 7.0.0'])
         expect(described_class.instance).to receive(:find_gem).with(requirement)
 
         described_class.from_module_metadata(metadata)


### PR DESCRIPTION
Metadata defaults updated to support 6.0.0.