### PR TITLE
(PDK-1180) Cleanly handle a null pdk-version in metadata.json

### DIFF
--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -257,10 +257,10 @@ module PDK
     def module_pdk_version
       metadata = module_metadata
 
-      if !metadata.nil? && metadata.include?('pdk-version')
-        metadata['pdk-version'].split.first
-      else
+      if metadata.nil? || metadata.fetch('pdk-version', nil).nil?
         nil
+      else
+        metadata['pdk-version'].split.first
       end
     rescue ArgumentError => e
       PDK.logger.error(e)

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -520,19 +520,31 @@ describe PDK::Util do
   describe 'module_pdk_version' do
     subject(:result) { described_class.module_pdk_version }
 
+    let(:module_metadata) { {} }
+
+    before(:each) do
+      allow(described_class).to receive(:module_metadata).and_return(module_metadata)
+    end
+
+    context 'is nil' do
+      let(:module_metadata) { { 'pdk-version' => nil } }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'is an empty string' do
+      let(:module_metadata) { { 'pdk-version' => '' } }
+
+      it { is_expected.to be_nil }
+    end
+
     context 'is in metadata' do
-      before(:each) do
-        allow(described_class).to receive(:module_metadata).and_return(mock_metadata.data)
-      end
+      let(:module_metadata) { mock_metadata.data }
 
       it { is_expected.to match(pdk_version) }
     end
 
     context 'is not in metadata' do
-      before(:each) do
-        allow(described_class).to receive(:module_metadata).and_return({})
-      end
-
       it { is_expected.to be nil }
     end
 


### PR DESCRIPTION
The existing code doesn't handle the case where it is explicitly defined as `null` in `metadata.json`.