### PR TITLE
(PDK-1272) Convert user/module module names to user-module

### DIFF
--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -163,7 +163,8 @@ module PDK
       # Do basic validation and parsing of the name parameter.
       def process_name(data)
         validate_name(data['name'])
-        author, _modname = data['name'].split(%r{[-/]}, 2)
+        author, modname = data['name'].split(%r{[-/]}, 2)
+        data['name'] = [author, modname].join('-')
 
         data['author'] ||= author if @data['author'] == DEFAULTS['author']
       end

--- a/spec/unit/pdk/module/metadata_spec.rb
+++ b/spec/unit/pdk/module/metadata_spec.rb
@@ -65,6 +65,12 @@ describe PDK::Module::Metadata do
     it 'errors when the provided name starts with a non-letter character' do
       expect { metadata.update!('name' => 'foo-1bar') }.to raise_error(ArgumentError, %r{Invalid 'name' field in metadata.json: module name must begin with a letter}i)
     end
+
+    it 'converts user/module style names to user-module' do
+      metadata.update!('name' => 'user/module')
+
+      expect(metadata.data['name']).to eq('user-module')
+    end
   end
 
   describe '#forge_ready?' do


### PR DESCRIPTION
By handling this during metadata.json validation/processing, it will automatically happen during `pdk convert` and `pdk update` without further changes.