### PR TITLE
(maint) Add --skip-bundle-install to `pdk new module`

### DIFF
--- a/lib/pdk/cli/new/module.rb
+++ b/lib/pdk/cli/new/module.rb
@@ -10,6 +10,7 @@ module PDK::CLI
 
     option nil, 'license', _('Specifies the license this module is written under. ' \
       "This should be a identifier from https://spdx.org/licenses/. Common values are 'Apache-2.0', 'MIT', or 'proprietary'."), argument: :required
+    option nil, 'skip-bundle-install', _('Do not automatically run `bundle install` after creating the module.'), hidden: true
 
     run do |opts, args, _cmd|
       require 'pdk/generate/module'

--- a/lib/pdk/generate/module.rb
+++ b/lib/pdk/generate/module.rb
@@ -86,7 +86,7 @@ module PDK
 
         begin
           if FileUtils.mv(temp_target_dir, target_dir)
-            Dir.chdir(target_dir) { PDK::Util::Bundler.ensure_bundle! }
+            Dir.chdir(target_dir) { PDK::Util::Bundler.ensure_bundle! } unless opts[:'skip-bundle-install']
 
             PDK.logger.info(_('Module \'%{name}\' generated at path \'%{path}\', from template \'%{template_url}\'.') % { name: opts[:module_name], path: target_dir, template_url: template_url })
             PDK.logger.info(_('In your module directory, add classes with the \'pdk new class\' command.'))


### PR DESCRIPTION
For use during package build where we create modules using `pdk new
module` in order to generate the Gemfile.lock files.