### PR TITLE
(PDK-1181) Display error when metadata.json missing or unreadable

### DIFF
--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -261,6 +261,9 @@ module PDK
       else
         nil
       end
+    rescue ArgumentError => e
+      PDK.logger.error(e)
+      nil
     end
     module_function :module_pdk_version
   end

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -535,5 +535,13 @@ describe PDK::Util do
 
       it { is_expected.to be nil }
     end
+
+    context 'if there is a problem reading the metadata.json file' do
+      before(:each) do
+        allow(described_class).to receive(:module_metadata).and_raise(ArgumentError, 'some error')
+      end
+
+      it { is_expected.to be_nil }
+    end
   end
 end


### PR DESCRIPTION
Instead of the ArgumentError trace.