### PR TITLE
(PDK-654) Allow rubocop to determine its own targets by default

### DIFF
--- a/lib/pdk/validate/ruby/rubocop.rb
+++ b/lib/pdk/validate/ruby/rubocop.rb
@@ -8,6 +8,8 @@ require 'pdk/validate/ruby_validator'
 module PDK
   module Validate
     class Rubocop < BaseValidator
+      ALLOW_EMPTY_TARGETS = true
+
       def self.name
         'rubocop'
       end

--- a/spec/acceptance/validate_ruby_spec.rb
+++ b/spec/acceptance/validate_ruby_spec.rb
@@ -34,7 +34,7 @@ describe 'pdk validate ruby', module_command: true do
     end
 
     context 'when validating specific directories' do
-      another_violation_rb = File.join('lib', 'puppet', 'another_violation.rb')
+      another_violation_rb = File.join('spec', 'fixtures', 'test', 'another_violation.rb')
 
       before(:all) do
         FileUtils.mkdir_p(File.dirname(another_violation_rb))
@@ -43,7 +43,7 @@ describe 'pdk validate ruby', module_command: true do
         end
       end
 
-      describe command('pdk validate ruby lib') do
+      describe command('pdk validate ruby spec/fixtures') do
         its(:exit_status) { is_expected.not_to eq(0) }
         its(:stdout) { is_expected.to match(%r{#{Regexp.escape(another_violation_rb)}}) }
         its(:stdout) { is_expected.not_to match(%r{#{Regexp.escape(spec_violation_rb)}}) }
@@ -58,8 +58,8 @@ describe 'pdk validate ruby', module_command: true do
 
       its(:stdout) do
         is_expected.to have_junit_testsuite('rubocop').with_attributes(
-          'failures' => a_value > 1,
-          'tests'    => a_value >= 3,
+          'failures' => a_value >= 1,
+          'tests'    => a_value >= 2,
         )
       end
 
@@ -71,10 +71,9 @@ describe 'pdk validate ruby', module_command: true do
       end
 
       its(:stdout) do
-        is_expected.to have_junit_testcase.in_testsuite('rubocop').with_attributes(
-          'classname' => a_string_matching(%r{UselessAssignment}),
-          'name'      => a_string_starting_with(File.join('spec', 'violation.rb')),
-        ).that_failed
+        is_expected.not_to have_junit_testcase.in_testsuite('rubocop').with_attributes(
+          'name' => a_string_starting_with(File.join('spec', 'fixtures')),
+        )
       end
     end
   end

--- a/spec/unit/pdk/cli/validate_spec.rb
+++ b/spec/unit/pdk/cli/validate_spec.rb
@@ -165,6 +165,7 @@ describe 'Running `pdk validate` in a module' do
     before(:each) do
       allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env).with(hash_including(:'puppet-dev' => true)).and_return(puppet_env)
       allow(PDK::Util::PuppetVersion).to receive(:fetch_puppet_dev).and_return(nil)
+      expect(validators).to all(receive(:invoke).with(any_args).and_return(0))
     end
 
     it 'activates puppet github source' do
@@ -225,6 +226,7 @@ describe 'Running `pdk validate` in a module' do
 
     before(:each) do
       allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env).with(hash_including(:'puppet-version' => puppet_version)).and_return(puppet_env)
+      expect(validators).to all(receive(:invoke).with(any_args).and_return(0))
     end
 
     it 'activates resolved puppet version' do
@@ -255,6 +257,7 @@ describe 'Running `pdk validate` in a module' do
 
     before(:each) do
       allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env).with(hash_including(:'pe-version' => pe_version)).and_return(puppet_env)
+      expect(validators).to all(receive(:invoke).with(any_args).and_return(0))
     end
 
     it 'activates resolved puppet version' do

--- a/spec/unit/pdk/validate/rubocop_spec.rb
+++ b/spec/unit/pdk/validate/rubocop_spec.rb
@@ -42,15 +42,8 @@ describe PDK::Validate::Rubocop do
     context 'when given no targets' do
       let(:targets) { [] }
 
-      let(:files) { [File.join('spec', 'spec_helper.rb')] }
-      let(:globbed_files) { files.map { |file| File.join(module_root, file) } }
-
-      before(:each) do
-        allow(Dir).to receive(:glob).with(glob_pattern).and_return(globbed_files)
-      end
-
       it 'returns the module root' do
-        expect(target_files.first).to eq(files)
+        expect(target_files.first).to be_empty
       end
     end
 


### PR DESCRIPTION
If the rubocop validator is invoked without explicitly specifying some targets, we now allow rubocop to determine its own targets (rather than using a glob in PDK to build a list of target files). This has the desirable side effect of making rubocop honour any `Exclude` patterns in `.rubocop.yml`.