### PR TITLE
(PDK-1273) Whitelist Ruby symbols in YAML validator

### DIFF
--- a/lib/pdk/validate/yaml/syntax.rb
+++ b/lib/pdk/validate/yaml/syntax.rb
@@ -9,6 +9,7 @@ module PDK
     class YAML
       class Syntax < BaseValidator
         IGNORE_DOTFILES = false
+        YAML_WHITELISTED_CLASSES = [Symbol].freeze
 
         def self.name
           'yaml-syntax'
@@ -75,7 +76,7 @@ module PDK
             end
 
             begin
-              ::YAML.safe_load(File.read(target), [], [], true)
+              ::YAML.safe_load(File.read(target), YAML_WHITELISTED_CLASSES, [], true)
 
               report.add_event(
                 file:     target,

--- a/lib/pdk/validate/yaml/syntax.rb
+++ b/lib/pdk/validate/yaml/syntax.rb
@@ -97,6 +97,17 @@ module PDK
                 },
               )
               return_val = 1
+            rescue Psych::DisallowedClass => e
+              report.add_event(
+                file:     target,
+                source:   name,
+                state:    :failure,
+                severity: 'error',
+                message:  _('Unsupported class: %{message}') % {
+                  message: e.message,
+                },
+              )
+              return_val = 1
             end
           end
 

--- a/spec/unit/pdk/validate/yaml/syntax_spec.rb
+++ b/spec/unit/pdk/validate/yaml/syntax_spec.rb
@@ -79,6 +79,24 @@ describe PDK::Validate::YAML::Syntax do
       end
     end
 
+    context 'when a target is provided that contains valid YAML with a symbol value' do
+      let(:targets) do
+        [
+          { name: '.sync.yml', content: "---\n  foo: :bar" },
+        ]
+      end
+
+      it 'adds a passing event to the report' do
+        expect(report).to receive(:add_event).with(
+          file:     targets.first[:name],
+          source:   'yaml-syntax',
+          state:    :passed,
+          severity: 'ok',
+        )
+        expect(return_value).to eq(0)
+      end
+    end
+
     context 'when a target is provided that contains invalid YAML' do
       let(:targets) do
         [

--- a/spec/unit/pdk/validate/yaml/syntax_spec.rb
+++ b/spec/unit/pdk/validate/yaml/syntax_spec.rb
@@ -100,6 +100,25 @@ describe PDK::Validate::YAML::Syntax do
       end
     end
 
+    context 'when a target is provided that contains an unsupported class' do
+      let(:targets) do
+        [
+          { name: 'file.yml', content: "--- !ruby/object:File {}\n" },
+        ]
+      end
+
+      it 'adds a failure event to the report' do
+        expect(report).to receive(:add_event).with(
+          file:     targets.first[:name],
+          source:   'yaml-syntax',
+          state:    :failure,
+          severity: 'error',
+          message:  a_string_matching(%r{unspecified class: file}i),
+        )
+        expect(return_value).to eq(1)
+      end
+    end
+
     context 'when targets are provided that contain valid and invalid YAML' do
       let(:targets) do
         [


### PR DESCRIPTION
Ruby symbols are the only additional classes allowed in Puppet's YAML loader, so this should be the only one we need to add.