### PR TITLE
Update bundler dependency

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.1.9'
+  spec.required_ruby_version = '>= 2.3.0'
 
-  spec.add_runtime_dependency 'bundler', '~> 1.15'
+  spec.add_runtime_dependency 'bundler', '~> 2.0.0'
   spec.add_runtime_dependency 'cri', '~> 2.10.1'
   spec.add_runtime_dependency 'childprocess', '~> 0.7.1'
   spec.add_runtime_dependency 'gettext-setup', '~> 0.24'


### PR DESCRIPTION
Bundler 2.0.0 is out, this kicks PDK up to use it. Based on https://github.com/bundler/bundler/blob/v2.0.0/CHANGELOG.md, the only impact is that it's a breaking change to the minimum Ruby / RubyGems versions.