### PR TITLE
(PDK-1086) pdk build --force to warn if necessary and continue

### DIFF
--- a/lib/pdk/cli/build.rb
+++ b/lib/pdk/cli/build.rb
@@ -28,8 +28,12 @@ module PDK::CLI
       #
       unless module_metadata.forge_ready?
         if opts[:force]
-          PDK.logger.error _('This module is missing required fields in the metadata.json. Re-run the build command without --force to add this information.')
-          exit 1
+          PDK.logger.warn _(
+            'This module is missing the following fields in the metadata.json: %{fields}. ' \
+            'These missing fields may affect the visibility of the module on the Forge.',
+          ) % {
+            fields: module_metadata.missing_fields.join(', '),
+          }
         else
           module_metadata.interview_for_forge!
           module_metadata.write!('metadata.json')

--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -153,12 +153,12 @@ module PDK
         end
       end
 
-      private
-
       def missing_fields
         fields = DEFAULTS.keys - %w[data_provider requirements dependencies]
         fields.select { |key| @data[key].nil? || @data[key].empty? }
       end
+
+      private
 
       # Do basic validation and parsing of the name parameter.
       def process_name(data)

--- a/spec/acceptance/build_spec.rb
+++ b/spec/acceptance/build_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper_acceptance'
+
+describe 'pdk build', module_command: true do
+  context 'when run inside of a module' do
+    include_context 'in a new module', 'build'
+
+    metadata = {
+      'name'                    => 'testuser-build',
+      'version'                 => '0.1.0',
+      'author'                  => 'testuser',
+      'summary'                 => 'a test module',
+      'source'                  => 'https://github.com/testuser/puppet-build',
+      'project_page'            => 'https://testuser.github.io/puppet-build',
+      'issues_url'              => 'https://github.com/testuser/puppet-build/issues',
+      'dependencies'            => [],
+      'operatingsystem_support' => [{ 'operatingsystem' => 'windows', 'operatingsystemrelease' => ['10'] }],
+      'requirements'            => [{ 'name' => 'puppet', 'version_requirement' => '> 4.10.0 < 7.0.0' }],
+      'pdk-version'             => '1.2.3',
+      'template-url'            => 'https://github.com/puppetlabs/pdk-templates',
+      'template-ref'            => 'heads/master-0-g1234abc',
+    }
+
+    context 'when the module has complete metadata' do
+      before(:all) do
+        File.open('metadata.json', 'w') do |f|
+          f.puts metadata.to_json
+        end
+      end
+
+      after(:all) do
+        FileUtils.remove_entry_secure('pkg')
+      end
+
+      describe command('pdk build --force') do
+        its(:exit_status) { is_expected.to eq(0) }
+        its(:stdout) { is_expected.to have_no_output }
+        its(:stderr) { is_expected.not_to match(%r{WARN|ERR}) }
+        its(:stderr) { is_expected.to match(%r{Build of #{metadata['name']} has completed successfully}) }
+
+        describe file(File.join('pkg', "#{metadata['name']}-#{metadata['version']}.tar.gz")) do
+          it { is_expected.to be_file }
+        end
+      end
+    end
+
+    context 'when the module has incomplete metadata' do
+      before(:all) do
+        File.open('metadata.json', 'w') do |f|
+          f.puts metadata.reject { |k, _| k == 'source' }.to_json
+        end
+      end
+
+      after(:all) do
+        FileUtils.remove_entry_secure('pkg')
+      end
+
+      describe command('pdk build --force') do
+        its(:exit_status) { is_expected.to eq(0) }
+        its(:stdout) { is_expected.to have_no_output }
+        its(:stderr) { is_expected.to match(%r{WARN.+missing the following fields.+source}) }
+        its(:stderr) { is_expected.to match(%r{Build of #{metadata['name']} has completed successfully}) }
+
+        describe file(File.join('pkg', "#{metadata['name']}-#{metadata['version']}.tar.gz")) do
+          it { is_expected.to be_file }
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/pdk/cli/build_spec.rb
+++ b/spec/unit/pdk/cli/build_spec.rb
@@ -56,6 +56,7 @@ describe 'PDK::CLI build' do
     context 'and the module contains incomplete metadata' do
       before(:each) do
         allow(mock_metadata_obj).to receive(:forge_ready?).and_return(false)
+        allow(mock_metadata_obj).to receive(:missing_fields).and_return(%w[operatingsystem_support source])
         allow(PDK::Module::Build).to receive(:new).with(any_args).and_return(mock_builder)
       end
 
@@ -71,9 +72,9 @@ describe 'PDK::CLI build' do
       context 'with --force option' do
         let(:command_opts) { ['--force'] }
 
-        it 'outputs an error message' do
-          expect(logger).to receive(:error).with(a_string_matching(%r{This module is missing required fields in the metadata.json}i))
-          expect { PDK::CLI.run(['build'] + command_opts) }.to exit_nonzero
+        it 'outputs an warning and continues' do
+          expect(logger).to receive(:warn).with(a_string_matching(%r{fields in the metadata\.json: operatingsystem_support, source}im))
+          expect { PDK::CLI.run(['build'] + command_opts) }.not_to raise_error
         end
       end
     end


### PR DESCRIPTION
If there is missing fields in the `metadata.json` when running `pdk build --force`, display an warning and continue as is expected when running with `--force`.

```
$ pdk new module foo --skip-interview
pdk (INFO): Creating new module: foo
[✔] Resolving default Gemfile dependencies.
pdk (INFO): Module 'foo' generated at path '/home/tsharpe/code/puppetlabs/pdk/foo', from template 'https://github.com/puppetlabs/pdk-templates'.
pdk (INFO): In your module directory, add classes with the 'pdk new class' command.
$ cd foo
$ pdk build --force
pdk (WARN): This module is missing the following fields in the metadata.json: summary, source, project_page, issues_url. These missing fields may affect the visibility of the module on the Forge.
pdk (INFO): Building tsharpe-foo version 0.1.0
pdk (INFO): Build of tsharpe-foo has completed successfully. Built package can be found here: /home/tsharpe/code/puppetlabs/pdk/foo/pkg/tsharpe-foo-0.1.0.tar.gz
```

Fixes #634 