### PR TITLE
(MAINT) Add "needs-triage" default labels to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,3 @@
+---
+labels: needs-triage
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve the PDK
+labels: bug, needs-triage
 
 ---
 


### PR DESCRIPTION
Not sure how to test this before merge? I guess I could merge it into master on my fork?