### PR TITLE
(PDK-1093) Replace null values and empty data structures in metadata when converting

### DIFF
--- a/lib/pdk/module/convert.rb
+++ b/lib/pdk/module/convert.rb
@@ -118,7 +118,7 @@ module PDK
             metadata = PDK::Module::Metadata.from_file(metadata_path)
             new_values = PDK::Module::Metadata::DEFAULTS.select do |key, _|
               !metadata.data.key?(key) || metadata.data[key].nil? ||
-                (metadata.data[key].respond_to?(:empty?) && metadata.data[key].empty?)
+                (key == 'requirements' && metadata.data[key].empty?)
             end
             metadata.update!(new_values)
           rescue ArgumentError

--- a/lib/pdk/module/convert.rb
+++ b/lib/pdk/module/convert.rb
@@ -111,7 +111,10 @@ module PDK
           if File.readable?(metadata_path)
             begin
               metadata = PDK::Module::Metadata.from_file(metadata_path)
-              new_values = PDK::Module::Metadata::DEFAULTS.reject { |key, _| metadata.data.key?(key) }
+              new_values = PDK::Module::Metadata::DEFAULTS.select do |key, _|
+                !metadata.data.key?(key) || metadata.data[key].nil? ||
+                  (metadata.data[key].respond_to?(:empty?) && metadata.data[key].empty?)
+              end
               metadata.update!(new_values)
             rescue ArgumentError
               metadata = PDK::Generate::Module.prepare_metadata(options) unless options[:noop] # rubocop:disable Metrics/BlockNesting

--- a/lib/pdk/module/convert.rb
+++ b/lib/pdk/module/convert.rb
@@ -108,21 +108,21 @@ module PDK
 
       def update_metadata(metadata_path, template_metadata)
         if File.file?(metadata_path)
-          if File.readable?(metadata_path)
-            begin
-              metadata = PDK::Module::Metadata.from_file(metadata_path)
-              new_values = PDK::Module::Metadata::DEFAULTS.select do |key, _|
-                !metadata.data.key?(key) || metadata.data[key].nil? ||
-                  (metadata.data[key].respond_to?(:empty?) && metadata.data[key].empty?)
-              end
-              metadata.update!(new_values)
-            rescue ArgumentError
-              metadata = PDK::Generate::Module.prepare_metadata(options) unless options[:noop] # rubocop:disable Metrics/BlockNesting
-            end
-          else
+          unless File.readable?(metadata_path)
             raise PDK::CLI::ExitWithError, _('Unable to update module metadata; %{path} exists but it is not readable.') % {
               path: metadata_path,
             }
+          end
+
+          begin
+            metadata = PDK::Module::Metadata.from_file(metadata_path)
+            new_values = PDK::Module::Metadata::DEFAULTS.select do |key, _|
+              !metadata.data.key?(key) || metadata.data[key].nil? ||
+                (metadata.data[key].respond_to?(:empty?) && metadata.data[key].empty?)
+            end
+            metadata.update!(new_values)
+          rescue ArgumentError
+            metadata = PDK::Generate::Module.prepare_metadata(options) unless options[:noop]
           end
         elsif File.exist?(metadata_path)
           raise PDK::CLI::ExitWithError, _('Unable to update module metadata; %{path} exists but it is not a file.') % {

--- a/spec/unit/pdk/module/convert_spec.rb
+++ b/spec/unit/pdk/module/convert_spec.rb
@@ -379,9 +379,10 @@ describe PDK::Module::Convert do
 
           let(:existing_metadata) do
             {
-              'name'         => 'testuser-testmodule',
-              'dependencies' => [],
-              'license'      => nil,
+              'name'                    => 'testuser-testmodule',
+              'requirements'            => [],
+              'operatingsystem_support' => [],
+              'license'                 => nil,
             }.to_json
           end
 
@@ -397,13 +398,17 @@ describe PDK::Module::Convert do
             expect(updated_metadata).to include('template-url' => 'http://my.test/template.git', 'template-ref' => 'v1.2.3')
           end
 
-          it 'creates a requirements array with a puppet requirement' do
+          it 'updates an empty requirements array with a puppet requirement' do
             expect(updated_metadata).to include('requirements')
             expect(updated_metadata['requirements'].find { |req| req['name'] == 'puppet' }).to be
           end
 
           it 'creates an empty dependencies array' do
             expect(updated_metadata).to include('dependencies' => [])
+          end
+
+          it 'does not modify an empty operatingsystem_support array' do
+            expect(updated_metadata).to include('operatingsystem_support' => [])
           end
 
           context 'but contains invalid JSON' do

--- a/spec/unit/pdk/module/convert_spec.rb
+++ b/spec/unit/pdk/module/convert_spec.rb
@@ -379,7 +379,9 @@ describe PDK::Module::Convert do
 
           let(:existing_metadata) do
             {
-              'name' => 'testuser-testmodule',
+              'name'         => 'testuser-testmodule',
+              'dependencies' => [],
+              'license'      => nil,
             }.to_json
           end
 


### PR DESCRIPTION
Currently when we're updating a module's `metadata.json` file during
convert, we only replace values if they are completely absent from the
file. Unfortunately, this means if - for example - the existing metadata
defines `dependencies` as `null` or an empty array then it will not be
updated when the module is converted and it will subsequently fail to
validate cleanly.

This PR changes the metadata merging logic so that values defined as
`null` will be replaced with the default metadata value. Additionally, if the `requirements` array exists but is empty, it will also be updated with the default value.