### PR TITLE
(PDK-1100) Exclude known artifacts from build instead of cleaning

### DIFF
--- a/spec/unit/pdk/module/build_spec.rb
+++ b/spec/unit/pdk/module/build_spec.rb
@@ -346,20 +346,4 @@ describe PDK::Module::Build do
       end
     end
   end
-
-  describe '#cleanup_module' do
-    subject(:instance) { described_class.new(module_dir: module_dir) }
-
-    let(:module_dir) { File.join(root_dir, 'tmp', 'my-module') }
-
-    after(:each) do
-      instance.cleanup_module
-    end
-
-    it 'ensures the rake binstub is present before cleaning up spec fixtures' do
-      expect(PDK::Util::Bundler).to receive(:ensure_bundle!).ordered
-      expect(PDK::Util::Bundler).to receive(:ensure_binstubs!).with('rake').ordered
-      expect(PDK::Test::Unit).to receive(:tear_down).ordered
-    end
-  end
 end


### PR DESCRIPTION
By handling it in this manner, we can remove the need to call the PDK shipped `spec_clean` task. This is the only dependency on the PDK runtime environment when calling `PDK::Module::Build.invoke` from outside of PDK (as needs to be done in puppetlabs_spec_helper's `build` rake task).