### PR TITLE
(PDK-1204) pdk bundle execs in the context of the pwd

### DIFF
--- a/lib/pdk/cli/bundle.rb
+++ b/lib/pdk/cli/bundle.rb
@@ -27,7 +27,7 @@ EOF
       gemfile_env = PDK::Util::Bundler::BundleHelper.gemfile_env(puppet_env[:gemset])
 
       command = PDK::CLI::Exec::Command.new(PDK::CLI::Exec.bundle_bin, *args).tap do |c|
-        c.context = :module
+        c.context = :pwd
         c.update_environment(gemfile_env)
       end
 

--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -94,7 +94,7 @@ module PDK
         end
 
         def context=(new_context)
-          unless [:system, :module].include?(new_context)
+          unless [:system, :module, :pwd].include?(new_context)
             raise ArgumentError, _("Expected execution context to be :system or :module but got '%{context}'.") % { context: new_context }
           end
 
@@ -132,7 +132,7 @@ module PDK
 
           @process.environment['BUNDLE_IGNORE_CONFIG'] = '1'
 
-          if context == :module
+          if [:module, :pwd].include?(context)
             @process.environment['GEM_HOME'] = PDK::Util::RubyVersion.gem_home
             @process.environment['GEM_PATH'] = PDK::Util::RubyVersion.gem_path
 
@@ -155,7 +155,7 @@ module PDK
               raise PDK::CLI::FatalError, _('Current working directory is not part of a module. (No metadata.json was found.)')
             end
 
-            if Dir.pwd == mod_root
+            if Dir.pwd == mod_root || context == :pwd
               run_process_in_clean_env!
             else
               Dir.chdir(mod_root) do

--- a/spec/acceptance/bundle_spec.rb
+++ b/spec/acceptance/bundle_spec.rb
@@ -4,11 +4,33 @@ describe 'pdk bundle' do
   context 'in a new module' do
     include_context 'in a new module', 'bundle'
 
+    before(:all) do
+      File.open(File.join('manifests', 'init.pp'), 'w') do |f|
+        f.puts '$foo = "bar"'
+      end
+    end
+
     describe command('pdk bundle env') do
       its(:exit_status) { is_expected.to eq 0 }
       # use this weird regex to match for empty string to get proper diff output on failure
       its(:stdout) { is_expected.to match(%r{\A\Z}) }
       its(:stderr) { is_expected.to match(%r{## Environment}) }
+    end
+
+    context 'when running in a subdirectory of the module root' do
+      before(:all) do
+        Dir.chdir('manifests')
+      end
+
+      after(:all) do
+        Dir.chdir('..')
+      end
+
+      describe command('pdk bundle exec puppet-lint init.pp') do
+        its(:exit_status) { is_expected.to eq(0) }
+        its(:stdout) { is_expected.to match(%r{\A\Z}) }
+        its(:stderr) { is_expected.to match(%r{double quoted string}im) }
+      end
     end
   end
 end


### PR DESCRIPTION
Adds a new `:pwd` context to `PDK::CLI::Exec` that behaves the same as
the `:module` context in that it sets up the Ruby environment to use the
vendored libraries, but it runs the command from the working directory
rather than the module root.

This makes `pdk bundle exec` behave more like `bundle exec`.