### PR TITLE
(maint) Allow developers to add additional gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ build-iPhoneSimulator/
 /spec/reports/
 /tmp/
 /vendor/gems/
+Gemfile.local
 
 # ignore bundler generated binstubs, but keep setup/console scripts
 /bin/*

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 
 if RUBY_VERSION < '2.4.0'
   # avoid newer versions that do not support ruby 2.1 anymore
+  gem 'cri', '>= 2.10.1', '< 2.11.0'
   gem 'nokogiri', '1.7.2'
 else
   # rubocop:disable Bundler/DuplicatedGem
@@ -50,6 +51,6 @@ extra_gemfiles = [
 
 extra_gemfiles.each do |gemfile|
   if File.file?(gemfile) && File.readable?(gemfile)
-    eval(File.read(gemfile), binding)
+    eval(File.read(gemfile), binding) # rubocop:disable Security/Eval
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,15 @@ end
 group :acceptance do
   gem 'serverspec'
 end
+
+# Evaluate Gemfile.local and ~/.gemfile if they exist
+extra_gemfiles = [
+  "#{__FILE__}.local",
+  File.join(Dir.home, '.gemfile'),
+]
+
+extra_gemfiles.each do |gemfile|
+  if File.file?(gemfile) && File.readable?(gemfile)
+    eval(File.read(gemfile), binding)
+  end
+end


### PR DESCRIPTION
Previous people were not able to add additional gems when developing the PDK,
for example 'pry-stack_explorer', without modifying the Gemfile which could be
accidentally commited.  This commit adds the common Gemfile.local and
~/.gemfile pattern to the Gemfile.