### PR TITLE
(MAINT) Bump default packaged ruby version to 2.4.5

### DIFF
--- a/lib/pdk/util/ruby_version.rb
+++ b/lib/pdk/util/ruby_version.rb
@@ -45,8 +45,9 @@ module PDK
         end
 
         def default_ruby_version
-          # For now, the packaged versions will be using default of 2.4.4.
-          return '2.4.4' if PDK::Util.package_install?
+          # For now, the packaged versions will be using default of 2.4.5
+          # FIXME: make this dynamic
+          return '2.4.5' if PDK::Util.package_install?
 
           # TODO: may not be a safe assumption that highest available version should be default
           latest_ruby_version


### PR DESCRIPTION
We should figure out a way to not have to update this every time runtime ruby version changes.