### PR TITLE
(PDK-1194) Exclude plans/**/*.pp from PDK::Validate::PuppetSyntax

### DIFF
--- a/lib/pdk/validate/base_validator.rb
+++ b/lib/pdk/validate/base_validator.rb
@@ -52,7 +52,8 @@ module PDK
                 end
               end
 
-              target_list = target_list.reject { |file| PDK::Module.default_ignored_pathspec.match(file) }
+              ignore_list = ignore_pathspec
+              target_list = target_list.reject { |file| ignore_list.match(file) }
 
               skipped << target if target_list.flatten.empty?
               target_list
@@ -74,6 +75,18 @@ module PDK
           end
         }.compact.flatten
         [matched, skipped, invalid]
+      end
+
+      def self.ignore_pathspec
+        ignore_pathspec = PDK::Module.default_ignored_pathspec.dup
+
+        if respond_to?(:pattern_ignore)
+          Array(pattern_ignore).each do |pattern|
+            ignore_pathspec.add(pattern)
+          end
+        end
+
+        ignore_pathspec
       end
 
       def self.parse_options(_options, targets)

--- a/lib/pdk/validate/puppet/puppet_syntax.rb
+++ b/lib/pdk/validate/puppet/puppet_syntax.rb
@@ -37,6 +37,10 @@ module PDK
         '**/**.pp'
       end
 
+      def self.pattern_ignore
+        '/plans/**/*.pp'
+      end
+
       def self.spinner_text(_targets = nil)
         _('Checking Puppet manifest syntax (%{pattern}).') % { pattern: pattern }
       end

--- a/spec/unit/pdk/validate/puppet_syntax_spec.rb
+++ b/spec/unit/pdk/validate/puppet_syntax_spec.rb
@@ -18,6 +18,33 @@ describe PDK::Validate::PuppetSyntax do
 
   it_behaves_like 'it accepts .pp targets'
 
+  describe '.parse_targets' do
+    context 'when the module contains task .pp files' do
+      subject(:parsed_targets) { described_class.parse_targets(targets: targets) }
+
+      before(:each) do
+        allow(Dir).to receive(:glob).with(any_args).and_call_original
+        allow(Dir).to receive(:glob).with(glob_pattern).and_return(globbed_files)
+        allow(File).to receive(:expand_path).with(any_args).and_call_original
+        allow(File).to receive(:expand_path).with(module_root).and_return(module_root)
+      end
+
+      let(:targets) { [] }
+      let(:glob_pattern) { File.join(module_root, described_class.pattern) }
+      let(:globbed_files) do
+        [
+          File.join(module_root, 'manifests', 'init.pp'),
+          File.join(module_root, 'plans', 'foo.pp'),
+          File.join(module_root, 'plans', 'nested', 'thing.pp'),
+        ]
+      end
+
+      it 'does not include the task .pp files in the return value' do
+        expect(parsed_targets.first).to eq([File.join('manifests', 'init.pp')])
+      end
+    end
+  end
+
   describe '.parse_options' do
     subject(:command_args) { described_class.parse_options(options, targets) }
 


### PR DESCRIPTION
Plan syntax validation works slightly differently to regular manifest validation. It will probably be cleaner to implement this as a separate validator rather complicate the existing Puppet syntax validator with conditional behaviour.