### PR TITLE
(maint) Pin parallel gem to 1.13.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ end
 group :test do
   gem 'coveralls'
   gem 'license_finder', '~> 3.0.4'
+  gem 'parallel', '= 1.13.0'
   gem 'parser', '~> 2.5.1.2'
   gem 'rake', '~> 10.0'
   gem 'rspec', '~> 3.0'


### PR DESCRIPTION
parallel 1.14.0 was just released which depends on Ruby >= 2.2