### PR TITLE
(maint) Fix package tests to remove hardcoding

### DIFF
--- a/package-testing/spec/package/airgapped_usage_spec.rb
+++ b/package-testing/spec/package/airgapped_usage_spec.rb
@@ -3,14 +3,6 @@ require 'spec_helper_package'
 describe 'Basic usage in an air-gapped environment' do
   module_name = 'airgapped_module'
 
-  def hosts_file
-    if windows_node?
-      '/cygdrive/c/Windows/System32/Drivers/etc/hosts'
-    else
-      '/etc/hosts'
-    end
-  end
-
   context 'with rubygems.org access disabled' do
     before(:all) do
       shell("cp #{hosts_file} #{hosts_file}.bak")
@@ -48,8 +40,8 @@ describe 'Basic usage in an air-gapped environment' do
           subject { super().content.gsub(%r{^DEPENDENCIES.+?\n\n}m, '') }
 
           it 'is identical to the vendored lockfile' do
-            # TODO: Need to find a better way to get 'latest_ruby' programmatically so we can use the correct vendored gemfile.
-            vendored_lockfile = File.join(install_dir, 'share', 'cache', 'Gemfile-2.5.1.lock')
+            vendored_lockfile = File.join(install_dir, 'share', 'cache', "Gemfile-#{latest_ruby}.lock")
+
             is_expected.to eq(file(vendored_lockfile).content.gsub(%r{^DEPENDENCIES.+?\n\n}m, ''))
           end
         end

--- a/package-testing/spec/package/support/spec_utils.rb
+++ b/package-testing/spec/package/support/spec_utils.rb
@@ -26,4 +26,21 @@ module SpecUtils
     path = File.join(install_dir, 'private', 'git')
     windows_node? ? "& '#{File.join(path, 'cmd', 'git.exe')}'" : File.join(path, 'bin', 'git')
   end
+
+  def hosts_file
+    if windows_node?
+      '/cygdrive/c/Windows/System32/Drivers/etc/hosts'
+    else
+      '/etc/hosts'
+    end
+  end
+
+  def ruby_cache_dir
+    File.join(install_dir(true), 'private', 'ruby')
+  end
+
+  def latest_ruby
+    installed_rubies = shell("cd #{ruby_cache_dir}; ls -dr *").stdout.split
+    installed_rubies[0]
+  end
 end

--- a/package-testing/spec/package/validate_a_new_module_spec.rb
+++ b/package-testing/spec/package/validate_a_new_module_spec.rb
@@ -30,8 +30,8 @@ describe 'C100321 - Generate a module and validate it (i.e. ensure bundle instal
         subject { super().content.gsub(%r{^DEPENDENCIES.+?\n\n}m, '') }
 
         it 'is identical to the vendored lockfile' do
-          # TODO: Need to find a better way to get 'latest_ruby' programmatically so we can use the correct vendored gemfile.
-          vendored_lockfile = File.join(install_dir, 'share', 'cache', 'Gemfile-2.5.1.lock')
+          vendored_lockfile = File.join(install_dir, 'share', 'cache', "Gemfile-#{latest_ruby}.lock")
+
           is_expected.to eq(file(vendored_lockfile).content.gsub(%r{^DEPENDENCIES.+?\n\n}m, ''))
         end
       end


### PR DESCRIPTION
The vendored Gemfile name had a hardcoded value with the "latest ruby"
version. This caused breakage in package tests each time packaged ruby
versions were updated. This fix updates the tests to detect the latest version
from the pdk private cache.