### PR TITLE
(PDK-972) Don't register a pending change when deleting non-existent files

### DIFF
--- a/lib/pdk/module/update_manager.rb
+++ b/lib/pdk/module/update_manager.rb
@@ -48,7 +48,7 @@ module PDK
 
         {
           added:    @added_files,
-          removed:  @removed_files,
+          removed:  @removed_files.select { |f| File.exist?(f) },
           modified: @diff_cache.reject { |_, value| value.nil? },
         }
       end


### PR DESCRIPTION
```
semirhage :0: pdk/foo (git:master → origin U:1 ?:1!)$ ../bin/pdk update
pdk (INFO): Updating tsharpe-foo using the default template, from master@bcb7883 to master@bcb7883

-----------Files to be removed----------
.gitlab-ci.yml

----------------------------------------
Do you want to continue and make these changes to your module? Yes

------------Update completed------------

.

semirhage :0: pdk/foo (git:master → origin U:1 ?:1!)$ ../bin/pdk update
No changes required.
```