### PR TITLE
(PDK-925) Exclude files that wouldn't be packaged from being validated

### DIFF
--- a/lib/pdk/module.rb
+++ b/lib/pdk/module.rb
@@ -1,0 +1,20 @@
+require 'pathspec'
+
+module PDK
+  module Module
+    DEFAULT_IGNORED = [
+      '/pkg/',
+      '.*',
+      '~*',
+      '/coverage',
+      '/checksums.json',
+      '/REVISION',
+      '/spec/fixtures/modules/',
+    ].freeze
+
+    def default_ignored_pathspec
+      @default_ignored_pathspec ||= PathSpec.new(DEFAULT_IGNORED)
+    end
+    module_function :default_ignored_pathspec
+  end
+end

--- a/lib/pdk/module/build.rb
+++ b/lib/pdk/module/build.rb
@@ -3,21 +3,12 @@ require 'minitar'
 require 'zlib'
 require 'pathspec'
 require 'find'
+require 'pdk/module'
 require 'pdk/tests/unit'
 
 module PDK
   module Module
     class Build
-      DEFAULT_IGNORED = [
-        '/pkg/',
-        '.*',
-        '~*',
-        '/coverage',
-        '/checksums.json',
-        '/REVISION',
-        '/spec/fixtures/modules/',
-      ].freeze
-
       def self.invoke(options = {})
         new(options).build
       end
@@ -213,7 +204,7 @@ module PDK
               ignored = ignored.add("\/#{File.basename(target_dir)}\/")
             end
 
-            DEFAULT_IGNORED.each { |r| ignored.add(r) }
+            PDK::Module::DEFAULT_IGNORED.each { |r| ignored.add(r) }
 
             ignored
           end

--- a/spec/unit/pdk/validate/base_validator_spec.rb
+++ b/spec/unit/pdk/validate/base_validator_spec.rb
@@ -98,15 +98,17 @@ describe PDK::Validate::BaseValidator do
       end
     end
 
-    context 'when the globbed files include spec/fixtures files' do
+    context 'when the globbed files include files matching the default ignore list' do
       let(:targets) { [] }
       let(:glob_pattern) { File.join(module_root, described_class.pattern) }
       let(:files) { [File.join('manifests', 'init.pp')] }
-      let(:fixture_file) { File.join(module_root, 'spec', 'fixtures', 'test', 'manifests', 'init.pp') }
+      let(:fixture_file) { File.join(module_root, 'spec', 'fixtures', 'modules', 'test', 'manifests', 'init.pp') }
+      let(:pkg_file) { File.join(module_root, 'pkg', 'my-module-0.0.1', 'manifests', 'init.pp') }
       let(:globbed_files) do
         [
           File.join(module_root, 'manifests', 'init.pp'),
           fixture_file,
+          pkg_file,
         ]
       end
 
@@ -116,8 +118,12 @@ describe PDK::Validate::BaseValidator do
         allow(File).to receive(:expand_path).with(module_root).and_return(module_root)
       end
 
-      it 'does not return the files under spec/fixtures' do
-        expect(target_files[0]).not_to include(fixture_file)
+      it 'does not return the files under spec/fixtures/' do
+        expect(target_files[0]).not_to include(a_string_including('spec/fixtures'))
+      end
+
+      it 'does not return the files under pkg/' do
+        expect(target_files[0]).not_to include(a_string_including('pkg/'))
       end
     end
 


### PR DESCRIPTION
So things under `pkg/`, `spec/fixtures/modules` and editor-created temporary files aren't matched by the validator globbing logic.