### PR TITLE
(maint) Pin cri to <= 2.15.6

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'bundler', '>= 1.15.0', '< 3.0.0'
   spec.add_runtime_dependency 'childprocess', '~> 0.7.1'
-  spec.add_runtime_dependency 'cri', ' >= 2.10.1', '< 2.16.0'
+  spec.add_runtime_dependency 'cri', ' >= 2.10.1', '<= 2.15.6'
   spec.add_runtime_dependency 'diff-lcs', '1.3'
   spec.add_runtime_dependency 'ffi', '~> 1.9.0'
   spec.add_runtime_dependency 'gettext-setup', '~> 0.24'


### PR DESCRIPTION
cri 2.15.7 changed the behaviour of the options hash so that unspecified
flags are defaulted to an explicit `false` rather than being unset. From
the look of https://github.com/ddfreyne/cri/issues/94 though this
behaviour may be changing in the next release so lets pin cri to
a maximum of 2.15.6 for now until the behaviour stabilises and then we
can make the necessary changes.

/cc #674