### PR TITLE
(maint) Enforce line endings in Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -137,3 +137,7 @@ Style/SymbolArray:
   Description: Using percent style obscures symbolic intent of array's contents.
   Enabled: true
   EnforcedStyle: brackets
+
+# Enforce LF line endings, even when on Windows
+Layout/EndOfLine:
+  EnforcedStyle: lf


### PR DESCRIPTION
Previously running rubocop while on Windows would fail on every single file
unless the line endings were set to CRLF. This commit enforces the LF
line ending for all files, even on Windows, to keep the experience and
expectation consistent across all platforms.