### PR TITLE
(PDK-1193) Saves packaged template-url in metadata as a keyword

### DIFF
--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -108,6 +108,7 @@ module PDK
           raise ArgumentError, _('Invalid JSON in metadata.json: %{msg}') % { msg: e.message }
         end
 
+        data['template-url'] = PDK::Util::TemplateURI.default_template_uri.metadata_format if PDK::Util.package_install? && data['template-url'] == PDK::Util::TemplateURI::PACKAGED_TEMPLATE_KEYWORD
         new(data)
       end
 

--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -9,6 +9,7 @@ module PDK
   module Module
     class TemplateDir
       attr_accessor :module_metadata
+      attr_reader :uri
 
       # Initialises the TemplateDir object with the path or URL to the template
       # and the block of code to run to be run while the template is available.
@@ -61,7 +62,7 @@ module PDK
             }
           end
         end
-        @cloned_from = uri.metadata_format
+        @uri = uri
 
         @init = init
         @moduleroot_dir = File.join(@path, 'moduleroot')
@@ -94,7 +95,7 @@ module PDK
       def metadata
         {
           'pdk-version'  => PDK::Util::Version.version_string,
-          'template-url' => @cloned_from,
+          'template-url' => uri.metadata_format,
           'template-ref' => cache_template_ref(@path),
         }
       end

--- a/spec/unit/pdk/module/convert_spec.rb
+++ b/spec/unit/pdk/module/convert_spec.rb
@@ -390,6 +390,7 @@ describe PDK::Module::Convert do
 
     before(:each) do
       allow(File).to receive(:open).with(any_args).and_call_original
+      allow(PDK::Util).to receive(:package_install?).and_return(false)
     end
 
     context 'when the metadata file exists' do

--- a/spec/unit/pdk/module/metadata_spec.rb
+++ b/spec/unit/pdk/module/metadata_spec.rb
@@ -10,9 +10,14 @@ describe PDK::Module::Metadata do
       }.to_json
     end
 
+    before(:each) do
+      allow(PDK::Util).to receive(:package_install?).and_return(true)
+    end
+
     it 'can populate itself from a metadata.json file on disk' do
       allow(File).to receive(:file?).with(metadata_json_path).and_return(true)
       allow(File).to receive(:readable?).with(metadata_json_path).and_return(true)
+      allow(PDK::Util).to receive(:package_install?).and_return(false)
       allow(File).to receive(:read).with(metadata_json_path).and_return(metadata_json_content)
 
       expect(described_class.from_file(metadata_json_path).data).to include('name' => 'foo-bar', 'version' => '0.1.0')

--- a/spec/unit/pdk/module/update_spec.rb
+++ b/spec/unit/pdk/module/update_spec.rb
@@ -100,7 +100,7 @@ describe PDK::Module::Update do
 
     context 'when using the default template' do
       let(:options) { { noop: true } }
-      let(:template_url) { PDK::Util::TemplateURI.default_template_uri }
+      let(:template_url) { PDK::Util::TemplateURI.default_template_uri.metadata_format }
 
       it 'refers to the template as the default template' do
         expect(logger).to receive(:info).with(a_string_matching(%r{using the default template}i))


### PR DESCRIPTION
Currently, for packaged installations the default templates template-url
is saved in the metadata.json as the file path. This breaks when a
module that is developed with PDK on Windows is moved to a Linux installation
of PDK, since the Windows path doesn't exist. With this fix, the default
packaged template path will be determined by PDK using the keyword
'pdk-default' in that same metadata.json field and the approriate
platform specific template location will be used.

Requires #434 