### PR TITLE
(PDK-1104) Don't always override custom template url with default

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -39,7 +39,9 @@ module PDK::CLI
   end
 
   def self.template_url_option(dsl)
-    dsl.option nil, 'template-url', _('Specifies the URL to the template to use when creating new modules or classes.'), argument: :required, default: PDK::Util.default_template_url
+    desc = _('Specifies the URL to the template to use when creating new modules or classes. (default: %{default_url})') % { default_url: PDK::Util.default_template_url }
+
+    dsl.option nil, 'template-url', desc, argument: :required
   end
 
   def self.skip_interview_option(dsl)

--- a/spec/unit/pdk/cli/convert_spec.rb
+++ b/spec/unit/pdk/cli/convert_spec.rb
@@ -19,8 +19,8 @@ describe 'PDK::CLI convert' do
     end
 
     context 'and provided no flags' do
-      it 'invokes the converter with the default template' do
-        expect(PDK::Module::Convert).to receive(:invoke).with(:'template-url' => PDK::Util.default_template_url)
+      it 'invokes the converter with no template specified' do
+        expect(PDK::Module::Convert).to receive(:invoke).with({})
 
         PDK::CLI.run(['convert'])
       end
@@ -36,7 +36,7 @@ describe 'PDK::CLI convert' do
 
     context 'and the --noop flag has been passed' do
       it 'passes the noop option through to the converter' do
-        expect(PDK::Module::Convert).to receive(:invoke).with(:noop => true, :'template-url' => anything)
+        expect(PDK::Module::Convert).to receive(:invoke).with(noop: true)
 
         PDK::CLI.run(['convert', '--noop'])
       end
@@ -44,7 +44,7 @@ describe 'PDK::CLI convert' do
 
     context 'and the --force flag has been passed' do
       it 'passes the force option through to the converter' do
-        expect(PDK::Module::Convert).to receive(:invoke).with(:force => true, :'template-url' => anything)
+        expect(PDK::Module::Convert).to receive(:invoke).with(force: true)
 
         PDK::CLI.run(['convert', '--force'])
       end
@@ -60,7 +60,7 @@ describe 'PDK::CLI convert' do
 
     context 'and the --skip-interview flag has been passed' do
       it 'passes the skip-interview option through to the converter' do
-        expect(PDK::Module::Convert).to receive(:invoke).with(:'skip-interview' => true, :'template-url' => anything)
+        expect(PDK::Module::Convert).to receive(:invoke).with(:'skip-interview' => true)
 
         PDK::CLI.run(['convert', '--skip-interview'])
       end
@@ -68,7 +68,7 @@ describe 'PDK::CLI convert' do
 
     context 'and the --full-interview flag has been passed' do
       it 'passes the full-interview option through to the converter' do
-        expect(PDK::Module::Convert).to receive(:invoke).with(:'full-interview' => true, :'template-url' => anything)
+        expect(PDK::Module::Convert).to receive(:invoke).with(:'full-interview' => true)
 
         PDK::CLI.run(['convert', '--full-interview'])
       end
@@ -77,7 +77,7 @@ describe 'PDK::CLI convert' do
     context 'and the --skip-interview and --full-interview flags have been passed' do
       it 'ignores full-interview and continues with a log message' do
         expect(logger).to receive(:info).with(a_string_matching(%r{Ignoring --full-interview and continuing with --skip-interview.}i))
-        expect(PDK::Module::Convert).to receive(:invoke).with(:'skip-interview' => true, :'full-interview' => false, :'template-url' => anything)
+        expect(PDK::Module::Convert).to receive(:invoke).with(:'skip-interview' => true, :'full-interview' => false)
 
         PDK::CLI.run(['convert', '--skip-interview', '--full-interview'])
       end
@@ -86,7 +86,7 @@ describe 'PDK::CLI convert' do
     context 'and the --force and --full-interview flags have been passed' do
       it 'ignores full-interview and continues with a log message' do
         expect(logger).to receive(:info).with(a_string_matching(%r{Ignoring --full-interview and continuing with --force.}i))
-        expect(PDK::Module::Convert).to receive(:invoke).with(:force => true, :'full-interview' => false, :'template-url' => anything)
+        expect(PDK::Module::Convert).to receive(:invoke).with(:force => true, :'full-interview' => false)
 
         PDK::CLI.run(['convert', '--force', '--full-interview'])
       end

--- a/spec/unit/pdk/cli/new/task_spec.rb
+++ b/spec/unit/pdk/cli/new/task_spec.rb
@@ -78,8 +78,7 @@ describe 'PDK::CLI new task' do
       context 'and provided a description for the task' do
         let(:generator_opts) do
           {
-            :description    => 'test_task description',
-            :'template-url' => anything,
+            description: 'test_task description',
           }
         end
 

--- a/spec/unit/pdk/module/convert_spec.rb
+++ b/spec/unit/pdk/module/convert_spec.rb
@@ -343,6 +343,22 @@ describe PDK::Module::Convert do
     end
   end
 
+  describe '#template_url' do
+    subject { described_class.new(options).template_url }
+
+    let(:options) { {} }
+
+    context 'when a template-url is provided in the options' do
+      let(:options) { { :'template-url' => 'https://my/custom/template' } }
+
+      it { is_expected.to eq('https://my/custom/template') }
+    end
+
+    context 'when no template-url is provided in the options' do
+      it { is_expected.to eq(PDK::Util.default_template_url) }
+    end
+  end
+
   describe '#update_metadata' do
     subject(:updated_metadata) do
       JSON.parse(described_class.new.update_metadata(metadata_path, template_metadata).to_json)


### PR DESCRIPTION
In most of the generators, the fact that we specify a default value for
the `--template-url` option overrides any template specified in the
metadata or `answers.json`.