### PR TITLE
(PDK-735) Implement a YAML validator

### DIFF
--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -6,7 +6,7 @@ module PDK::CLI
     usage _('validate [validators] [options] [targets]')
     summary _('Run static analysis tests.')
     description _(
-      "Run metadata, Puppet, Ruby, or Tasks validation.\n\n" \
+      "Run metadata, YAML, Puppet, Ruby, or Tasks validation.\n\n" \
       '[validators] is an optional comma-separated list of validators to use. ' \
       'If not specified, all validators are used. ' \
       "Note that when using PowerShell, the list of validators must be enclosed in single quotes.\n\n" \

--- a/lib/pdk/module.rb
+++ b/lib/pdk/module.rb
@@ -4,7 +4,6 @@ module PDK
   module Module
     DEFAULT_IGNORED = [
       '/pkg/',
-      '.*',
       '~*',
       '/coverage',
       '/checksums.json',
@@ -13,8 +12,10 @@ module PDK
       '/vendor/',
     ].freeze
 
-    def default_ignored_pathspec
-      @default_ignored_pathspec ||= PathSpec.new(DEFAULT_IGNORED)
+    def default_ignored_pathspec(ignore_dotfiles = true)
+      PathSpec.new(DEFAULT_IGNORED).tap do |ps|
+        ps.add('.*') if ignore_dotfiles
+      end
     end
     module_function :default_ignored_pathspec
   end

--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -269,8 +269,14 @@ module PDK
         if File.file?(loc) && File.readable?(loc)
           begin
             YAML.safe_load(File.read(loc), [], [], true)
-          rescue StandardError => e
-            PDK.logger.warn(_("'%{file}' is not a valid YAML file: %{message}") % { file: loc, message: e.message })
+          rescue Psych::SyntaxError => e
+            PDK.logger.warn _("'%{file}' is not a valid YAML file: %{problem} %{context} at line %{line} column %{column}") % {
+              file:    loc,
+              problem: e.problem,
+              context: e.context,
+              line:    e.line,
+              column:  e.column,
+            }
             {}
           end
         else

--- a/lib/pdk/validate.rb
+++ b/lib/pdk/validate.rb
@@ -2,11 +2,18 @@ require 'pdk/validate/metadata_validator'
 require 'pdk/validate/puppet_validator'
 require 'pdk/validate/ruby_validator'
 require 'pdk/validate/tasks_validator'
+require 'pdk/validate/yaml_validator'
 
 module PDK
   module Validate
     def self.validators
-      @validators ||= [MetadataValidator, PuppetValidator, RubyValidator, TasksValidator].freeze
+      @validators ||= [
+        MetadataValidator,
+        YAMLValidator,
+        PuppetValidator,
+        RubyValidator,
+        TasksValidator,
+      ].freeze
     end
 
     class ParseOutputError < StandardError; end

--- a/lib/pdk/validate/yaml/syntax.rb
+++ b/lib/pdk/validate/yaml/syntax.rb
@@ -1,0 +1,109 @@
+require 'pdk'
+require 'pdk/cli/exec'
+require 'pdk/validate/base_validator'
+require 'pdk/util'
+require 'pathname'
+
+module PDK
+  module Validate
+    class YAML
+      class Syntax < BaseValidator
+        IGNORE_DOTFILES = false
+
+        def self.name
+          'yaml-syntax'
+        end
+
+        def self.pattern
+          [
+            '**/*.yaml',
+            '*.yaml',
+            '**/*.yml',
+            '*.yml',
+          ]
+        end
+
+        def self.spinner_text(_targets = [])
+          _('Checking YAML syntax (%{targets}).') % {
+            targets: pattern,
+          }
+        end
+
+        def self.create_spinner(targets = [], options = {})
+          return unless PDK::CLI::Util.interactive?
+          options = options.merge(PDK::CLI::Util.spinner_opts_for_platform)
+
+          exec_group = options[:exec_group]
+          @spinner = if exec_group
+                       exec_group.add_spinner(spinner_text(targets), options)
+                     else
+                       TTY::Spinner.new("[:spinner] #{spinner_text(targets)}", options)
+                     end
+          @spinner.auto_spin
+        end
+
+        def self.stop_spinner(exit_code)
+          if exit_code.zero? && @spinner
+            @spinner.success
+          elsif @spinner
+            @spinner.error
+          end
+        end
+
+        def self.invoke(report, options = {})
+          targets, skipped, invalid = parse_targets(options)
+
+          process_skipped(report, skipped)
+          process_invalid(report, invalid)
+
+          return 0 if targets.empty?
+
+          return_val = 0
+          create_spinner(targets, options)
+
+          targets.each do |target|
+            unless File.readable?(target)
+              report.add_event(
+                file:     target,
+                source:   name,
+                state:    :failure,
+                severity: 'error',
+                message:  _('Could not be read.'),
+              )
+              return_val = 1
+              next
+            end
+
+            begin
+              ::YAML.safe_load(File.read(target), [], [], true)
+
+              report.add_event(
+                file:     target,
+                source:   name,
+                state:    :passed,
+                severity: 'ok',
+              )
+            rescue Psych::SyntaxError => e
+              report.add_event(
+                file:     target,
+                source:   name,
+                state:    :failure,
+                severity: 'error',
+                line:     e.line,
+                column:   e.column,
+                message:  _('%{problem} %{context}') % {
+                  problem: e.problem,
+                  context: e.context,
+                },
+              )
+              return_val = 1
+            end
+          end
+
+          stop_spinner(return_val)
+          return_val
+        end
+      end
+    end
+  end
+end

--- a/lib/pdk/validate/yaml_validator.rb
+++ b/lib/pdk/validate/yaml_validator.rb
@@ -1,0 +1,31 @@
+require 'pdk'
+require 'pdk/cli/exec'
+require 'pdk/validate/base_validator'
+require 'pdk/validate/yaml/syntax'
+
+module PDK
+  module Validate
+    class YAMLValidator < BaseValidator
+      def self.name
+        'yaml'
+      end
+
+      def self.validators
+        [
+          PDK::Validate::YAML::Syntax,
+        ]
+      end
+
+      def self.invoke(report, options = {})
+        exit_code = 0
+
+        validators.each do |validator|
+          exit_code = validator.invoke(report, options)
+          break if exit_code != 0
+        end
+
+        exit_code
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,6 +63,7 @@ RSpec.shared_context :validators do
   let(:validators) do
     [
       PDK::Validate::MetadataValidator,
+      PDK::Validate::YAMLValidator,
       PDK::Validate::PuppetValidator,
       PDK::Validate::RubyValidator,
       PDK::Validate::TasksValidator,

--- a/spec/support/it_accepts_metadata_json_targets.rb
+++ b/spec/support/it_accepts_metadata_json_targets.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples_for 'it accepts metadata.json targets' do
 
     before(:each) do
       glob_pattern.each do |pattern|
-        allow(Dir).to receive(:glob).with(pattern).and_return(globbed_files)
+        allow(Dir).to receive(:glob).with(pattern, anything).and_return(globbed_files)
       end
     end
 
@@ -19,7 +19,7 @@ RSpec.shared_examples_for 'it accepts metadata.json targets' do
 
       context 'and the module contains a metadata.json file' do
         before(:each) do
-          allow(Dir).to receive(:glob).with(module_metadata_json).and_return([module_metadata_json])
+          allow(Dir).to receive(:glob).with(module_metadata_json, anything).and_return([module_metadata_json])
           allow(File).to receive(:expand_path).with(module_root).and_return(module_root)
         end
 

--- a/spec/support/it_accepts_pp_targets.rb
+++ b/spec/support/it_accepts_pp_targets.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples_for 'it accepts .pp targets' do
     let(:glob_pattern) { File.join(module_root, described_class.pattern) }
 
     before(:each) do
-      allow(Dir).to receive(:glob).with(glob_pattern).and_return(globbed_files)
+      allow(Dir).to receive(:glob).with(glob_pattern, anything).and_return(globbed_files)
       allow(File).to receive(:expand_path).with(module_root).and_return(module_root)
     end
 

--- a/spec/unit/pdk/validate/base_validator_spec.rb
+++ b/spec/unit/pdk/validate/base_validator_spec.rb
@@ -89,7 +89,7 @@ describe PDK::Validate::BaseValidator do
 
       before(:each) do
         allow(File).to receive(:directory?).and_return(true)
-        allow(Dir).to receive(:glob).with(glob_pattern).and_return(globbed_files)
+        allow(Dir).to receive(:glob).with(glob_pattern, anything).and_return(globbed_files)
         allow(File).to receive(:expand_path).with(module_root).and_return(module_root)
       end
 
@@ -114,7 +114,7 @@ describe PDK::Validate::BaseValidator do
 
       before(:each) do
         allow(File).to receive(:directory?).and_return(true)
-        allow(Dir).to receive(:glob).with(glob_pattern).and_return(globbed_files)
+        allow(Dir).to receive(:glob).with(glob_pattern, anything).and_return(globbed_files)
         allow(File).to receive(:expand_path).with(module_root).and_return(module_root)
       end
 
@@ -134,7 +134,7 @@ describe PDK::Validate::BaseValidator do
       let(:globbed_target2) { targets2.map { |target| File.join(module_root, target) } }
 
       before(:each) do
-        allow(Dir).to receive(:glob).with(glob_pattern).and_return(globbed_target2)
+        allow(Dir).to receive(:glob).with(glob_pattern, anything).and_return(globbed_target2)
         allow(File).to receive(:directory?).with('target1.pp').and_return(false)
         allow(File).to receive(:directory?).with('target2/').and_return(true)
         allow(File).to receive(:file?).with('target1.pp').and_return(true)
@@ -163,7 +163,7 @@ describe PDK::Validate::BaseValidator do
       end
 
       before(:each) do
-        allow(Dir).to receive(:glob).with(File.join(module_root, described_class.pattern)).and_return(globbed_target2)
+        allow(Dir).to receive(:glob).with(File.join(module_root, described_class.pattern), anything).and_return(globbed_target2)
         allow(File).to receive(:directory?).with('target3/').and_return(true)
       end
 

--- a/spec/unit/pdk/validate/puppet_syntax_spec.rb
+++ b/spec/unit/pdk/validate/puppet_syntax_spec.rb
@@ -24,7 +24,7 @@ describe PDK::Validate::PuppetSyntax do
 
       before(:each) do
         allow(Dir).to receive(:glob).with(any_args).and_call_original
-        allow(Dir).to receive(:glob).with(glob_pattern).and_return(globbed_files)
+        allow(Dir).to receive(:glob).with(glob_pattern, anything).and_return(globbed_files)
         allow(File).to receive(:expand_path).with(any_args).and_call_original
         allow(File).to receive(:expand_path).with(module_root).and_return(module_root)
       end

--- a/spec/unit/pdk/validate/rubocop_spec.rb
+++ b/spec/unit/pdk/validate/rubocop_spec.rb
@@ -57,7 +57,7 @@ describe PDK::Validate::Rubocop do
       end
 
       before(:each) do
-        allow(Dir).to receive(:glob).with(glob_pattern).and_return(globbed_target2)
+        allow(Dir).to receive(:glob).with(glob_pattern, anything).and_return(globbed_target2)
         allow(File).to receive(:directory?).with('target1.rb').and_return(false)
         allow(File).to receive(:directory?).with('target2/').and_return(true)
         allow(File).to receive(:file?).with('target1.rb').and_return(true)

--- a/spec/unit/pdk/validate/tasks/name_spec.rb
+++ b/spec/unit/pdk/validate/tasks/name_spec.rb
@@ -34,7 +34,7 @@ describe PDK::Validate::Tasks::Name do
 
     before(:each) do
       globbed_targets = targets.map { |r| File.join(module_root, r) }
-      allow(Dir).to receive(:glob).with(glob_pattern).and_return(globbed_targets)
+      allow(Dir).to receive(:glob).with(glob_pattern, anything).and_return(globbed_targets)
       allow(File).to receive(:expand_path).with(module_root).and_return(module_root)
     end
 

--- a/spec/unit/pdk/validate/yaml/syntax_spec.rb
+++ b/spec/unit/pdk/validate/yaml/syntax_spec.rb
@@ -1,0 +1,131 @@
+require 'spec_helper'
+
+describe PDK::Validate::YAML::Syntax do
+  let(:module_root) { File.join('path', 'to', 'test', 'module') }
+
+  before(:each) do
+    allow(PDK::Util).to receive(:module_root).and_return(module_root)
+    allow(File).to receive(:directory?).with(module_root).and_return(true)
+  end
+
+  describe '.spinner_text' do
+    subject(:text) { described_class.spinner_text }
+
+    it { is_expected.to match(%r{\AChecking YAML syntax}i) }
+  end
+
+  describe '.invoke' do
+    subject(:return_value) { described_class.invoke(report, targets: targets.map { |r| r[:name] }) }
+
+    let(:report) { PDK::Report.new }
+    let(:targets) { [] }
+
+    before(:each) do
+      targets.each do |target|
+        allow(File).to receive(:directory?).with(target[:name]).and_return(target.fetch(:directory, false))
+        allow(File).to receive(:file?).with(target[:name]).and_return(target.fetch(:file, true))
+        allow(File).to receive(:readable?).with(target[:name]).and_return(target.fetch(:readable, true))
+        allow(File).to receive(:read).with(target[:name]).and_return(target.fetch(:content, ''))
+      end
+    end
+
+    context 'when no valid targets are provided' do
+      it 'does not attempt to validate files' do
+        expect(report).to receive(:add_event).with(
+          file:     module_root,
+          source:   'yaml-syntax',
+          state:    :skipped,
+          severity: :info,
+          message:  a_string_matching(%r{\ATarget does not contain any}),
+        )
+        expect(return_value).to eq(0)
+      end
+    end
+
+    context 'when a target is provided that is an unreadable file' do
+      let(:targets) do
+        [
+          { name: '.sync.yml', readable: false },
+        ]
+      end
+
+      it 'adds a failure event to the report' do
+        expect(report).to receive(:add_event).with(
+          file:     targets.first[:name],
+          source:   'yaml-syntax',
+          state:    :failure,
+          severity: 'error',
+          message:  'Could not be read.',
+        )
+        expect(return_value).to eq(1)
+      end
+    end
+
+    context 'when a target is provided that contains valid YAML' do
+      let(:targets) do
+        [
+          { name: '.sync.yml', content: "---\n  foo: bar" },
+        ]
+      end
+
+      it 'adds a passing event to the report' do
+        expect(report).to receive(:add_event).with(
+          file:     targets.first[:name],
+          source:   'yaml-syntax',
+          state:    :passed,
+          severity: 'ok',
+        )
+        expect(return_value).to eq(0)
+      end
+    end
+
+    context 'when a target is provided that contains invalid YAML' do
+      let(:targets) do
+        [
+          { name: '.sync.yaml', content: "---\n\tfoo: bar" },
+        ]
+      end
+
+      it 'adds a failure event to the report' do
+        expect(report).to receive(:add_event).with(
+          file:     targets.first[:name],
+          source:   'yaml-syntax',
+          state:    :failure,
+          severity: 'error',
+          message:  a_string_matching(%r{\Afound character that cannot start}),
+          line:     2,
+          column:   1,
+        )
+        expect(return_value).to eq(1)
+      end
+    end
+
+    context 'when targets are provided that contain valid and invalid YAML' do
+      let(:targets) do
+        [
+          { name: 'invalid/data.yml', content: "---\n\tfoo: bar" },
+          { name: '.sync.yml', content: "---\n  foo: bar" },
+        ]
+      end
+
+      it 'adds events for all valid targets to the report' do
+        expect(report).to receive(:add_event).with(
+          file:     'invalid/data.yml',
+          source:   'yaml-syntax',
+          state:    :failure,
+          severity: 'error',
+          message:  a_string_matching(%r{\Afound character that cannot start}),
+          line:     2,
+          column:   1,
+        )
+        expect(report).to receive(:add_event).with(
+          file:     '.sync.yml',
+          source:   'yaml-syntax',
+          state:    :passed,
+          severity: 'ok',
+        )
+        expect(return_value).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/unit/pdk/validate/yaml_validator_spec.rb
+++ b/spec/unit/pdk/validate/yaml_validator_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe PDK::Validate::YAMLValidator do
+  let(:yaml_validators) do
+    [
+      PDK::Validate::YAML::Syntax,
+    ]
+  end
+
+  describe '.name' do
+    subject { described_class.name }
+
+    it { is_expected.to eq('yaml') }
+  end
+
+  describe '.validators' do
+    subject { described_class.validators }
+
+    it { is_expected.to eq(yaml_validators) }
+  end
+
+  describe '.invoke' do
+    subject(:return_value) { described_class.invoke(report, {}) }
+
+    let(:report) { PDK::Report.new }
+
+    before(:each) do
+      yaml_validators.each do |validator|
+        allow(validator).to receive(:invoke).with(report, anything).and_return(validator_return)
+      end
+    end
+
+    context 'when the validators succeed' do
+      let(:validator_return) { 0 }
+
+      it 'returns 0' do
+        expect(return_value).to eq(0)
+      end
+    end
+
+    context 'when the validators fail' do
+      let(:validator_return) { 1 }
+
+      it 'returns 1' do
+        expect(return_value).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Lots of changes to unrelated spec files due to the addition of `File::FNM_DOTMATCH` when building target lists (so that the YAML validator can validate hidden files).