### PR TITLE
(maint) Fix package tests

### DIFF
--- a/package-testing/spec/package/add_gem_to_module_spec.rb
+++ b/package-testing/spec/package/add_gem_to_module_spec.rb
@@ -7,10 +7,6 @@ describe 'C100545 - Generate a module, add a gem to it, and validate it' do
     its(:exit_status) { is_expected.to eq(0) }
   end
 
-  describe file(File.join(module_name, 'Gemfile.lock')) do
-    it { is_expected.not_to exist }
-  end
-
   context 'when a new gem dependency has been added to the Gemfile' do
     before(:all) do
       shell("echo \"gem \'nothing\'\" >> #{File.join(module_name, 'Gemfile')}")

--- a/package-testing/spec/package/airgapped_usage_spec.rb
+++ b/package-testing/spec/package/airgapped_usage_spec.rb
@@ -32,10 +32,6 @@ describe 'Basic usage in an air-gapped environment' do
           is_expected.to include('template-url' => a_string_matching(%r{\Afile://.+pdk-templates\.git\Z}))
         end
       end
-
-      describe file(File.join(module_name, 'Gemfile.lock')) do
-        it { is_expected.not_to exist }
-      end
     end
 
     context 'when validating the module' do

--- a/package-testing/spec/package/airgapped_usage_spec.rb
+++ b/package-testing/spec/package/airgapped_usage_spec.rb
@@ -45,12 +45,12 @@ describe 'Basic usage in an air-gapped environment' do
         it { is_expected.to be_file }
 
         describe 'the content of the file' do
-          subject { super().content }
+          subject { super().content.gsub(%r{^DEPENDENCIES.+?\n\n}m, '') }
 
           it 'is identical to the vendored lockfile' do
             # TODO: Need to find a better way to get 'latest_ruby' programmatically so we can use the correct vendored gemfile.
             vendored_lockfile = File.join(install_dir, 'share', 'cache', 'Gemfile-2.5.1.lock')
-            is_expected.to eq(file(vendored_lockfile).content)
+            is_expected.to eq(file(vendored_lockfile).content.gsub(%r{^DEPENDENCIES.+?\n\n}m, ''))
           end
         end
       end

--- a/package-testing/spec/package/support/install_pdk.rb
+++ b/package-testing/spec/package/support/install_pdk.rb
@@ -37,8 +37,9 @@ module PackageHelpers
   end
 
   def install_osx_pdk_package(host)
-    package_volume_name = "pdk-#{ENV['SUITE_VERSION']}"
-    package_filename = "#{package_volume_name}-1-installer.pkg"
+    version, = host.platform.split('-')[1, 2]
+    package_volume_name = "pdk-#{ENV['SUITE_VERSION']}-1.osx#{version}"
+    package_filename = "pdk-#{ENV['SUITE_VERSION']}-1-installer.pkg"
     host.generic_install_dmg(build_artifact_url(host.platform), package_volume_name, package_filename)
   end
 

--- a/package-testing/spec/package/validate_a_new_module_spec.rb
+++ b/package-testing/spec/package/validate_a_new_module_spec.rb
@@ -14,10 +14,6 @@ describe 'C100321 - Generate a module and validate it (i.e. ensure bundle instal
         is_expected.to include('template-url' => a_string_matching(%r{\Afile://.+pdk-templates\.git\Z}))
       end
     end
-
-    describe file(File.join(module_name, 'Gemfile.lock')) do
-      it { is_expected.not_to exist }
-    end
   end
 
   context 'when validating the module' do

--- a/package-testing/spec/package/validate_a_new_module_spec.rb
+++ b/package-testing/spec/package/validate_a_new_module_spec.rb
@@ -27,12 +27,12 @@ describe 'C100321 - Generate a module and validate it (i.e. ensure bundle instal
       it { is_expected.to be_file }
 
       describe 'the content of the file' do
-        subject { super().content }
+        subject { super().content.gsub(%r{^DEPENDENCIES.+?\n\n}m, '') }
 
         it 'is identical to the vendored lockfile' do
           # TODO: Need to find a better way to get 'latest_ruby' programmatically so we can use the correct vendored gemfile.
           vendored_lockfile = File.join(install_dir, 'share', 'cache', 'Gemfile-2.5.1.lock')
-          is_expected.to eq(file(vendored_lockfile).content)
+          is_expected.to eq(file(vendored_lockfile).content.gsub(%r{^DEPENDENCIES.+?\n\n}m, ''))
         end
       end
     end


### PR DESCRIPTION
 * PDK now lays down a `Gemfile.lock` when initialising a module, so we can't expect it to be absent.
 * Remove the `DEPENDENCIES` section of the `Gemfile.lock` before comparing. This section only lists the specified depedencies whereas the `GEMS` section is more important as it contains all the fully resolved dependencies. The `DEPENDENCIES` section can cause false failures in cases where different ways of specifying the dependency resolve to the same version e.g. `puppet (~> 6.0)` != `puppet (= 6.0.4)` even though they resolve to the same version.
 * Either the SUITE_VERSION env var changed for OSX or the path vanagon creates changed since the last release. In any case, the path to the `.pkg` in the `.dmg` has changed and we need to update our OSX package install logic.