### PR TITLE
(PDK-1200) Fix bundle env handling with puppet-dev

### DIFF
--- a/lib/pdk/cli/test/unit.rb
+++ b/lib/pdk/cli/test/unit.rb
@@ -70,6 +70,9 @@ module PDK::CLI
         puppet_env = PDK::CLI::Util.puppet_from_opts_or_env(opts)
         PDK::Util::PuppetVersion.fetch_puppet_dev if opts.key?(:'puppet-dev')
         PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
+
+        opts.merge!(puppet_env[:gemset])
+
         PDK::Util::Bundler.ensure_bundle!(puppet_env[:gemset])
 
         exit_code = PDK::Test::Unit.invoke(report, opts)

--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -91,6 +91,9 @@ module PDK::CLI
       puppet_env = PDK::CLI::Util.puppet_from_opts_or_env(opts)
       PDK::Util::PuppetVersion.fetch_puppet_dev if opts.key?(:'puppet-dev')
       PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
+
+      options.merge!(puppet_env[:gemset])
+
       PDK::Util::Bundler.ensure_bundle!(puppet_env[:gemset])
 
       exit_code = 0

--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -69,8 +69,11 @@ module PDK
         setup
 
         tests = options.fetch(:tests)
+
+        environment = { 'CI_SPEC_OPTIONS' => '--format j' }
+        environment['PUPPET_GEM_VERSION'] = options[:puppet] if options[:puppet]
         spinner_msg = options.key?(:parallel) ? _('Running unit tests in parallel.') : _('Running unit tests.')
-        result = rake(cmd(tests, options), spinner_msg, 'CI_SPEC_OPTIONS' => '--format j')
+        result = rake(cmd(tests, options), spinner_msg, environment)
 
         json_result = if options.key?(:parallel)
                         PDK::Util.find_all_json_in(result[:stdout])

--- a/lib/pdk/util/bundler.rb
+++ b/lib/pdk/util/bundler.rb
@@ -46,8 +46,9 @@ module PDK
         bundle.update_lock!(with: gem_overrides, local: all_deps_available)
 
         # If there are missing dependencies after updating the lockfile, let `bundle install`
-        # go out and get them.
-        unless bundle.installed?
+        # go out and get them. If the specified puppet gem version points to a remote location
+        # or local filepath, then run bundle install as well.
+        if !bundle.installed? || (gem_overrides[:puppet] && gem_overrides[:puppet].start_with?('file://', 'git://', 'https://'))
           bundle.install!(gem_overrides)
         end
 

--- a/lib/pdk/validate/base_validator.rb
+++ b/lib/pdk/validate/base_validator.rb
@@ -141,6 +141,7 @@ module PDK
 
           command = PDK::CLI::Exec::Command.new(*cmd_argv).tap do |c|
             c.context = :module
+            c.environment = { 'PUPPET_GEM_VERSION' => options[:puppet] } if options[:puppet]
             unless options[:split_exec]
               exec_group = options[:exec_group]
               if exec_group

--- a/spec/acceptance/version_changer_spec.rb
+++ b/spec/acceptance/version_changer_spec.rb
@@ -26,9 +26,47 @@ describe 'puppet version selection' do
       end
     end
 
-    describe command('pdk validate --puppet-dev') do
-      its(:stderr) { is_expected.to match(%r{Using Puppet file://}i) }
-      its(:exit_status) { is_expected.to eq(0) }
+    describe 'puppet-dev uses the correct puppet env' do
+      before(:all) do
+        File.open(File.join('manifests', 'init.pp'), 'w') do |f|
+          f.puts <<-PPFILE
+# version_select
+class version_select {
+}
+          PPFILE
+        end
+
+        FileUtils.mkdir_p(File.join('spec', 'classes'))
+        File.open(File.join('spec', 'classes', 'version_select_spec.rb'), 'w') do |f|
+          f.puts <<-TESTFILE
+require 'spec_helper'
+
+describe 'version_select' do
+  context 'test env' do
+    it('has path') {
+      path = Gem::Specification.find_by_name('puppet').source.options.key?('path')
+      expect(path).to be true
+    }
+  end
+end
+          TESTFILE
+        end
+      end
+
+      describe command('pdk validate --puppet-dev') do
+        its(:stderr) { is_expected.to match(%r{Using Puppet file://}i) }
+        its(:exit_status) { is_expected.to eq(0) }
+      end
+
+      describe command('pdk test unit') do
+        its(:exit_status) { is_expected.not_to eq(0) }
+        its(:stderr) { is_expected.not_to match(%r{Using Puppet file://}i) }
+      end
+
+      describe command('pdk test unit --puppet-dev') do
+        its(:exit_status) { is_expected.to eq(0) }
+        its(:stderr) { is_expected.to match(%r{Using Puppet file://}i) }
+      end
     end
   end
 end

--- a/spec/acceptance/version_changer_spec.rb
+++ b/spec/acceptance/version_changer_spec.rb
@@ -53,14 +53,19 @@ end
         end
       end
 
-      describe command('pdk validate --puppet-dev') do
-        its(:stderr) { is_expected.to match(%r{Using Puppet file://}i) }
+      describe command('pdk validate') do
+        its(:stderr) { is_expected.not_to match(%r{Using Puppet file://}i) }
         its(:exit_status) { is_expected.to eq(0) }
       end
 
       describe command('pdk test unit') do
         its(:exit_status) { is_expected.not_to eq(0) }
         its(:stderr) { is_expected.not_to match(%r{Using Puppet file://}i) }
+      end
+
+      describe command('pdk validate --puppet-dev') do
+        its(:stderr) { is_expected.to match(%r{Using Puppet file://}i) }
+        its(:exit_status) { is_expected.to eq(0) }
       end
 
       describe command('pdk test unit --puppet-dev') do

--- a/spec/unit/pdk/cli/test/unit_spec.rb
+++ b/spec/unit/pdk/cli/test/unit_spec.rb
@@ -6,8 +6,11 @@ describe '`pdk test unit`' do
 
   it { is_expected.not_to be_nil }
 
+  let(:ruby_version) { '2.4.3' }
+  let(:puppet_version) { '5.4.0' }
+
   before(:each) do
-    allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env).and_return(ruby_version: '2.4.3', gemset: { puppet: '5.4.0' })
+    allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env).and_return(ruby_version: ruby_version, gemset: { puppet: puppet_version })
     allow(PDK::Util::RubyVersion).to receive(:use)
     allow(PDK::Util::Bundler).to receive(:ensure_bundle!).with(hash_including(:puppet))
   end
@@ -91,7 +94,7 @@ describe '`pdk test unit`' do
 
       context 'when passed --clean-fixtures' do
         it 'invokes the command with :clean-fixtures => true' do
-          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, :tests => anything, :'clean-fixtures' => true).once.and_return(0)
+          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, :puppet => puppet_version, :tests => anything, :'clean-fixtures' => true).once.and_return(0)
           expect {
             test_unit_cmd.run_this(['--clean-fixtures'])
           }.to exit_zero
@@ -100,7 +103,7 @@ describe '`pdk test unit`' do
 
       context 'when not passed --clean-fixtures' do
         it 'invokes the command without :clean-fixtures' do
-          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, tests: anything).once.and_return(0)
+          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, puppet: puppet_version, tests: anything).once.and_return(0)
           expect {
             test_unit_cmd.run_this([])
           }.to exit_zero
@@ -153,7 +156,7 @@ describe '`pdk test unit`' do
   context 'with --puppet-dev' do
     let(:puppet_env) do
       {
-        ruby_version: '2.4.3',
+        ruby_version: ruby_version,
         gemset: { puppet: 'file://path/to/puppet' },
       }
     end
@@ -196,7 +199,7 @@ describe '`pdk test unit`' do
     let(:puppet_version) { '5.3' }
     let(:puppet_env) do
       {
-        ruby_version: '2.4.3',
+        ruby_version: ruby_version,
         gemset: { puppet: '5.3.5' },
       }
     end


### PR DESCRIPTION
Bundler requires that you continue to pass in PUPPET_GEM_VERSION
when doing check, install, and exec. Previously we were only setting
the puppet gem env when doing a bundle check and updating the lock file.