### PR TITLE
Be less strict when using #hash_including with defaults

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,3 +95,35 @@ RSpec.shared_context :validators do
     ]
   end
 end
+
+# Similar to RSpec’s built-in #hash_including, but does not require the keys of
+# `expected` to be present in `actual` -- what matters is that for all keys in
+# `expected`, the value in `actual` and `expected` is the same.
+#
+#     hash = Hash.new { |hash, key| 9000 }
+#     moo(hash)
+#
+# This passes:
+#
+#     expect(something)
+#       .to receive(:moo)
+#       .with(hash_with_defaults_including(stuff: 9000))
+#
+# This does not pass:
+#
+#     expect(something)
+#       .to receive(:moo)
+#       .with(hash_including(stuff: 9000))
+RSpec::Matchers.define :hash_with_defaults_including do |expected|
+  include RSpec::Matchers::Composable
+
+  match do |actual|
+    expected.keys.all? do |key|
+      values_match?(expected[key], actual[key])
+    end
+  end
+
+  description do
+    "hash_with_defaults_including(#{expected.inspect})"
+  end
+end

--- a/spec/unit/pdk/cli/build_spec.rb
+++ b/spec/unit/pdk/cli/build_spec.rb
@@ -97,7 +97,7 @@ describe 'PDK::CLI build' do
       include_context 'exits cleanly'
 
       it 'invokes the builder with the default target directory' do
-        expect(PDK::Module::Build).to receive(:new).with(hash_including(:'target-dir' => File.join(Dir.pwd, 'pkg'))).and_return(mock_builder)
+        expect(PDK::Module::Build).to receive(:new).with(hash_with_defaults_including(:'target-dir' => File.join(Dir.pwd, 'pkg'))).and_return(mock_builder)
       end
     end
 

--- a/spec/unit/pdk/cli/test/unit_spec.rb
+++ b/spec/unit/pdk/cli/test/unit_spec.rb
@@ -101,7 +101,7 @@ describe '`pdk test unit`' do
 
       context 'when passed --clean-fixtures' do
         it 'invokes the command with :clean-fixtures => true' do
-          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, hash_including(:puppet => puppet_version, :tests => anything, :'clean-fixtures' => true)).once.and_return(0)
+          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, hash_with_defaults_including(:puppet => puppet_version, :tests => anything, :'clean-fixtures' => true)).once.and_return(0)
           expect {
             test_unit_cmd.run_this(['--clean-fixtures'])
           }.to exit_zero
@@ -110,7 +110,7 @@ describe '`pdk test unit`' do
 
       context 'when not passed --clean-fixtures' do
         it 'invokes the command without :clean-fixtures' do
-          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, hash_including(puppet: puppet_version, tests: anything)).once.and_return(0)
+          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, hash_with_defaults_including(puppet: puppet_version, tests: anything)).once.and_return(0)
           expect {
             test_unit_cmd.run_this([])
           }.to exit_zero
@@ -119,7 +119,7 @@ describe '`pdk test unit`' do
 
       context 'when tests pass' do
         before(:each) do
-          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, hash_including(:tests)).once.and_return(0)
+          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, hash_with_defaults_including(tests: anything)).once.and_return(0)
         end
 
         it do
@@ -151,7 +151,7 @@ describe '`pdk test unit`' do
 
       context 'when tests fail' do
         before(:each) do
-          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, hash_including(:tests)).once.and_return(1)
+          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, hash_with_defaults_including(tests: anything)).once.and_return(1)
         end
 
         it do


### PR DESCRIPTION
This PR introduces #hash_with_defaults_including, which is similar to RSpec’s built-in #hash_including, but does not require the keys of `expected` to be present in `actual` -- what matters is that for all keys in `expected`, the value in `actual` and `expected` is the same.

```ruby
hash = Hash.new { |hash, key| 9000 }
moo(hash)
```

This passes:

```
expect(something)
  .to receive(:moo)
  .with(hash_with_defaults_including(stuff: 9000))
```

This does not pass:

```ruby
expect(something)
  .to receive(:moo)
  .with(hash_including(stuff: 9000))
```

This is in preparation of landing ddfreyne/cri#99, which makes use of these `Hash` defaults to specify default values for options.