### PR TITLE
(PDK-1308) Ensure PDK-written non-templated files have trailing newline

### DIFF
--- a/lib/pdk/util/filesystem.rb
+++ b/lib/pdk/util/filesystem.rb
@@ -4,7 +4,13 @@ module PDK
       def write_file(path, content)
         raise ArgumentError unless path.is_a?(String) || path.respond_to?(:to_path)
 
-        File.open(path, 'wb') { |f| f.write(content.encode(universal_newline: true)) }
+        # Harmonize newlines across platforms.
+        content = content.encode(universal_newline: true)
+
+        # Make sure all written files have a trailing newline.
+        content += "\n" unless content[-1] == "\n"
+
+        File.open(path, 'wb') { |f| f.write(content) }
       end
       module_function :write_file
     end

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -117,15 +117,17 @@ describe PDK::Generate::Module do
       end
 
       context 'when the module template contains template files' do
+        let(:content) { 'test_file_content' }
+
         before(:each) do
-          allow(test_template_dir).to receive(:render).and_yield('test_file_path', 'test_file_content')
+          allow(test_template_dir).to receive(:render).and_yield('test_file_path', content)
         end
 
         it 'writes the rendered files from the template to the temporary directory' do
           described_class.invoke(invoke_opts)
 
           test_template_file.rewind
-          expect(test_template_file.read).to eq('test_file_content')
+          expect(test_template_file.read).to eq(content + "\n")
         end
       end
 

--- a/spec/unit/pdk/generate/puppet_object_spec.rb
+++ b/spec/unit/pdk/generate/puppet_object_spec.rb
@@ -76,7 +76,8 @@ describe PDK::Generate::PuppetObject do
     let(:dest_dir) { File.dirname(dest_path) }
     let(:template_path) { '/path/to/file/template' }
     let(:template_data) { { some: 'data', that: 'the', template: 'needs' } }
-    let(:template_file) { instance_double(PDK::TemplateFile, render: 'rendered file content') }
+    let(:template_content) { 'rendered file content' }
+    let(:template_file) { instance_double(PDK::TemplateFile, render: template_content) }
     let(:rendered_file) { StringIO.new }
 
     before(:each) do
@@ -95,7 +96,7 @@ describe PDK::Generate::PuppetObject do
       allow(FileUtils).to receive(:mkdir_p).with(dest_dir)
       templated_object.render_file(dest_path, template_path, template_data)
       rendered_file.rewind
-      expect(rendered_file.read).to eq('rendered file content')
+      expect(rendered_file.read).to eq(template_content + "\n")
     end
 
     context 'when it fails to create the parent directories' do

--- a/spec/unit/pdk/util/vendored_file_spec.rb
+++ b/spec/unit/pdk/util/vendored_file_spec.rb
@@ -77,7 +77,7 @@ describe PDK::Util::VendoredFile do
           it 'caches the download to disk' do
             vendored_file_read
 
-            expect(cached_file.string).to eq(gem_vendored_content)
+            expect(cached_file.string).to eq(gem_vendored_content + "\n")
           end
 
           it 'returns the downloaded content' do


### PR DESCRIPTION
There are some files that PDK writes that are not derived from templates
in the pdk-templates repo. The most notable example of this is the
metadata.json file which is constructed as a Ruby hash and then
serialized to JSON and written to a file. When PDK writes these files it
was not including a trailing newline and files having trailing newlines
is a best practice.

This change updates the PDK::Util::Filesystem.write_file method to
ensure that it always writes files with a trailing newline.

Some of the unit tests around writing templated files also needed to be
updated because of the way the tests were implemented did not simulate
template files that already contained trailing newlines.