### PR TITLE
(PDK-547) Ensure all PDK created files use LF line endings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,6 +74,9 @@ RSpec/ExampleLength:
 RSpec/MessageSpies:
   EnforcedStyle: receive
 
+RSpec/ScatteredSetup:
+  Enabled: False
+
 # Style Cops
 Style/AsciiComments:
   Description: Names, non-english speaking communities.

--- a/lib/pdk/answer_file.rb
+++ b/lib/pdk/answer_file.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'pdk/util/filesystem'
 
 module PDK
   # Singleton accessor to the current answer file being used by the PDK.
@@ -20,6 +21,8 @@ module PDK
   class AnswerFile
     attr_reader :answers
     attr_reader :answer_file_path
+
+    include PDK::Util::Filesystem
 
     # Initialises the AnswerFile object, which stores the responses to certain
     # interactive questions.
@@ -107,9 +110,7 @@ module PDK
     def save_to_disk
       FileUtils.mkdir_p(File.dirname(answer_file_path))
 
-      File.open(answer_file_path, 'w') do |answer_file|
-        answer_file.puts JSON.pretty_generate(answers)
-      end
+      write_file(answer_file_path, JSON.pretty_generate(answers))
     rescue SystemCallError, IOError => e
       raise PDK::CLI::FatalError, _("Unable to write '%{file}': %{msg}") % {
         file: answer_file_path,

--- a/lib/pdk/generate/module.rb
+++ b/lib/pdk/generate/module.rb
@@ -17,6 +17,8 @@ require 'pdk/util/version'
 module PDK
   module Generate
     class Module
+      extend PDK::Util::Filesystem
+
       def self.validate_options(opts)
         unless PDK::CLI::Util::OptionValidator.valid_module_name?(opts[:module_name])
           error_msg = _(
@@ -40,7 +42,7 @@ module PDK
 
         begin
           test_file = File.join(parent_dir, '.pdk-test-writable')
-          File.open(test_file, 'w') { |f| f.write('This file was created by the Puppet Development Kit to test if this folder was writable, you can safely remove this file.') }
+          write_file(test_file, 'This file was created by the Puppet Development Kit to test if this folder was writable, you can safely remove this file.')
           FileUtils.rm_f(test_file)
         rescue Errno::EACCES
           raise PDK::CLI::FatalError, _("You do not have permission to write to '%{parent_dir}'") % {
@@ -59,7 +61,7 @@ module PDK
             templates.render do |file_path, file_content|
               file = Pathname.new(temp_target_dir) + file_path
               file.dirname.mkpath
-              file.write(file_content)
+              write_file(file, file_content)
             end
 
             # Add information about the template used to generate the module to the

--- a/lib/pdk/generate/puppet_object.rb
+++ b/lib/pdk/generate/puppet_object.rb
@@ -5,6 +5,7 @@ require 'pdk/logger'
 require 'pdk/module/metadata'
 require 'pdk/module/templatedir'
 require 'pdk/template_file'
+require 'pdk/util/filesystem'
 
 module PDK
   module Generate
@@ -180,7 +181,7 @@ module PDK
           }
         end
 
-        File.open(dest_path, 'w') { |f| f.write file_content }
+        PDK::Util::Filesystem.write_file(dest_path, file_content)
       rescue SystemCallError => e
         raise PDK::CLI::FatalError, _("Unable to write to file '%{path}': %{message}") % {
           path:    dest_path,

--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -1,9 +1,12 @@
 require 'json'
+require 'pdk/util/filesystem'
 
 module PDK
   module Module
     class Metadata
       attr_accessor :data
+
+      include PDK::Util::Filesystem
 
       OPERATING_SYSTEMS = {
         'RedHat based Linux' => [
@@ -120,9 +123,7 @@ module PDK
       end
 
       def write!(path)
-        File.open(path, 'w') do |file|
-          file.puts to_json
-        end
+        write_file(path, to_json)
       end
 
       def forge_ready?

--- a/lib/pdk/module/update_manager.rb
+++ b/lib/pdk/module/update_manager.rb
@@ -3,6 +3,7 @@ require 'diff/lcs/hunk'
 require 'English'
 require 'fileutils'
 require 'set'
+require 'pdk/util/filesystem'
 
 module PDK
   module Module
@@ -148,7 +149,7 @@ module PDK
       def write_file(path, content)
         FileUtils.mkdir_p(File.dirname(path))
         PDK.logger.debug(_("writing '%{path}'") % { path: path })
-        File.open(path, 'w') { |f| f.puts content }
+        PDK::Util::Filesystem.write_file(path, content)
       rescue Errno::EACCES
         raise PDK::CLI::ExitWithError, _("You do not have permission to write to '%{path}'") % { path: path }
       end

--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -4,6 +4,7 @@ require 'tempfile'
 require 'pdk/util/version'
 require 'pdk/util/windows'
 require 'pdk/util/vendored_file'
+require 'pdk/util/filesystem'
 
 module PDK
   module Util

--- a/lib/pdk/util/filesystem.rb
+++ b/lib/pdk/util/filesystem.rb
@@ -1,0 +1,12 @@
+module PDK
+  module Util
+    module Filesystem
+      def write_file(path, content)
+        raise ArgumentError unless path.is_a?(String) || path.respond_to?(:to_path)
+
+        File.open(path, 'wb') { |f| f.write(content.encode(universal_newline: true)) }
+      end
+      module_function :write_file
+    end
+  end
+end

--- a/lib/pdk/util/vendored_file.rb
+++ b/lib/pdk/util/vendored_file.rb
@@ -2,6 +2,7 @@ require 'pdk/util'
 require 'net/https'
 require 'openssl'
 require 'fileutils'
+require 'pdk/util/filesystem'
 
 module PDK
   module Util
@@ -22,6 +23,8 @@ module PDK
       attr_reader :file_name
       attr_reader :url
 
+      include PDK::Util::Filesystem
+
       def initialize(file_name, url)
         @file_name = file_name
         @url = url
@@ -36,9 +39,7 @@ module PDK
         # TODO: should only write if it's valid JSON
         # TODO: need a way to invalidate if out of date
         FileUtils.mkdir_p(File.dirname(gem_vendored_path))
-        File.open(gem_vendored_path, 'w') do |fd|
-          fd.write(content)
-        end
+        write_file(gem_vendored_path, content)
         content
       end
 

--- a/spec/acceptance/new_module_spec.rb
+++ b/spec/acceptance/new_module_spec.rb
@@ -42,5 +42,10 @@ describe 'Creating a new module' do
       it { is_expected.to be_file }
       it { is_expected.to contain(%r{## Release 0.1.0}i) }
     end
+
+    eol_check = '(Get-Content .\foo\spec\spec_helper.rb -Delimiter [String].Empty) -Match "`r`n"'
+    describe command(eol_check), if: Gem.win_platform? do
+      its(:stdout) { is_expected.to match(%r{\AFalse$}) }
+    end
   end
 end

--- a/spec/unit/pdk/answer_file_spec.rb
+++ b/spec/unit/pdk/answer_file_spec.rb
@@ -164,7 +164,7 @@ describe PDK::AnswerFile do
       let(:fake_file) { StringIO.new }
 
       before(:each) do
-        allow(File).to receive(:open).with(default_path, 'w').and_yield(fake_file)
+        allow(File).to receive(:open).with(default_path, 'wb').and_yield(fake_file)
       end
 
       it 'writes the answer set to disk' do
@@ -185,7 +185,7 @@ describe PDK::AnswerFile do
     context 'when an IOError is raised' do
       before(:each) do
         allow(File).to receive(:open).with(any_args).and_call_original
-        allow(File).to receive(:open).with(default_path, 'w').and_raise(IOError, 'some error message')
+        allow(File).to receive(:open).with(default_path, 'wb').and_raise(IOError, 'some error message')
       end
 
       it 'raises a FatalError' do
@@ -197,7 +197,7 @@ describe PDK::AnswerFile do
     context 'when a SystemCallError is raised' do
       before(:each) do
         allow(File).to receive(:open).with(any_args).and_call_original
-        allow(File).to receive(:open).with(default_path, 'w').and_raise(SystemCallError, 'some other error')
+        allow(File).to receive(:open).with(default_path, 'wb').and_raise(SystemCallError, 'some other error')
       end
 
       it 'raises a FatalError' do

--- a/spec/unit/pdk/generate/puppet_object_spec.rb
+++ b/spec/unit/pdk/generate/puppet_object_spec.rb
@@ -83,7 +83,7 @@ describe PDK::Generate::PuppetObject do
       allow(logger).to receive(:info).with(a_string_matching(%r{creating '#{dest_path}' from template}i))
       allow(PDK::TemplateFile).to receive(:new).with(template_path, template_data).and_return(template_file)
       allow(File).to receive(:open).with(any_args).and_call_original
-      allow(File).to receive(:open).with(dest_path, 'w').and_yield(rendered_file)
+      allow(File).to receive(:open).with(dest_path, 'wb').and_yield(rendered_file)
     end
 
     it 'creates the parent directories for the destination path if needed' do
@@ -112,7 +112,7 @@ describe PDK::Generate::PuppetObject do
 
     context 'when it fails to write the destination file' do
       before(:each) do
-        allow(File).to receive(:open).with(dest_path, 'w').and_raise(SystemCallError, 'some message')
+        allow(File).to receive(:open).with(dest_path, 'wb').and_raise(SystemCallError, 'some message')
         allow(FileUtils).to receive(:mkdir_p).with(dest_dir)
       end
 

--- a/spec/unit/pdk/generate/task_spec.rb
+++ b/spec/unit/pdk/generate/task_spec.rb
@@ -88,7 +88,7 @@ describe PDK::Generate::Task do
 
     before(:each) do
       metadata_file = File.join(module_dir, 'tasks', "#{given_name}.json")
-      allow(File).to receive(:open).with(metadata_file, 'w').and_yield(mock_file)
+      allow(File).to receive(:open).with(metadata_file, 'wb').and_yield(mock_file)
       generator.write_task_metadata
       mock_file.rewind
     end

--- a/spec/unit/pdk/module/update_manager_spec.rb
+++ b/spec/unit/pdk/module/update_manager_spec.rb
@@ -36,7 +36,7 @@ describe PDK::Module::UpdateManager do
 
       before(:each) do
         allow(File).to receive(:open).with(any_args).and_call_original
-        allow(File).to receive(:open).with(dummy_file, 'w').and_yield(dummy_file_io)
+        allow(File).to receive(:open).with(dummy_file, 'wb').and_yield(dummy_file_io)
         update_manager.sync_changes!
         dummy_file_io.rewind
       end
@@ -47,7 +47,7 @@ describe PDK::Module::UpdateManager do
 
       context 'but if the file can not be written to' do
         before(:each) do
-          allow(File).to receive(:open).with(dummy_file, 'w').and_raise(Errno::EACCES)
+          allow(File).to receive(:open).with(dummy_file, 'wb').and_raise(Errno::EACCES)
         end
 
         it 'exits with an error' do
@@ -208,7 +208,7 @@ describe PDK::Module::UpdateManager do
 
         before(:each) do
           allow(File).to receive(:open).with(any_args).and_call_original
-          allow(File).to receive(:open).with(dummy_file, 'w').and_yield(dummy_file_io)
+          allow(File).to receive(:open).with(dummy_file, 'wb').and_yield(dummy_file_io)
           update_manager.sync_changes!
           dummy_file_io.rewind
         end
@@ -219,7 +219,7 @@ describe PDK::Module::UpdateManager do
 
         context 'but if the file can not be written to' do
           before(:each) do
-            allow(File).to receive(:open).with(dummy_file, 'w').and_raise(Errno::EACCES)
+            allow(File).to receive(:open).with(dummy_file, 'wb').and_raise(Errno::EACCES)
           end
 
           it 'exits with an error' do
@@ -250,7 +250,7 @@ describe PDK::Module::UpdateManager do
 
       context 'when syncing the changes' do
         it 'does not modify the file' do
-          expect(File).not_to receive(:open).with(dummy_file, 'w')
+          expect(File).not_to receive(:open).with(dummy_file, 'wb')
           update_manager.sync_changes!
         end
       end

--- a/spec/unit/pdk/util/vendored_file_spec.rb
+++ b/spec/unit/pdk/util/vendored_file_spec.rb
@@ -69,7 +69,7 @@ describe PDK::Util::VendoredFile do
             allow(mock_response).to receive(:body).and_return(gem_vendored_content)
             allow(FileUtils).to receive(:mkdir_p).with(File.dirname(gem_vendored_path))
             allow(File).to receive(:open).with(any_args).and_call_original
-            allow(File).to receive(:open).with(gem_vendored_path, 'w').and_yield(cached_file)
+            allow(File).to receive(:open).with(gem_vendored_path, 'wb').and_yield(cached_file)
           end
 
           let(:cached_file) { StringIO.new }


### PR DESCRIPTION
Consolidates all the places where PDK writes module files so that they all call a single utility method. Inside that method we open the specified file for binary writes, re-encode the content to write so that it uses universal newlines (`\n`) rather than `\r` or `\r\n` and then write it to disk.