### PR TITLE
(PDK-1339) Read or interview for analytics config

### DIFF
--- a/lib/pdk.rb
+++ b/lib/pdk.rb
@@ -1,5 +1,6 @@
 require 'pdk/analytics'
 require 'pdk/answer_file'
+require 'pdk/config'
 require 'pdk/generate'
 require 'pdk/i18n'
 require 'pdk/logger'
@@ -11,7 +12,9 @@ require 'pdk/version'
 module PDK
   def self.analytics
     @analytics ||= PDK::Analytics.build_client(
-      logger: PDK.logger,
+      logger:   PDK.logger,
+      disabled: ENV['PDK_DISABLE_ANALYTICS'] || PDK.config.user['analytics']['disabled'],
+      uuid:     PDK.config.user['analytics']['user-id'],
     )
   end
 end

--- a/lib/pdk/analytics.rb
+++ b/lib/pdk/analytics.rb
@@ -5,42 +5,16 @@ require 'pdk/analytics/client/noop'
 
 module PDK
   module Analytics
-    def self.build_client(logger: ::Logger.new(STDERR))
-      # TODO: PDK-1339
-      config_file = File.expand_path('~/.puppetlabs/bolt/analytics.yaml')
-      config = load_config(config_file)
-
-      if config['disabled'] || ENV['PDK_DISABLE_ANALYTICS']
+    def self.build_client(logger: ::Logger.new(STDERR), disabled:, uuid:)
+      if disabled
         logger.debug 'Analytics opt-out is set, analytics will be disabled'
         Client::Noop.new(logger)
       else
-        unless config.key?('user-id')
-          config['user-id'] = SecureRandom.uuid
-          write_config(config_file, config)
-        end
-
-        Client::GoogleAnalytics.new(logger, config['user-id'])
+        Client::GoogleAnalytics.new(logger, uuid)
       end
     rescue StandardError => e
       logger.debug "Failed to initialize analytics client, analytics will be disabled: #{e}"
       Client::Noop.new(logger)
-    end
-
-    # TODO: Extract config handling out of Analytics and pass in the parsed
-    # config instead
-    def self.load_config(filename)
-      # TODO: Catch errors from YAML and File
-      if File.exist?(filename)
-        YAML.safe_load(File.read(filename))
-      else
-        {}
-      end
-    end
-
-    def self.write_config(filename, config)
-      # TODO: Catch errors from FileUtils & File
-      FileUtils.mkdir_p(File.dirname(filename))
-      File.write(filename, config.to_yaml)
     end
   end
 end

--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -15,6 +15,7 @@ require 'pdk/util/puppet_version'
 
 module PDK::CLI
   def self.run(args)
+    PDK::Config.analytics_config_interview! unless PDK::Config.analytics_config_exist?
     @base_cmd.run(args)
   rescue PDK::CLI::ExitWithError => e
     PDK.logger.send(e.log_level, e.message)

--- a/lib/pdk/cli/util/interview.rb
+++ b/lib/pdk/cli/util/interview.rb
@@ -30,7 +30,13 @@ module PDK
             @prompt.print pastel.bold(_('[Q %{current_number}/%{questions_total}]') % { current_number: i, questions_total: num_questions }) + ' '
             @prompt.puts pastel.bold(question[:question])
             @prompt.puts question[:help] if question.key?(:help)
-            if question.key?(:choices)
+
+            case question[:type]
+            when :yes
+              yes?(_('-->')) do |q|
+                q.default(question[:default]) if question.key?(:default)
+              end
+            when :multi_select
               multi_select(_('-->'), per_page: question[:choices].count) do |q|
                 q.enum ')'
                 q.default(*question[:default]) if question.key?(:default)

--- a/lib/pdk/config.rb
+++ b/lib/pdk/config.rb
@@ -1,0 +1,48 @@
+require 'pdk/config/errors'
+require 'pdk/config/json'
+require 'pdk/config/namespace'
+require 'pdk/config/validator'
+require 'pdk/config/value'
+require 'pdk/config/yaml'
+
+module PDK
+  def self.config
+    @config ||= PDK::Config.new
+  end
+
+  class Config
+    def user
+      @user ||= PDK::Config::JSON.new('user', file: PDK::Config.user_config_path) do
+        mount :module_defaults, PDK::Config::JSON.new(file: PDK.answers.answer_file_path)
+
+        mount :analytics, PDK::Config::YAML.new(file: PDK::Config.analytics_config_path) do
+          value :disabled do
+            validate PDK::Config::Validator.boolean
+            default_to { PDK::Config.bolt_analytics_config.fetch('disabled', false) }
+          end
+
+          value :uuid do
+            validate PDK::Config::Validator.uuid
+            default_to do
+              require 'securerandom'
+
+              PDK::Config.bolt_analytics_config.fetch('uuid', SecureRandom.uuid)
+            end
+          end
+        end
+      end
+    end
+
+    def self.bolt_analytics_config
+      PDK::Config::YAML.new(file: File.expand_path('~/.puppetlabs/bolt/analytics.yaml'))
+    end
+
+    def self.analytics_config_path
+      File.join(File.dirname(PDK::Util.configdir), 'puppetlabs', 'analytics.yml')
+    end
+
+    def self.user_config_path
+      File.join(PDK::Util.configdir, 'user_config.json')
+    end
+  end
+end

--- a/lib/pdk/config.rb
+++ b/lib/pdk/config.rb
@@ -18,15 +18,15 @@ module PDK
         mount :analytics, PDK::Config::YAML.new(file: PDK::Config.analytics_config_path) do
           value :disabled do
             validate PDK::Config::Validator.boolean
-            default_to { PDK::Config.bolt_analytics_config.fetch('disabled', false) }
+            default_to { PDK::Config.bolt_analytics_config.fetch('disabled', true) }
           end
 
-          value :uuid do
+          value 'user-id' do
             validate PDK::Config::Validator.uuid
             default_to do
               require 'securerandom'
 
-              PDK::Config.bolt_analytics_config.fetch('uuid', SecureRandom.uuid)
+              PDK::Config.bolt_analytics_config.fetch('user-id', SecureRandom.uuid)
             end
           end
         end

--- a/lib/pdk/config/errors.rb
+++ b/lib/pdk/config/errors.rb
@@ -1,0 +1,5 @@
+module PDK
+  class Config
+    class LoadError < StandardError; end
+  end
+end

--- a/lib/pdk/config/json.rb
+++ b/lib/pdk/config/json.rb
@@ -1,0 +1,23 @@
+require 'pdk/config/namespace'
+
+module PDK
+  class Config
+    class JSON < Namespace
+      def parse_data(data, _filename)
+        return {} if data.nil? || data.empty?
+
+        require 'json'
+
+        ::JSON.parse(data)
+      rescue ::JSON::ParserError => e
+        raise PDK::Config::LoadError, e.message
+      end
+
+      def serialize_data(data)
+        require 'json'
+
+        ::JSON.pretty_generate(data)
+      end
+    end
+  end
+end

--- a/lib/pdk/config/namespace.rb
+++ b/lib/pdk/config/namespace.rb
@@ -1,0 +1,273 @@
+module PDK
+  class Config
+    class Namespace
+      # @param value [String] the new name of this namespace.
+      attr_writer :name
+
+      # @return [String] the path to the file associated with the contents of
+      #   this namespace.
+      attr_reader :file
+
+      # @return [self] the parent namespace of this namespace.
+      attr_accessor :parent
+
+      # Initialises the PDK::Config::Namespace object.
+      #
+      # @param name [String] the name of the namespace (defaults to nil).
+      # @param params [Hash{Symbol => Object}] keyword parameters for the
+      #   method.
+      # @option params [String] :file the path to the file associated with the
+      #   contents of the namespace (defaults to nil).
+      # @option params [self] :parent the parent {self} that this namespace is
+      #   a child of (defaults to nil).
+      # @param block [Proc] a block that is evaluated within the new instance.
+      def initialize(name = nil, file: nil, parent: nil, &block)
+        @file = File.expand_path(file) unless file.nil?
+        @values = {}
+        @name = name.to_s
+        @parent = parent
+
+        instance_eval(&block) if block_given?
+      end
+
+      # Pre-configure a value in the namespace.
+      #
+      # Allows you to specify validators and a default value for value in the
+      # namespace (see PDK::Config::Value#initialize).
+      #
+      # @param key [String,Symbol] the name of the value.
+      # @param block [Proc] a block that is evaluated within the new [self].
+      #
+      # @return [nil]
+      def value(key, &block)
+        @values[key.to_s] ||= PDK::Config::Value.new(key.to_s)
+        @values[key.to_s].instance_eval(&block) if block_given?
+      end
+
+      # Mount a provided [self] (or subclass) into the namespace.
+      #
+      # @param key [String,Symbol] the name of the namespace to be mounted.
+      # @param obj [self] the namespace to be mounted.
+      # @param block [Proc] a block to be evaluated within the instance of the
+      #   newly mounted namespace.
+      #
+      # @raise [ArgumentError] if the object to be mounted is not a {self} or
+      #   subclass thereof.
+      #
+      # @return [self] the mounted namespace.
+      def mount(key, obj, &block)
+        raise ArgumentError, _('Only PDK::Config::Namespace objects can be mounted into a namespace') unless obj.is_a?(PDK::Config::Namespace)
+        obj.parent = self
+        obj.name = key.to_s
+        obj.instance_eval(&block) if block_given?
+        data[key.to_s] = obj
+      end
+
+      # Create and mount a new child namespace.
+      #
+      # @param name [String,Symbol] the name of the new namespace.
+      # @param block [Proc]
+      def namespace(name, &block)
+        mount(name, PDK::Config::Namespace.new, &block)
+      end
+
+      # Get the value of the named key.
+      #
+      # If there is a value for that key, return it. If not, follow the logic
+      # described in {#default_config_value} to determine the default value to
+      # return.
+      #
+      # @note Unlike a Ruby Hash, this will not return `nil` in the event that
+      #   the key does not exist (see #fetch).
+      #
+      # @param key [String,Symbol] the name of the value to retrieve.
+      #
+      # @return [Object] the requested value.
+      def [](key)
+        data[key.to_s]
+      end
+
+      # Get the value of the named key or the provided default value if not
+      # present.
+      #
+      # This differs from {#[]} in an important way in that it allows you to
+      # return a default value, which is not possible using `[] || default` as
+      # non-existent values when accessed normally via {#[]} will be defaulted
+      # to a new Hash.
+      #
+      # @param key [String,Symbol] the name of the value to fetch.
+      # @param default_value [Object] the value to return if the namespace does
+      #   not contain the requested value.
+      #
+      # @return [Object] the requested value.
+      def fetch(key, default_value)
+        data.fetch(key.to_s, default_value)
+      end
+
+      # Set the value of the named key.
+      #
+      # If the key has been pre-configured with {#value}, then the value of the
+      # key will be validated against any validators that have been configured.
+      #
+      # After the value has been set in memory, the value will then be
+      # persisted to disk.
+      #
+      # @param key [String,Symbol] the name of the configuration value.
+      # @param value [Object] the value of the configuration value.
+      #
+      # @return [nil]
+      def []=(key, value)
+        @values[key.to_s].validate!([name, key.to_s].join('.'), value) if @values.key?(key.to_s)
+
+        data[key.to_s] = value
+        save_data
+      end
+
+      # Convert the namespace into a Hash of values, suitable for serialising
+      # and persisting to disk.
+      #
+      # Child namespaces that are associated with their own files are excluded
+      # from the Hash (as their values will be persisted to their own files)
+      # and nil values are removed from the Hash.
+      #
+      # @return [Hash{String => Object}] the values from the namespace that
+      #   should be persisted to disk.
+      def to_h
+        data.inject({}) do |new_hash, (key, value)|
+          new_hash[key] = if value.is_a?(PDK::Config::Namespace)
+                            value.include_in_parent? ? value.to_h : nil
+                          else
+                            value
+                          end
+          new_hash.delete_if { |_, v| v.nil? }
+        end
+      end
+
+      # @return [Boolean] true if the namespace has a parent, otherwise false.
+      def child_namespace?
+        !parent.nil?
+      end
+
+      # Determines the fully qualified name of the namespace.
+      #
+      # If this is a child namespace, then fully qualified name for the
+      # namespace will be "<parent>.<child>".
+      #
+      # @return [String] the fully qualifed name of the namespace.
+      def name
+        child_namespace? ? [parent.name, @name].join('.') : @name
+      end
+
+      # Determines if the contents of the namespace should be included in the
+      # parent namespace when persisting to disk.
+      #
+      # If the namespace has been mounted into a parent namespace and is not
+      # associated with its own file on disk, then the values in the namespace
+      # should be included in the parent namespace when persisting to disk.
+      #
+      # @return [Boolean] true if the values should be included in the parent
+      #   namespace.
+      def include_in_parent?
+        child_namespace? && file.nil?
+      end
+
+      private
+
+      # @abstract Subclass and override {#parse_data} to implement parsing logic
+      #   for a particular config file format.
+      #
+      # @param data [String] The content of the file to be parsed.
+      # @param filename [String] The path to the file to be parsed.
+      #
+      # @return [Hash{String => Object}] the data to be loaded into the
+      #   namespace.
+      def parse_data(_data, _filename)
+        {}
+      end
+
+      # Read the file associated with the namespace.
+      #
+      # @raise [PDK::Config::LoadError] if the file is removed during read.
+      # @raise [PDK::Config::LoadError] if the user doesn't have the
+      #   permissions needed to read the file.
+      # @return [String,nil] the contents of the file or nil if the file does
+      #   not exist.
+      def load_data
+        return if file.nil?
+        return unless PDK::Util::Filesystem.file?(file)
+
+        PDK::Util::Filesystem.read_file(file)
+      rescue Errno::ENOENT => e
+        raise PDK::Config::LoadError, e.message
+      rescue Errno::EACCES
+        raise PDK::Config::LoadError, _('Unable to open %{file} for reading') % {
+          file: file,
+        }
+      end
+
+      # @abstract Subclass and override {#save_data} to implement generating
+      #   logic for a particular config file format.
+      #
+      # @param data [Hash{String => Object}] the data stored in the namespace
+      #
+      # @return [String] the serialized contents of the namespace suitable for
+      #   writing to disk.
+      def serialize_data(_data); end
+
+      # Persist the contents of the namespace to disk.
+      #
+      # Directories will be automatically created and the contents of the
+      # namespace will be serialized automatically with {#serialize_data}.
+      #
+      # @raise [PDK::Config::LoadError] if one of the intermediary path components
+      #   exist but is not a directory.
+      # @raise [PDK::Config::LoadError] if the user does not have the
+      #   permissions needed to write the file.
+      #
+      # @return [nil]
+      def save_data
+        return if file.nil?
+
+        FileUtils.mkdir_p(File.dirname(file))
+
+        PDK::Util::Filesystem.write_file(file, serialize_data(to_h))
+      rescue Errno::EACCES
+        raise PDK::Config::LoadError, _('Unable to open %{file} for writing') % {
+          file: file,
+        }
+      rescue SystemCallError => e
+        raise PDK::Config::LoadError, e.message
+      end
+
+      # Memoised accessor for the loaded data.
+      #
+      # @return [Hash<String => Object>] the contents of the namespace.
+      def data
+        @data ||= parse_data(load_data, file).tap do |h|
+          h.default_proc = default_config_value
+        end
+      end
+
+      # The default behaviour of the namespace when the requested value does
+      # not exist.
+      #
+      # If the value has been pre-configured with {#value} to have a default
+      # value, resolve the default value and set it in the namespace
+      # (triggering a call to {#save_data}. Otherwise, set the value to a new
+      # Hash to allow for arbitrary level of nested values.
+      #
+      # @return [Proc] suitable for use by {Hash#default_proc}.
+      def default_config_value
+        ->(hash, key) do
+          if @values.key?(key) && @values[key].default?
+            self[key] = @values[key].default
+          else
+            hash[key] = {}.tap do |h|
+              h.default_proc = default_config_value
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pdk/config/validator.rb
+++ b/lib/pdk/config/validator.rb
@@ -1,0 +1,31 @@
+module PDK
+  class Config
+    # A collection of predefined validators for use with {PDK::Config::Value}.
+    #
+    # @example
+    #   value :enabled do
+    #     validate PDK::Config::Validator.boolean
+    #   end
+    module Validator
+      # @return [Hash{Symbol => [Proc,String]}] a {PDK::Config::Value}
+      #   validator that ensures that the value is either a TrueClass or
+      #   FalseClass.
+      def self.boolean
+        {
+          proc:    ->(value) { [true, false].include?(value) },
+          message: _('must be a boolean true or false'),
+        }
+      end
+
+      # @return [Hash{Symbol => [Proc,String]}] a {PDK::Config::Value}
+      #   validator that ensures that the value is a String that matches the
+      #   regex for a version 4 UUID.
+      def self.uuid
+        {
+          proc:    ->(value) { value.match(%r{\A\h{8}(?:-\h{4}){3}-\h{12}\z}) },
+          message: _('must be a version 4 UUID'),
+        }
+      end
+    end
+  end
+end

--- a/lib/pdk/config/value.rb
+++ b/lib/pdk/config/value.rb
@@ -1,0 +1,94 @@
+module PDK
+  class Config
+    # A class for describing the value of a {PDK::Config} setting.
+    #
+    # Generally, this is never instantiated manually, but is instead
+    # instantiated by passing a block to {PDK::Config::Namespace#value}.
+    #
+    # @example
+    #
+    # PDK::Config::Namespace.new('analytics') do
+    #   value :disabled do
+    #     validate PDK::Config::Validator.boolean
+    #     default_to { false }
+    #   end
+    # end
+    class Value
+      # Initialises an empty value definition.
+      #
+      # @param name [String,Symbol] the name of the value.
+      def initialize(name)
+        @name = name
+        @validators = []
+      end
+
+      # Assign a validator to the value.
+      #
+      # @param validator [Hash{Symbol => [Proc,String]}]
+      # @option validator [Proc] :proc a lambda that takes the value to be
+      #   validated as the argument and returns `true` if the value is valid.
+      # @option validator [String] :message a description of what the validator
+      #   is testing for, that is displayed to the user as part of the error
+      #   message for invalid values.
+      #
+      # @raise [ArgumentError] if not passed a Hash.
+      # @raise [ArgumentError] if the Hash doesn't have a `:proc` key that
+      #   contains a Proc.
+      # @raise [ArgumentError] if the Hash doesn't have a `:message` key that
+      #   contains a String.
+      #
+      # @return [nil]
+      def validate(validator)
+        raise ArgumentError, _('validator must be a Hash') unless validator.is_a?(Hash)
+        raise ArgumentError, _('the :proc key must contain a Proc') unless validator.key?(:proc) && validator[:proc].is_a?(Proc)
+        raise ArgumentError, _('the :message key must contain a String') unless validator.key?(:message) && validator[:message].is_a?(String)
+
+        @validators << validator
+      end
+
+      # Validate a value against the assigned validators.
+      #
+      # @param key [String] the name of the value being validated.
+      # @param value [Object] the value being validated.
+      #
+      # @raise [ArgumentError] if any of the assigned validators fail to
+      #   validate the value.
+      #
+      # @return [nil]
+      def validate!(key, value)
+        @validators.each do |validator|
+          next if validator[:proc].call(value)
+
+          raise ArgumentError, _('%{key} %{message}') % {
+            key:     key,
+            message: validator[:message],
+          }
+        end
+      end
+
+      # Assign a default value.
+      #
+      # @param block [Proc] a block that is lazy evaluated when necessary in
+      #   order to determine the default value.
+      #
+      # @return [nil]
+      def default_to(&block)
+        raise ArgumentError, _('must be passed a block') unless block_given?
+        @default_to = block
+      end
+
+      # Evaluate the default value block.
+      #
+      # @return [Object,nil] the result of evaluating the block given to
+      #   {#default_to}, or `nil` if the value has no default.
+      def default
+        default? ? @default_to.call : nil
+      end
+
+      # @return [Boolean] true if the value has a default value block.
+      def default?
+        !@default_to.nil?
+      end
+    end
+  end
+end

--- a/lib/pdk/config/yaml.rb
+++ b/lib/pdk/config/yaml.rb
@@ -1,0 +1,31 @@
+require 'pdk/config/namespace'
+
+module PDK
+  class Config
+    class YAML < Namespace
+      def parse_data(data, filename)
+        return {} if data.nil? || data.empty?
+
+        require 'yaml'
+
+        ::YAML.safe_load(data, [Symbol], [], true)
+      rescue Psych::SyntaxError => e
+        raise PDK::Config::LoadError, _('Syntax error when loading %{file}: %{error}') % {
+          file:  filename,
+          error: "#{e.problem} #{e.context}",
+        }
+      rescue Psych::DisallowedClass => e
+        raise PDK::Config::LoadError, _('Unsupported class in %{file}: %{error}') % {
+          file:  filename,
+          error: e.message,
+        }
+      end
+
+      def serialize_data(data)
+        require 'yaml'
+
+        ::YAML.dump(data)
+      end
+    end
+  end
+end

--- a/lib/pdk/generate/module.rb
+++ b/lib/pdk/generate/module.rb
@@ -199,6 +199,7 @@ module PDK
             question: _('What operating systems does this module support?'),
             help:     _('Use the up and down keys to move between the choices, space to select and enter to continue.'),
             required: true,
+            type:     :multi_select,
             choices:  PDK::Module::Metadata::OPERATING_SYSTEMS,
             default:  PDK::Module::Metadata::DEFAULT_OPERATING_SYSTEMS.map do |os_name|
               # tty-prompt uses a 1-index

--- a/lib/pdk/logger.rb
+++ b/lib/pdk/logger.rb
@@ -6,12 +6,24 @@ module PDK
   end
 
   class Logger < ::Logger
+    WRAP_COLUMN_LIMIT = 78
+
     def initialize
       super(STDERR)
 
       # TODO: Decide on output format.
       self.formatter = proc do |severity, _datetime, _progname, msg|
-        "pdk (#{severity}): #{msg}\n"
+        prefix = "pdk (#{severity}): "
+        if msg.is_a?(Hash)
+          if msg.fetch(:wrap, false)
+            wrap_pattern = %r{(.{1,#{WRAP_COLUMN_LIMIT - prefix.length}})(\s+|\Z)}
+            "#{prefix}#{msg[:text].gsub(wrap_pattern, "\\1\n#{' ' * prefix.length}")}\n"
+          else
+            "#{prefix}#{msg[:text]}\n"
+          end
+        else
+          "#{prefix}#{msg}\n"
+        end
       end
 
       self.level = ::Logger::INFO

--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -106,6 +106,14 @@ module PDK
     end
     module_function :cachedir
 
+    def configdir
+      if Gem.win_platform?
+        File.join(ENV['LOCALAPPDATA'], 'PDK')
+      else
+        File.join(ENV.fetch('XDG_CONFIG_HOME', File.join(Dir.home, '.config')), 'pdk')
+      end
+    end
+
     # Returns path to the root of the module being worked on.
     #
     # @return [String, nil] Fully qualified base path to module, or nil if

--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -113,6 +113,7 @@ module PDK
         File.join(ENV.fetch('XDG_CONFIG_HOME', File.join(Dir.home, '.config')), 'pdk')
       end
     end
+    module_function :configdir
 
     # Returns path to the root of the module being worked on.
     #

--- a/lib/pdk/util/filesystem.rb
+++ b/lib/pdk/util/filesystem.rb
@@ -14,6 +14,14 @@ module PDK
       end
       module_function :write_file
 
+      def read_file(file, nil_on_error: false)
+        File.read(file)
+      rescue => e
+        raise e unless nil_on_error
+        nil
+      end
+      module_function :read_file
+
       #:nocov:
       # These methods just wrap core Ruby functionality and
       # can be ignored for code coverage

--- a/spec/unit/pdk/analytics_spec.rb
+++ b/spec/unit/pdk/analytics_spec.rb
@@ -1,26 +1,22 @@
 require 'spec_helper'
+require 'securerandom'
 
 describe PDK::Analytics do
   let(:default_config) { {} }
   let(:logger) { instance_double(Logger, debug: true) }
+  let(:uuid) { SecureRandom.uuid }
 
   before(:each) do
     # We use a hard override to disable analytics for tests, but that obviously
     # interferes with these tests...
     ENV.delete('PDK_DISABLE_ANALYTICS')
-
-    # Ensure these tests will never read or write a local config
-    allow(described_class).to receive(:load_config).and_return(default_config)
-    allow(described_class).to receive(:write_config)
   end
 
   describe '.build_client' do
-    subject { described_class.build_client(logger: logger) }
+    subject { described_class.build_client(logger: logger, uuid: uuid, disabled: disabled) }
 
     context 'when analytics is disabled' do
-      before(:each) do
-        default_config.replace('disabled' => true)
-      end
+      let(:disabled) { true }
 
       it 'returns an instance of the Noop client' do
         is_expected.to be_an_instance_of(described_class::Client::Noop)
@@ -28,6 +24,8 @@ describe PDK::Analytics do
     end
 
     context 'when analytics are enabled' do
+      let(:disabled) { false }
+
       it 'returns an instance of the GoogleAnalytics client' do
         is_expected.to be_an_instance_of(described_class::Client::GoogleAnalytics)
       end
@@ -42,22 +40,5 @@ describe PDK::Analytics do
         end
       end
     end
-  end
-
-  # TODO: refactor these tests
-  it 'uses the uuid in the config if it exists' do
-    uuid = SecureRandom.uuid
-    default_config.replace('user-id' => uuid)
-
-    expect(described_class.build_client(logger: logger).user_id).to eq(uuid)
-  end
-
-  it "assigns the user a uuid if one doesn't exist" do
-    uuid = SecureRandom.uuid
-    allow(SecureRandom).to receive(:uuid).and_return(uuid)
-
-    expect(described_class).to receive(:write_config).with(kind_of(String), include('user-id' => uuid))
-
-    expect(described_class.build_client(logger: logger).user_id).to eq(uuid)
   end
 end

--- a/spec/unit/pdk/config/json_spec.rb
+++ b/spec/unit/pdk/config/json_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'tempfile'
+
+describe PDK::Config::JSON do
+  subject(:json_config) { described_class.new(file: tempfile) }
+
+  let(:tempfile) do
+    file = Tempfile.new('test')
+    file.write(data)
+    file.close
+    file.path
+  end
+  let(:data) { '{}' }
+
+  describe '#parse_data' do
+    subject(:parse_data) { json_config.parse_data(data, tempfile) }
+
+    context 'when the file does not exist or is unreadable' do
+      let(:data) { nil }
+
+      it 'returns an empty hash' do
+        expect(parse_data).to eq({})
+      end
+    end
+
+    context 'when the file contains a valid JSON object' do
+      let(:data) { '{ "foo": "bar" }' }
+
+      it 'returns the parsed JSON as a Hash' do
+        expect(parse_data).to eq('foo' => 'bar')
+      end
+    end
+  end
+
+  describe '#serialize_data' do
+    subject(:serialized_data) { json_config.serialize_data(json_config.to_h) }
+
+    context 'when there is no data stored' do
+      it 'writes an empty JSON object to disk' do
+        expect(serialized_data).to eq("{\n}")
+      end
+    end
+
+    context 'when there is data stored' do
+      it 'writes the JSON object to disk' do
+        json_config['foo'] = 'bar'
+        expect(serialized_data).to eq("{\n  \"foo\": \"bar\"\n}")
+      end
+    end
+  end
+end

--- a/spec/unit/pdk/config/namespace_spec.rb
+++ b/spec/unit/pdk/config/namespace_spec.rb
@@ -1,0 +1,213 @@
+require 'spec_helper'
+
+describe PDK::Config::Namespace do
+  subject(:config) { described_class.new('config') }
+
+  shared_context :with_a_nested_namespace do |name|
+    before(:each) do
+      config.namespace(name)
+    end
+  end
+
+  shared_context :with_a_mounted_file do |name|
+    before(:each) do
+      path = File.expand_path(File.join('path', 'to', name))
+      allow(PDK::Util::Filesystem).to receive(:read_file).with(path, anything)
+      allow(PDK::Util::Filesystem).to receive(:write_file).with(path, anything)
+
+      config.mount(name, PDK::Config::JSON.new(file: path))
+    end
+  end
+
+  describe '#load_data' do
+    context 'when creating a namespace from a file' do
+      subject(:new_namespace) { described_class.new('new_namespace', file: path) }
+
+      let(:path) { File.expand_path(File.join('path', 'to', 'my', 'config', 'file')) }
+
+      before(:each) do
+        allow(PDK::Util::Filesystem).to receive(:file?).with(path).and_return(true)
+      end
+
+      context 'when the file is deleted mid-read' do
+        before(:each) do
+          allow(PDK::Util::Filesystem).to receive(:read_file).with(path).and_raise(Errno::ENOENT, 'error')
+        end
+
+        it 'raises PDK::Config::LoadError' do
+          expect { new_namespace[:test] }.to raise_error(PDK::Config::LoadError, %r{error})
+        end
+      end
+
+      context 'when the file is unreadable' do
+        before(:each) do
+          allow(PDK::Util::Filesystem).to receive(:read_file).with(path).and_raise(Errno::EACCES)
+        end
+
+        it 'raises PDK::Config::LoadError' do
+          expect {
+            new_namespace[:test]
+          }.to raise_error(PDK::Config::LoadError, "Unable to open #{path} for reading")
+        end
+      end
+    end
+  end
+
+  describe '#[]' do
+    before(:each) do
+      config[:foo] = 'bar'
+    end
+
+    it 'can access values with either Symbol or String keys' do
+      expect([config[:foo], config['foo']]).to all(eq('bar'))
+    end
+
+    it 'can access arbitrarily deep values' do
+      expect(config[:bar][:baz]).to eq({})
+    end
+  end
+
+  describe '#namespace' do
+    before(:each) do
+      config.namespace('test')
+    end
+
+    it 'mounts a new Namespace at the specified name' do
+      expect(config['test']).to be_a(described_class)
+    end
+
+    it 'sets the name of the new Namespace' do
+      expect(config['test'].name).to eq('config.test')
+    end
+
+    it 'sets the parent of the new Namespace' do
+      expect(config['test'].parent).to eq(config)
+    end
+
+    it 'does not set a file for the new Namespace' do
+      expect(config['test'].file).to be_nil
+    end
+  end
+
+  describe '#mount' do
+    let(:new_namespace) { described_class.new }
+
+    before(:each) do
+      config.mount('test_mount', new_namespace)
+    end
+
+    it 'mounts the provided namespace at the specified name' do
+      expect(config['test_mount']).to eq(new_namespace)
+    end
+
+    it 'sets the name of the provided namespace' do
+      expect(config['test_mount'].name).to eq('config.test_mount')
+    end
+
+    it 'sets the parent of the provided namespace' do
+      expect(config['test_mount'].parent).to eq(config)
+    end
+  end
+
+  describe '#value' do
+    before(:each) do
+      config.value('my_value') { default_to { 'foo' } }
+    end
+
+    it 'configures the rules for a new value in a namespace' do
+      expect(config['my_value']).to eq('foo')
+    end
+  end
+
+  describe '#name' do
+    include_context :with_a_nested_namespace, 'nested'
+    include_context :with_a_mounted_file, 'mounted'
+
+    context 'on a root namespace' do
+      it 'returns the name of the namespace' do
+        expect(config.name).to eq('config')
+      end
+    end
+
+    context 'on a nested namespace' do
+      it 'returns the names of the parent and child namespaces as a dotted heirarchy' do
+        expect(config['nested'].name).to eq('config.nested')
+      end
+    end
+
+    context 'on a mounted file' do
+      it 'returns the names of the parent and mounted file as a dotted heirarchy' do
+        expect(config['mounted'].name).to eq('config.mounted')
+      end
+    end
+  end
+
+  describe '#to_h' do
+    include_context :with_a_nested_namespace, 'nested'
+    include_context :with_a_mounted_file, 'mounted'
+
+    before(:each) do
+      config['in_root'] = true
+      config['nested']['value'] = 'is saved too'
+      config['mounted']['value'] = 'is saved to a different file'
+    end
+
+    it 'includes the contents of namespaces' do
+      expect(config.to_h).to include('nested' => { 'value' => 'is saved too' })
+    end
+
+    it 'includes values in its own namespace' do
+      expect(config.to_h).to include('in_root' => true)
+    end
+
+    it 'does not include the values in mounted files' do
+      expect(config.to_h).not_to have_key('mounted')
+    end
+  end
+
+  describe '#child_namespace?' do
+    include_context :with_a_nested_namespace, 'nested'
+    include_context :with_a_mounted_file, 'mounted'
+
+    context 'on a root namespace' do
+      it 'returns false' do
+        expect(config.child_namespace?).to be_falsey
+      end
+    end
+
+    context 'on a nested namespace' do
+      it 'returns true' do
+        expect(config['nested'].child_namespace?).to be_truthy
+      end
+    end
+
+    context 'on a mounted file' do
+      it 'returns true' do
+        expect(config['mounted'].child_namespace?).to be_truthy
+      end
+    end
+  end
+
+  describe '#include_in_parent?' do
+    include_context :with_a_nested_namespace, 'nested'
+    include_context :with_a_mounted_file, 'mounted'
+
+    context 'on a root namespace' do
+      it 'returns false' do
+        expect(config.include_in_parent?).to be_falsey
+      end
+    end
+
+    context 'on a nested namespace' do
+      it 'returns true' do
+        expect(config['nested'].include_in_parent?).to be_truthy
+      end
+    end
+
+    context 'on a mounted file' do
+      it 'returns true' do
+        expect(config['mounted'].include_in_parent?).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/unit/pdk/config/value_spec.rb
+++ b/spec/unit/pdk/config/value_spec.rb
@@ -1,0 +1,152 @@
+require 'spec_helper'
+
+describe PDK::Config::Value do
+  subject(:config_value) { described_class.new(name) }
+
+  let(:name) { 'my_config_value' }
+
+  describe '#validate' do
+    subject(:validate) { config_value.validate(validator) }
+
+    context 'when passed an object that is not a Hash' do
+      let(:validator) { ->(_) { true } }
+
+      it 'raises an error' do
+        expect { validate }.to raise_error(ArgumentError, 'validator must be a Hash')
+      end
+    end
+
+    context 'when passed a Hash without a :proc key' do
+      let(:validator) { { message: 'test message' } }
+
+      it 'raises an error' do
+        expect { validate }.to raise_error(ArgumentError, 'the :proc key must contain a Proc')
+      end
+    end
+
+    context 'when passed a Hash with a :proc key that does not contain a Proc' do
+      let(:validator) { { proc: true, message: 'test message' } }
+
+      it 'raises an error' do
+        expect { validate }.to raise_error(ArgumentError, 'the :proc key must contain a Proc')
+      end
+    end
+
+    context 'when passed a Hash without a :message key' do
+      let(:validator) { { proc: ->(_) { true } } }
+
+      it 'raises an error' do
+        expect { validate }.to raise_error(ArgumentError, 'the :message key must contain a String')
+      end
+    end
+
+    context 'when passed a Hash with a :message key that does not contain a string' do
+      let(:validator) { { proc: ->(_) { true }, message: true } }
+
+      it 'raises an error' do
+        expect { validate }.to raise_error(ArgumentError, 'the :message key must contain a String')
+      end
+    end
+
+    context 'when passed a valid validator Hash' do
+      let(:validator) { { proc: ->(_) { true }, message: 'passing validator' } }
+
+      it 'does not raise an error' do
+        expect { validate }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#validate!' do
+    subject(:validate!) { config_value.validate!(key, value) }
+
+    let(:key) { 'user.foo.bar' }
+    let(:value) { 'a value' }
+
+    context 'when there are no validators' do
+      it 'does not raise an error' do
+        expect { validate! }.not_to raise_error
+      end
+    end
+
+    context 'when there is a passing validator' do
+      before(:each) do
+        config_value.validate(proc: ->(_) { true }, message: 'always passes')
+      end
+
+      it 'does not raise an error' do
+        expect { validate! }.not_to raise_error
+      end
+    end
+
+    context 'when there is a failing validator' do
+      before(:each) do
+        config_value.validate(proc: ->(_) { false }, message: 'always fails')
+      end
+
+      it 'raises an error' do
+        expect { validate! }.to raise_error(ArgumentError, "#{key} always fails")
+      end
+    end
+
+    context 'when there are multiple validators' do
+      before(:each) do
+        config_value.validate(proc: ->(_) { true }, message: 'always passes')
+        config_value.validate(proc: ->(_) { false }, message: 'always fails 1')
+        config_value.validate(proc: ->(_) { false }, message: 'always fails 2')
+      end
+
+      it 'raises an error for the first failing validator' do
+        expect { validate! }.to raise_error(ArgumentError, "#{key} always fails 1")
+      end
+    end
+  end
+
+  describe '#default_to' do
+    context 'when passed a block' do
+      it 'does not raise an error' do
+        expect { config_value.default_to { 'a value' } }.not_to raise_error
+      end
+    end
+
+    context 'when not passed a block' do
+      it 'raises an error' do
+        expect { config_value.default_to }.to raise_error(ArgumentError, 'must be passed a block')
+      end
+    end
+  end
+
+  describe '#default?' do
+    subject(:default?) { config_value.default? }
+
+    context 'when there is no default value Proc for the value' do
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when there is a default value Proc for the value' do
+      before(:each) do
+        config_value.default_to { 'a default value' }
+      end
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe '#default' do
+    subject(:default) { config_value.default }
+
+    context 'when there is no default value Proc for the value' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'when there is a default value Proc for the value' do
+      before(:each) do
+        config_value.default_to { 'a value' }
+      end
+
+      it 'returns the return value of the Proc' do
+        expect(default).to eq('a value')
+      end
+    end
+  end
+end

--- a/spec/unit/pdk/config/yaml_spec.rb
+++ b/spec/unit/pdk/config/yaml_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe PDK::Config::YAML do
+  subject(:yaml_config) { described_class.new(file: tempfile) }
+
+  let(:tempfile) do
+    file = Tempfile.new('test')
+    file.write(data)
+    file.close
+    file.path
+  end
+  let(:data) { nil }
+
+  describe '#parse_data' do
+    subject(:parse_data) { yaml_config.parse_data(data, tempfile) }
+
+    context 'when the file does not exist or is unreadable' do
+      let(:data) { nil }
+
+      it 'returns an empty hash' do
+        expect(parse_data).to eq({})
+      end
+    end
+
+    context 'when the file contains a valid YAML object' do
+      let(:data) { "---\nfoo: bar\n" }
+
+      it 'returns the parsed YAML as a Hash' do
+        expect(parse_data).to eq('foo' => 'bar')
+      end
+    end
+
+    context 'when the file contains invalid YAML' do
+      let(:data) { "---\n\tfoo: bar" }
+
+      it 'raises PDK::Config::LoadError' do
+        expect { parse_data }.to raise_error(PDK::Config::LoadError, %r{syntax error}i)
+      end
+    end
+
+    context 'when the file contains valid YAML with invalid data classes' do
+      let(:data) { "--- !ruby/object:File {}\n" }
+
+      it 'raises PDK::Config::LoadError' do
+        expect { parse_data }.to raise_error(PDK::Config::LoadError, %r{unsupported class}i)
+      end
+    end
+  end
+
+  describe '#serialize_data' do
+    subject(:serialized_data) { yaml_config.serialize_data(yaml_config.to_h) }
+
+    context 'when there is no data stored' do
+      it 'writes an empty YAML hash to disk' do
+        expect(serialized_data).to eq("--- {}\n")
+      end
+    end
+
+    context 'when there is data stored' do
+      it 'writes the YAML document to disk' do
+        yaml_config['foo'] = 'bar'
+        expect(serialized_data).to eq("---\nfoo: bar\n")
+      end
+    end
+  end
+end

--- a/spec/unit/pdk/config_spec.rb
+++ b/spec/unit/pdk/config_spec.rb
@@ -71,17 +71,65 @@ describe PDK::Config do
       context 'when there is no pre-existing bolt configuration' do
         it 'generates a new UUID' do
           expect(SecureRandom).to receive(:uuid).and_call_original
-          config.user['analytics']['uuid']
+          config.user['analytics']['user-id']
         end
       end
 
       context 'when there is a pre-existing bolt configuration' do
         let(:uuid) { SecureRandom.uuid }
-        let(:bolt_analytics_content) { "---\nuuid: #{uuid}\n" }
+        let(:bolt_analytics_content) { "---\nuser-id: #{uuid}\n" }
 
         it 'returns the value from the bolt configuration' do
-          expect(config.user['analytics']['uuid']).to eq(uuid)
+          expect(config.user['analytics']['user-id']).to eq(uuid)
         end
+      end
+    end
+  end
+
+  describe '.analytics_config_interview!' do
+    before(:each) do
+      prompt = TTY::TestPrompt.new
+      allow(TTY::Prompt).to receive(:new).and_return(prompt)
+      prompt.input << responses.join("\r") + "\r"
+      prompt.input.rewind
+
+      allow(PDK).to receive(:config).and_return(
+        instance_double(described_class, user: described_class::Namespace.new('user')),
+      )
+      allow(PDK::CLI::Util).to receive(:interactive?).and_return(true)
+
+      described_class.analytics_config_interview!
+    end
+
+    context 'when the user responds yes' do
+      let(:responses) { ['yes'] }
+
+      it 'sets user.analytics.disabled to false' do
+        expect(PDK.config.user['analytics']['disabled']).to be_falsey
+      end
+    end
+
+    context 'when the user responds no' do
+      let(:responses) { ['no'] }
+
+      it 'sets user.analytics.disabled to true' do
+        expect(PDK.config.user['analytics']['disabled']).to be_truthy
+      end
+    end
+
+    context 'when the user just hits enter' do
+      let(:responses) { [''] }
+
+      it 'sets user.analytics.disabled to false' do
+        expect(PDK.config.user['analytics']['disabled']).to be_falsey
+      end
+    end
+
+    context 'when the user cancels the interview' do
+      let(:responses) { ["\003"] } # \003 == Ctrl-C
+
+      it 'sets user.analytics.disabled to true' do
+        expect(PDK.config.user['analytics']['disabled']).to be_truthy
       end
     end
   end

--- a/spec/unit/pdk/config_spec.rb
+++ b/spec/unit/pdk/config_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+require 'securerandom'
+
+describe PDK::Config do
+  subject(:config) { described_class.new }
+
+  let(:answer_file_content) { '{}' }
+  let(:user_config_content) { '{}' }
+  let(:bolt_analytics_content) { '' }
+  let(:analytics_config_content) { '' }
+
+  def mock_file(path, content)
+    allow(PDK::Util::Filesystem).to receive(:write_file).with(File.expand_path(path), anything)
+    allow(PDK::Util::Filesystem).to receive(:read_file).with(File.expand_path(path), anything).and_return(content)
+  end
+
+  before(:each) do
+    allow(PDK::Util).to receive(:configdir).and_return(File.join('path', 'to', 'configdir'))
+    mock_file(PDK.answers.answer_file_path, answer_file_content)
+    mock_file(described_class.analytics_config_path, analytics_config_content)
+    mock_file(described_class.user_config_path, user_config_content)
+    mock_file('~/.puppetlabs/bolt/analytics.yaml', bolt_analytics_content)
+  end
+
+  describe 'user.analytics.disabled' do
+    context 'set' do
+      it 'can be set to true' do
+        expect { config.user['analytics']['disabled'] = true }.not_to raise_error
+      end
+
+      it 'can be set to false' do
+        expect { config.user['analytics']['disabled'] = false }.not_to raise_error
+      end
+
+      it 'can not be set to a string' do
+        expect { config.user['analytics']['disabled'] = 'no' }.to raise_error(%r{must be a boolean})
+      end
+    end
+
+    context 'default value' do
+      context 'when there is no pre-existing bolt configuration' do
+        it 'returns false' do
+          expect(config.user['analytics']['disabled']).to be_falsey
+        end
+      end
+
+      context 'when there is a pre-existing bolt configuration' do
+        let(:bolt_analytics_content) { "---\ndisabled: true\n" }
+
+        it 'returns the value from the bolt configuration' do
+          expect(config.user['analytics']['disabled']).to be_truthy
+        end
+      end
+    end
+  end
+
+  describe 'user.analytics.uuid' do
+    context 'set' do
+      it 'can be set to a string that looks like a V4 UUID' do
+        expect { config.user['analytics']['uuid'] = SecureRandom.uuid }.not_to raise_error
+      end
+
+      it 'can not be set to other values' do
+        expect { config.user['analytics']['uuid'] = 'totally a UUID' }.to raise_error(%r{must be a version 4 UUID})
+      end
+    end
+
+    context 'default value' do
+      context 'when there is no pre-existing bolt configuration' do
+        it 'generates a new UUID' do
+          expect(SecureRandom).to receive(:uuid).and_call_original
+          config.user['analytics']['uuid']
+        end
+      end
+
+      context 'when there is a pre-existing bolt configuration' do
+        let(:uuid) { SecureRandom.uuid }
+        let(:bolt_analytics_content) { "---\nuuid: #{uuid}\n" }
+
+        it 'returns the value from the bolt configuration' do
+          expect(config.user['analytics']['uuid']).to eq(uuid)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/pdk/util/filesystem_spec.rb
+++ b/spec/unit/pdk/util/filesystem_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe PDK::Util::Filesystem do
+  describe '.read_file' do
+    subject(:read_file) { described_class.read_file(path, nil_on_error: nil_on_error) }
+
+    let(:path) { File.join('path', 'to', 'my', 'file') }
+    let(:nil_on_error) { false }
+
+    context 'when given a path to a readable file' do
+      before(:each) do
+        allow(File).to receive(:read).with(path).and_return('some content')
+      end
+
+      it 'does not raise an error' do
+        expect { read_file }.not_to raise_error
+      end
+
+      it 'returns the file content' do
+        expect(read_file).to eq('some content')
+      end
+    end
+
+    context 'when given a path to an unreadable file' do
+      before(:each) do
+        allow(File).to receive(:read).with(path).and_raise(Errno::EACCES, 'some error')
+      end
+
+      context 'when nil_on_error => false' do
+        it 'raises the underlying error' do
+          expect { read_file }.to raise_error(Errno::EACCES, %r{some error})
+        end
+      end
+
+      context 'when nil_on_error => true' do
+        let(:nil_on_error) { true }
+
+        it 'does not raise an error' do
+          expect { read_file }.not_to raise_error
+        end
+
+        it 'returns nil' do
+          expect(read_file).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -274,6 +274,31 @@ describe PDK::Util do
     end
   end
 
+  describe '.configdir' do
+    subject { described_class.configdir }
+
+    context 'when running on Windows' do
+      before(:each) do
+        allow(Gem).to receive(:win_platform?).and_return(true)
+        allow(ENV).to receive(:[]).with('LOCALAPPDATA').and_return('C:/Users/test')
+      end
+
+      it 'returns a path in the %LOCALAPPDATA% folder' do
+        is_expected.to eq(File.join('C:/Users/test', 'PDK'))
+      end
+    end
+
+    context 'when running on a POSIX host' do
+      before(:each) do
+        allow(Gem).to receive(:win_platform?).and_return(false)
+        allow(Dir).to receive(:home).and_return('/home/test')
+      end
+
+      it 'returns a path inside the users .config directory' do
+        is_expected.to eq(File.join('/home/test', '.config', 'pdk'))
+      end
+    end
+  end
   describe '.module_root' do
     subject { described_class.module_root }
 

--- a/spec/unit/pdk_spec.rb
+++ b/spec/unit/pdk_spec.rb
@@ -6,4 +6,14 @@ describe PDK do
 
     it { is_expected.to be_an_instance_of(PDK::Logger) }
   end
+
+  describe '.config' do
+    subject(:config) { described_class.config }
+
+    it { is_expected.to be_an_instance_of(PDK::Config) }
+
+    it 'is memoised' do
+      expect(logger).to eq(described_class.logger)
+    end
+  end
 end


### PR DESCRIPTION
On the first run of PDK if the vendor-wide analytics config file is absent (`$XDG_CONFIG_HOME/puppetlabs/analytics.yml` or `%LOCALAPPDATA%/puppetlabs/analytics.yml`) the user will be greeted with the following question.

```
pdk (INFO): PDK collects anonymous usage information to help us understand how it is being used and make decisions on how to improve it. You can find out more about what data we collect and how it is used in the PDK documentation at https://puppet.com/docs/pdk/.
[Q 1/1] Do you consent to the collection of anonymous PDK usage information?
--> Yes

pdk (INFO): You can opt in or out of the usage data collection at any time by editing the analytics configuration file at /home/tsharpe/.config/puppetlabs/analytics.yml and changing the 'disabled' value.
```

If PDK is not being run interactively (i.e. being called from a script) then the interview will be skipped and the user will be automatically opted out of analytics.