### PR TITLE
Allow a newer childprocess

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'bundler', '>= 1.15.0', '< 3.0.0'
   spec.add_runtime_dependency 'cri', ' >= 2.10.1', '< 2.16.0'
-  spec.add_runtime_dependency 'childprocess', '~> 0.7.1'
+  spec.add_runtime_dependency 'childprocess', '>= 0.7.1', '< 2.0.0'
   spec.add_runtime_dependency 'gettext-setup', '~> 0.24'
   spec.add_runtime_dependency 'tty-spinner', '0.5.0'
   spec.add_runtime_dependency 'tty-prompt', '0.13.1'


### PR DESCRIPTION
73505faa181376727fbe42d1ac1ba35202bb98b3 pinned this to 0.7.1 but this means it's limited to the 0.7 branch. It should work with 0.9 as well.  It was bumped for a Windows 7 bugfix, but that was included in 0.6.3 so 0.7.0 should be safe as well.