### PR TITLE
(PDK-1202) Pass TemplateDir object through to TemplateFile

### DIFF
--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -117,7 +117,7 @@ module PDK
             dest_status = :delete
           else
             begin
-              dest_content = PDK::TemplateFile.new(File.join(template_loc, template_file), configs: config).render
+              dest_content = PDK::TemplateFile.new(File.join(template_loc, template_file), configs: config, template_dir: self).render
             rescue => e
               error_msg = _(
                 "Failed to render template '%{template}'\n" \

--- a/lib/pdk/template_file.rb
+++ b/lib/pdk/template_file.rb
@@ -44,6 +44,12 @@ module PDK
       end
     end
 
+    def config_for(path)
+      return nil unless respond_to?(:template_dir)
+
+      template_dir.config_for(path)
+    end
+
     private
 
     # Reads the content of the template file into memory.

--- a/spec/unit/pdk/template_file_spec.rb
+++ b/spec/unit/pdk/template_file_spec.rb
@@ -5,6 +5,32 @@ describe PDK::TemplateFile do
 
   let(:data) { { configs: { 'test' => 'value' }, some: 'value' } }
 
+  context '#config_for' do
+    subject { template_file.config_for(filename) }
+
+    let(:filename) { 'testfile' }
+    let(:template_path) { '/path/to/some/file' }
+
+    context 'when :template_dir not passed in the data hash' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'when :template_dir has been passed in the data hash' do
+      let(:data) do
+        {
+          configs: { 'test' => 'value' },
+          template_dir: instance_double(PDK::Module::TemplateDir),
+        }
+      end
+
+      before(:each) do
+        allow(data[:template_dir]).to receive(:config_for).with(filename).and_return(a: 'value')
+      end
+
+      it { is_expected.to eq(a: 'value') }
+    end
+  end
+
   context 'when asked to render a file' do
     let(:template_path) { '/path/to/some/file' }
 


### PR DESCRIPTION
This allows templates to access configuration for other files if they really need to (for example, generating a `.puppet-lint.rc` from the checks being disabled in the `Rakefile`). The config for another file can be accessed in the template using the `config_for` method, e.g.

```erb
<%= config_for('Rakefile')['default_lint_disabled_checks'] %>
```