### PR TITLE
(PDK-1342) Submit PDK analytics events

### DIFF
--- a/lib/pdk.rb
+++ b/lib/pdk.rb
@@ -12,13 +12,14 @@ require 'pdk/version'
 module PDK
   def self.analytics
     @analytics ||= PDK::Analytics.build_client(
-      logger:     PDK.logger,
-      disabled:   ENV['PDK_DISABLE_ANALYTICS'] || PDK.config.user['analytics']['disabled'],
-      user_id:    PDK.config.user['analytics']['user-id'],
-      app_id:     "UA-139917834-#{PDK::Util.development_mode? ? '2' : '1'}",
-      client:     :google_analytics,
-      app_name:   'pdk',
-      app_version: PDK::VERSION,
+      logger:        PDK.logger,
+      disabled:      ENV['PDK_DISABLE_ANALYTICS'] || PDK.config.user['analytics']['disabled'],
+      user_id:       PDK.config.user['analytics']['user-id'],
+      app_id:        "UA-139917834-#{PDK::Util.development_mode? ? '2' : '1'}",
+      client:        :google_analytics,
+      app_name:      'pdk',
+      app_version:   PDK::VERSION,
+      app_installer: PDK::Util.package_install? ? 'package' : 'gem',
     )
   end
 end

--- a/lib/pdk/analytics/client/google_analytics.rb
+++ b/lib/pdk/analytics/client/google_analytics.rb
@@ -7,6 +7,9 @@ module PDK
         CUSTOM_DIMENSIONS = {
           operating_system: :cd1,
           output_format:    :cd2,
+          ruby_version:     :cd3,
+          cli_options:      :cd4,
+          env_vars:         :cd5,
         }.freeze
 
         attr_reader :user_id
@@ -14,6 +17,7 @@ module PDK
         attr_reader :app_name
         attr_reader :app_id
         attr_reader :app_version
+        attr_reader :app_installer
 
         def initialize(opts)
           # lazy-load expensive gem code
@@ -30,6 +34,7 @@ module PDK
           @app_name = opts[:app_name]
           @app_id = opts[:app_id]
           @app_version = opts[:app_version]
+          @app_installer = opts[:app_installer]
         end
 
         def screen_view(screen, **kwargs)
@@ -83,21 +88,23 @@ module PDK
         # https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
         def base_params
           {
-            v:   PROTOCOL_VERSION,
+            v:    PROTOCOL_VERSION,
             # Client ID
-            cid: user_id,
+            cid:  user_id,
             # Tracking ID
-            tid: app_id,
+            tid:  app_id,
             # Application Name
-            an:  app_name,
+            an:   app_name,
             # Application Version
-            av:  app_version,
+            av:   app_version,
+            # Application Installer ID
+            aiid: app_installer,
             # Anonymize IPs
-            aip: true,
+            aip:  true,
             # User locale
-            ul:  Locale.current.to_rfc,
+            ul:   Locale.current.to_rfc,
             # Custom Dimension 1 (Operating System)
-            cd1: @os.value,
+            cd1:  @os.value,
           }
         end
 

--- a/lib/pdk/cli/build.rb
+++ b/lib/pdk/cli/build.rb
@@ -21,6 +21,8 @@ module PDK::CLI
         log_level: :info,
       )
 
+      PDK::CLI::Util.analytics_screen_view('build', opts)
+
       module_metadata = PDK::Module::Metadata.from_file('metadata.json')
 
       # TODO: Ensure forge metadata has been set, or call out to interview

--- a/lib/pdk/cli/bundle.rb
+++ b/lib/pdk/cli/bundle.rb
@@ -19,6 +19,8 @@ EOF
 
       PDK::CLI::Util.validate_puppet_version_opts({})
 
+      PDK::CLI::Util.analytics_screen_view('bundle')
+
       # Ensure that the correct Ruby is activated before running commend.
       puppet_env = PDK::CLI::Util.puppet_from_opts_or_env({})
       PDK::Util::RubyVersion.use(puppet_env[:ruby_version])

--- a/lib/pdk/cli/convert.rb
+++ b/lib/pdk/cli/convert.rb
@@ -28,6 +28,8 @@ module PDK::CLI
         raise PDK::CLI::ExitWithError, _('You can not specify --noop and --force when converting a module')
       end
 
+      PDK::CLI::Util.analytics_screen_view('convert', opts)
+
       if opts[:'skip-interview'] && opts[:'full-interview']
         PDK.logger.info _('Ignoring --full-interview and continuing with --skip-interview.')
         opts[:'full-interview'] = false

--- a/lib/pdk/cli/new/class.rb
+++ b/lib/pdk/cli/new/class.rb
@@ -24,6 +24,8 @@ module PDK::CLI
         raise PDK::CLI::ExitWithError, _("'%{name}' is not a valid class name") % { name: class_name }
       end
 
+      PDK::CLI::Util.analytics_screen_view('new_class', opts)
+
       PDK::Generate::PuppetClass.new(module_dir, class_name, opts).run
     end
   end

--- a/lib/pdk/cli/new/defined_type.rb
+++ b/lib/pdk/cli/new/defined_type.rb
@@ -22,6 +22,8 @@ module PDK::CLI
         raise PDK::CLI::ExitWithError, _("'%{name}' is not a valid defined type name") % { name: defined_type_name }
       end
 
+      PDK::CLI::Util.analytics_screen_view('new_defined_type', opts)
+
       PDK::Generate::DefinedType.new(module_dir, defined_type_name, opts).run
     end
   end

--- a/lib/pdk/cli/new/module.rb
+++ b/lib/pdk/cli/new/module.rb
@@ -21,6 +21,8 @@ module PDK::CLI
 
       PDK::CLI::Util.validate_template_opts(opts)
 
+      PDK::CLI::Util.analytics_screen_view('new_module', opts)
+
       if opts[:'skip-interview'] && opts[:'full-interview']
         PDK.logger.info _('Ignoring --full-interview and continuing with --skip-interview.')
         opts[:'full-interview'] = false
@@ -36,8 +38,6 @@ module PDK::CLI
         end
         opts[:target_dir] = target_dir.nil? ? opts[:module_name] : target_dir
       end
-
-      PDK.analytics.screen_view('new_module')
 
       PDK.logger.info(_('Creating new module: %{modname}') % { modname: module_name })
       PDK::Generate::Module.invoke(opts)

--- a/lib/pdk/cli/new/provider.rb
+++ b/lib/pdk/cli/new/provider.rb
@@ -19,6 +19,8 @@ module PDK::CLI
         raise PDK::CLI::ExitWithError, _("'%{name}' is not a valid provider name") % { name: provider_name }
       end
 
+      PDK::CLI::Util.analytics_screen_view('new_provider', opts)
+
       PDK::Generate::Provider.new(module_dir, provider_name, opts).run
     end
   end

--- a/lib/pdk/cli/new/task.rb
+++ b/lib/pdk/cli/new/task.rb
@@ -24,6 +24,8 @@ module PDK::CLI
         raise PDK::CLI::ExitWithError, _("'%{name}' is not a valid task name") % { name: task_name }
       end
 
+      PDK::CLI::Util.analytics_screen_view('new_task', opts)
+
       PDK::Generate::Task.new(module_dir, task_name, opts).run
     end
   end

--- a/lib/pdk/cli/test/unit.rb
+++ b/lib/pdk/cli/test/unit.rb
@@ -33,6 +33,8 @@ module PDK::CLI
 
       PDK::CLI::Util.module_version_check
 
+      PDK::CLI::Util.analytics_screen_view('test_unit', opts)
+
       # Ensure that the bundled gems are up to date and correct Ruby is activated before running or listing tests.
       puppet_env = PDK::CLI::Util.puppet_from_opts_or_env(opts)
       PDK::Util::PuppetVersion.fetch_puppet_dev if opts[:'puppet-dev']

--- a/lib/pdk/cli/update.rb
+++ b/lib/pdk/cli/update.rb
@@ -26,6 +26,8 @@ module PDK::CLI
         raise PDK::CLI::ExitWithError, _('You can not specify --noop and --force when updating a module')
       end
 
+      PDK::CLI::Util.analytics_screen_view('update', opts)
+
       updater = PDK::Module::Update.new(opts)
 
       updater.run

--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -31,6 +31,7 @@ module PDK::CLI
       targets = []
 
       if opts[:list]
+        PDK::CLI::Util.analytics_screen_view('validate', opts)
         PDK.logger.info(_('Available validators: %{validator_names}') % { validator_names: validator_names.join(', ') })
         exit 0
       end
@@ -69,6 +70,12 @@ module PDK::CLI
         end
       else
         PDK.logger.info(_('Running all available validators...'))
+      end
+
+      if validators == PDK::Validate.validators
+        PDK::CLI::Util.analytics_screen_view('validate', opts)
+      else
+        PDK::CLI::Util.analytics_screen_view(['validate', validators.map(&:name).sort].flatten.join('_'), opts)
       end
 
       # Subsequent arguments are targets.

--- a/lib/pdk/generate/module.rb
+++ b/lib/pdk/generate/module.rb
@@ -124,7 +124,7 @@ module PDK
         defaults['name'] = "#{opts[:username]}-#{opts[:module_name]}" unless opts[:module_name].nil?
         defaults['author'] = PDK.answers['author'] unless PDK.answers['author'].nil?
         defaults['license'] = PDK.answers['license'] unless PDK.answers['license'].nil?
-        defaults['license'] = opts[:license] if opts.key? :license
+        defaults['license'] = opts[:license] if opts.key?(:license)
 
         metadata = PDK::Module::Metadata.new(defaults)
         module_interview(metadata, opts) unless opts[:'skip-interview']

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -70,7 +70,7 @@ RSpec.configure do |c|
     puts "Working in #{tempdir}"
 
     analytics_config = Tempfile.new('analytics.yml')
-    analytics_config.write(YAML.dump(disabled: true))
+    analytics_config.write(YAML.dump('disabled' => true))
     analytics_config.close
     ENV['PDK_ANALYTICS_CONFIG'] = analytics_config.path
   end

--- a/spec/unit/pdk/analytics/client/google_analytics_spec.rb
+++ b/spec/unit/pdk/analytics/client/google_analytics_spec.rb
@@ -24,6 +24,7 @@ describe PDK::Analytics::Client::GoogleAnalytics do
       av:  options[:app_version],
       cid: options[:user_id],
       tid: options[:app_id],
+      aiid: options[:app_installer],
       ul:  Locale.current.to_rfc,
       aip: true,
       cd1: os_name,

--- a/spec/unit/pdk/cli/new/class_spec.rb
+++ b/spec/unit/pdk/cli/new/class_spec.rb
@@ -11,6 +11,12 @@ describe 'PDK::CLI new class' do
 
       expect { PDK::CLI.run(%w[new class test_class]) }.to exit_nonzero
     end
+
+    it 'does not submit the command to analytics' do
+      expect(analytics).not_to receive(:screen_view)
+
+      expect { PDK::CLI.run(%w[new class test_class]) }.to exit_nonzero
+    end
   end
 
   context 'when run from inside a module' do
@@ -22,10 +28,22 @@ describe 'PDK::CLI new class' do
       it 'exits non-zero and prints the `pdk new class` help' do
         expect { PDK::CLI.run(%w[new class]) }.to exit_nonzero.and output(help_text).to_stdout
       end
+
+      it 'does not submit the command to analytics' do
+        expect(analytics).not_to receive(:screen_view)
+
+        expect { PDK::CLI.run(%w[new class]) }.to exit_nonzero.and output(help_text).to_stdout
+      end
     end
 
     context 'and provided an empty string as the class name' do
       it 'exits non-zero and prints the `pdk new class` help' do
+        expect { PDK::CLI.run(['new', 'class', '']) }.to exit_nonzero.and output(help_text).to_stdout
+      end
+
+      it 'does not submit the command to analytics' do
+        expect(analytics).not_to receive(:screen_view)
+
         expect { PDK::CLI.run(['new', 'class', '']) }.to exit_nonzero.and output(help_text).to_stdout
       end
     end
@@ -36,16 +54,34 @@ describe 'PDK::CLI new class' do
 
         expect { PDK::CLI.run(%w[new class test-class]) }.to exit_nonzero
       end
+
+      it 'does not submit the command to analytics' do
+        expect(analytics).not_to receive(:screen_view)
+
+        expect { PDK::CLI.run(%w[new class test-class]) }.to exit_nonzero
+      end
     end
 
     context 'and provided a valid class name' do
-      let(:generator) { instance_double('PDK::Generate::PuppetClass') }
+      let(:generator) { instance_double('PDK::Generate::PuppetClass', run: true) }
+
+      after(:each) do
+        PDK::CLI.run(%w[new class test_class])
+      end
 
       it 'generates the class' do
         expect(PDK::Generate::PuppetClass).to receive(:new).with(anything, 'test_class', instance_of(Hash)).and_return(generator)
         expect(generator).to receive(:run)
+      end
 
-        PDK::CLI.run(%w[new class test_class])
+      it 'submits the command to analytics' do
+        allow(PDK::Generate::PuppetClass).to receive(:new).and_return(generator)
+
+        expect(analytics).to receive(:screen_view).with(
+          'new_class',
+          output_format: 'default',
+          ruby_version:  RUBY_VERSION,
+        )
       end
     end
   end

--- a/spec/unit/pdk/cli/new/defined_type_spec.rb
+++ b/spec/unit/pdk/cli/new/defined_type_spec.rb
@@ -11,11 +11,23 @@ describe 'PDK::CLI new defined_type' do
     it 'exits non-zero and prints the `pdk new defined_type` help' do
       expect { PDK::CLI.run(args) }.to exit_nonzero.and output(help_text).to_stdout
     end
+
+    it 'does not submit the command to analytics' do
+      expect(analytics).not_to receive(:screen_view)
+
+      expect { PDK::CLI.run(args) }.to exit_nonzero.and output(help_text).to_stdout
+    end
   end
 
   shared_examples 'it exits with an error' do |expected_error|
     it 'exits with an error' do
       expect(logger).to receive(:error).with(a_string_matching(expected_error))
+
+      expect { PDK::CLI.run(args) }.to exit_nonzero
+    end
+
+    it 'does not submit the command to analytics' do
+      expect(analytics).not_to receive(:screen_view)
 
       expect { PDK::CLI.run(args) }.to exit_nonzero
     end
@@ -52,17 +64,27 @@ describe 'PDK::CLI new defined_type' do
 
     context 'and provided a valid defined type name' do
       let(:generator) { PDK::Generate::DefinedType }
-      let(:generator_double) { instance_double(generator) }
+      let(:generator_double) { instance_double(generator, run: true) }
       let(:generator_opts) { instance_of(Hash) }
 
       before(:each) do
         allow(generator).to receive(:new).with(anything, 'test_define', generator_opts).and_return(generator_double)
       end
 
+      after(:each) do
+        PDK::CLI.run(%w[new defined_type test_define])
+      end
+
       it 'generates the defined type' do
         expect(generator_double).to receive(:run)
+      end
 
-        PDK::CLI.run(%w[new defined_type test_define])
+      it 'submits the command to analytics' do
+        expect(analytics).to receive(:screen_view).with(
+          'new_defined_type',
+          output_format: 'default',
+          ruby_version:  RUBY_VERSION,
+        )
       end
     end
   end

--- a/spec/unit/pdk/cli/new/module_spec.rb
+++ b/spec/unit/pdk/cli/new/module_spec.rb
@@ -9,11 +9,37 @@ describe 'Running `pdk new module`' do
       expect(logger).to receive(:info).with(%r{Creating new module:})
       PDK::CLI.run(%w[new module])
     end
+
+    it 'submits the command to analytics' do
+      allow(PDK::Generate::Module).to receive(:invoke)
+
+      expect(analytics).to receive(:screen_view).with(
+        'new_module',
+        output_format: 'default',
+        ruby_version: RUBY_VERSION,
+      )
+
+      PDK::CLI.run(%w[new module])
+    end
   end
 
   context 'when passed an invalid module name' do
     it 'informs the user that the module name is invalid' do
       expect(logger).to receive(:error).with(a_string_matching(%r{'123test'.*not.*valid module name}m))
+
+      expect { PDK::CLI.run(%w[new module 123test]) }.to exit_nonzero
+    end
+
+    # Unlike most other commands, the validation of parameters does not happen
+    # at the CLI layer as they can be later modified during the interview.
+    # FIXME - extract validation logic so module name can be validated here if
+    # specified
+    it 'submits the command to analytics' do
+      expect(analytics).to receive(:screen_view).with(
+        'new_module',
+        output_format: 'default',
+        ruby_version:  RUBY_VERSION,
+      )
 
       expect { PDK::CLI.run(%w[new module 123test]) }.to exit_nonzero
     end
@@ -28,12 +54,36 @@ describe 'Running `pdk new module`' do
       PDK::CLI.run(['new', 'module', module_name])
     end
 
+    it 'submits the command to analytics' do
+      allow(PDK::Generate::Module).to receive(:invoke)
+
+      expect(analytics).to receive(:screen_view).with(
+        'new_module',
+        output_format: 'default',
+        ruby_version:  RUBY_VERSION,
+      )
+
+      PDK::CLI.run(['new', 'module', module_name])
+    end
+
     context 'and a target directory' do
       let(:target_dir) { 'target' }
 
       it 'passes the target directory to PDK::Generate::Module.invoke' do
         expect(PDK::Generate::Module).to receive(:invoke).with(hash_including(module_name: module_name, target_dir: target_dir))
         expect(logger).to receive(:info).with("Creating new module: #{module_name}")
+        PDK::CLI.run(['new', 'module', module_name, target_dir])
+      end
+
+      it 'submits the command to analytics' do
+        allow(PDK::Generate::Module).to receive(:invoke)
+
+        expect(analytics).to receive(:screen_view).with(
+          'new_module',
+          output_format: 'default',
+          ruby_version:  RUBY_VERSION,
+        )
+
         PDK::CLI.run(['new', 'module', module_name, target_dir])
       end
     end
@@ -46,6 +96,19 @@ describe 'Running `pdk new module`' do
         expect(logger).to receive(:info).with("Creating new module: #{module_name}")
         PDK::CLI.run(['new', 'module', '--template-url', template_url, module_name])
       end
+
+      it 'submits the command to analytics' do
+        allow(PDK::Generate::Module).to receive(:invoke)
+
+        expect(analytics).to receive(:screen_view).with(
+          'new_module',
+          cli_options:   'template-url=redacted',
+          output_format: 'default',
+          ruby_version:  RUBY_VERSION,
+        )
+
+        PDK::CLI.run(['new', 'module', '--template-url', template_url, module_name])
+      end
     end
 
     context 'and the template-ref without the template-url option' do
@@ -53,6 +116,12 @@ describe 'Running `pdk new module`' do
 
       it 'does not invoke PDK::Generate::Module' do
         expect(PDK::Generate::Module).not_to receive(:invoke)
+        expect { PDK::CLI.run(['new', 'module', '--template-ref', template_ref, module_name]) }.to exit_nonzero
+      end
+
+      it 'does not submit a command to analytics' do
+        expect(analytics).not_to receive(:screen_view)
+
         expect { PDK::CLI.run(['new', 'module', '--template-ref', template_ref, module_name]) }.to exit_nonzero
       end
     end
@@ -65,12 +134,38 @@ describe 'Running `pdk new module`' do
         expect(logger).to receive(:info).with("Creating new module: #{module_name}")
         PDK::CLI.run(['new', 'module', '--license', license, module_name])
       end
+
+      it 'submits the command to analytics' do
+        allow(PDK::Generate::Module).to receive(:invoke)
+
+        expect(analytics).to receive(:screen_view).with(
+          'new_module',
+          cli_options:   'license=redacted',
+          output_format: 'default',
+          ruby_version:  RUBY_VERSION,
+        )
+
+        PDK::CLI.run(['new', 'module', '--license', license, module_name])
+      end
     end
 
     context 'and the skip-interview flag' do
       it 'passes true as the value of the skip-interview option to PDK::Generate::Module.invoke' do
         expect(PDK::Generate::Module).to receive(:invoke).with(hash_including(:'skip-interview' => true))
         expect(logger).to receive(:info).with("Creating new module: #{module_name}")
+        PDK::CLI.run(['new', 'module', '--skip-interview', module_name])
+      end
+
+      it 'submits the command to analytics' do
+        allow(PDK::Generate::Module).to receive(:invoke)
+
+        expect(analytics).to receive(:screen_view).with(
+          'new_module',
+          cli_options:   'skip-interview=true',
+          output_format: 'default',
+          ruby_version:  RUBY_VERSION,
+        )
+
         PDK::CLI.run(['new', 'module', '--skip-interview', module_name])
       end
     end
@@ -81,12 +176,38 @@ describe 'Running `pdk new module`' do
         expect(logger).to receive(:info).with("Creating new module: #{module_name}")
         PDK::CLI.run(['new', 'module', '--full-interview', module_name])
       end
+
+      it 'submits the command to analytics' do
+        allow(PDK::Generate::Module).to receive(:invoke)
+
+        expect(analytics).to receive(:screen_view).with(
+          'new_module',
+          cli_options:   'full-interview=true',
+          output_format: 'default',
+          ruby_version:  RUBY_VERSION,
+        )
+
+        PDK::CLI.run(['new', 'module', '--full-interview', module_name])
+      end
     end
 
     context 'and the --skip-interview and --full-interview flags have been passed' do
       it 'ignores full-interview and continues with a log message' do
         expect(logger).to receive(:info).with(a_string_matching(%r{Ignoring --full-interview and continuing with --skip-interview.}i))
         expect(PDK::Generate::Module).to receive(:invoke).with(hash_including(:'skip-interview' => true, :'full-interview' => false))
+
+        PDK::CLI.run(['new', 'module', '--skip-interview', '--full-interview'])
+      end
+
+      it 'submits the command to analytics' do
+        allow(PDK::Generate::Module).to receive(:invoke)
+
+        expect(analytics).to receive(:screen_view).with(
+          'new_module',
+          cli_options:   'skip-interview=true,full-interview=true',
+          output_format: 'default',
+          ruby_version:  RUBY_VERSION,
+        )
 
         PDK::CLI.run(['new', 'module', '--skip-interview', '--full-interview'])
       end
@@ -99,6 +220,18 @@ describe 'Running `pdk new module`' do
     it 'validates and parses the module name' do
       expect(PDK::Generate::Module).to receive(:invoke).with(hash_including(module_name: 'test123', username: 'user'))
       expect(logger).to receive(:info).with("Creating new module: #{module_name}")
+      PDK::CLI.run(['new', 'module', module_name])
+    end
+
+    it 'submits the command to analytics' do
+      allow(PDK::Generate::Module).to receive(:invoke)
+
+      expect(analytics).to receive(:screen_view).with(
+        'new_module',
+        output_format: 'default',
+        ruby_version:  RUBY_VERSION,
+      )
+
       PDK::CLI.run(['new', 'module', module_name])
     end
   end

--- a/spec/unit/pdk/cli_spec.rb
+++ b/spec/unit/pdk/cli_spec.rb
@@ -46,4 +46,16 @@ describe PDK::CLI do
       described_class.run([])
     end
   end
+
+  context 'when provided an invalid subcommand' do
+    it 'submits an event to analytics' do
+      expect(analytics).to receive(:event).with(
+        'CLI', 'invalid command', label: 'test acceptance --an-opt redacted redacted'
+      )
+
+      expect {
+        described_class.run(['test', 'acceptance', '--an-opt', 'opt-value', 'some_arg'])
+      }.to exit_nonzero.and output.to_stderr
+    end
+  end
 end


### PR DESCRIPTION
OK, I think this implements analytics submission for all the items that we're interested in according to our spec.

Common values that are submitted for every analytics event:
 * A random non-identifying user ID (shared with Bolt analytics if installed and enabled)
 * PDK version
 * PDK installation method (`package` or `gem`)
 * Operating system

We submit a "screen view" for every successful CLI command invocation that records:
 * The command name
 * The version of Ruby used to execute the PDK command
 * The anonymised command options and arguments
  * All arguments are redacted
  * All non-boolean option values are redacted (except `--puppet-version` and `--pe-version`)
 * The output formats for the command
 * `PDK_*` environment variables and their values (if set)

Invalid commands are submitted as a distinct analytics events with the arguments and option values redacted.

Whenever a template repo is used, we submit an event recording if the template is `default` or `custom` (n.b. we do not record the path to the template repo itself). Additionally, if the template repo being used is the default one, we submit events for each file rendered, recording if the file is `unmanaged`, `deleted`, `customized` or `default` (n.b. in the event of a `customized` file, we do not record what was changed, only that it was changed via `.sync.yml` overrides).

Given the concerns of GDPR compliance you note that we're very carefully and strictly testing the analytics calls to ensure that no unexpected data is accidentally passed in.