### PR TITLE
(PDK-1001) Chdir before execing git rather than "git -C"

### DIFF
--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -294,11 +294,13 @@ module PDK
         clone_result = PDK::Util::Git.git('clone', origin_repo, temp_dir)
 
         if clone_result[:exit_code].zero?
-          reset_result = PDK::Util::Git.git('-C', temp_dir, 'reset', '--hard', git_ref)
-          unless reset_result[:exit_code].zero?
-            PDK.logger.error reset_result[:stdout]
-            PDK.logger.error reset_result[:stderr]
-            raise PDK::CLI::FatalError, _("Unable to set HEAD of git repository at '%{repo}' to ref:'%{ref}'.") % { repo: temp_dir, ref: git_ref }
+          Dir.chdir(temp_dir) do
+            reset_result = PDK::Util::Git.git('reset', '--hard', git_ref)
+            unless reset_result[:exit_code].zero?
+              PDK.logger.error reset_result[:stdout]
+              PDK.logger.error reset_result[:stderr]
+              raise PDK::CLI::FatalError, _("Unable to set HEAD of git repository at '%{repo}' to ref:'%{ref}'.") % { repo: temp_dir, ref: git_ref }
+            end
           end
         else
           PDK.logger.error clone_result[:stdout]

--- a/spec/unit/pdk/module/template_dir_spec.rb
+++ b/spec/unit/pdk/module/template_dir_spec.rb
@@ -327,8 +327,9 @@ describe PDK::Module::TemplateDir do
       allow(PDK::Util).to receive(:default_template_url).and_return(path_or_url)
       allow(PDK::Util).to receive(:default_template_ref).and_return('default-ref')
       allow(PDK::Util).to receive(:make_tmpdir_name).with('pdk-templates').and_return(tmp_path)
+      allow(Dir).to receive(:chdir).with(tmp_path).and_yield
       allow(PDK::Util::Git).to receive(:git).with('clone', path_or_url, tmp_path).and_return(exit_code: 0)
-      allow(PDK::Util::Git).to receive(:git).with('-C', tmp_path, 'reset', '--hard', 'default-ref').and_return(exit_code: 0)
+      allow(PDK::Util::Git).to receive(:git).with('reset', '--hard', 'default-ref').and_return(exit_code: 0)
       allow(FileUtils).to receive(:remove_dir).with(tmp_path)
       allow(PDK::Util::Git).to receive(:git).with('--git-dir', anything, 'describe', '--all', '--long', '--always').and_return(exit_code: 0, stdout: '1234abcd')
       allow(PDK::Util::Version).to receive(:version_string).and_return('0.0.0')
@@ -349,8 +350,9 @@ describe PDK::Module::TemplateDir do
       allow(PDK::Util).to receive(:default_template_url).and_return('default-url')
       allow(PDK::Util).to receive(:default_template_ref).and_return('default-ref')
       allow(PDK::Util).to receive(:make_tmpdir_name).with('pdk-templates').and_return(tmp_path)
+      allow(Dir).to receive(:chdir).with(tmp_path).and_yield
       allow(PDK::Util::Git).to receive(:git).with('clone', path_or_url, tmp_path).and_return(exit_code: 0)
-      allow(PDK::Util::Git).to receive(:git).with('-C', tmp_path, 'reset', '--hard', 'origin/master').and_return(exit_code: 0)
+      allow(PDK::Util::Git).to receive(:git).with('reset', '--hard', 'origin/master').and_return(exit_code: 0)
       allow(FileUtils).to receive(:remove_dir).with(tmp_path)
       allow(PDK::Util::Git).to receive(:git).with('--git-dir', anything, 'describe', '--all', '--long', '--always').and_return(exit_code: 0, stdout: '1234abcd')
       allow(PDK::Util::Version).to receive(:version_string).and_return('0.0.0')


### PR DESCRIPTION
For users with old versions of git that don't support `git -C <directory>`.