### PR TITLE
(PDK-1365) Use dynamic ruby detection for default ruby instance

### DIFF
--- a/lib/pdk/util/ruby_version.rb
+++ b/lib/pdk/util/ruby_version.rb
@@ -48,12 +48,19 @@ module PDK
         end
 
         def default_ruby_version
-          # For now, the packaged versions will be using default of 2.4.5
-          # FIXME: make this dynamic
-          return '2.4.5' if PDK::Util.package_install?
-
-          # TODO: may not be a safe assumption that highest available version should be default
-          latest_ruby_version
+          @default_ruby_version ||= if PDK::Util.package_install?
+                                      # Default to the ruby that supports the latest puppet gem. If you wish to default to a
+                                      # specific Puppet Gem version use the following example;
+                                      #
+                                      # PDK::Util::PuppetVersion.find_gem_for('5.5.10')[:ruby_version]
+                                      #
+                                      PDK::Util::PuppetVersion.latest_available[:ruby_version]
+                                    else
+                                      # TODO: may not be a safe assumption that highest available version should be default
+                                      # WARNING Do NOT use PDK::Util::PuppetVersion.*** methods as it can recurse into this
+                                      # method and cause Stack Level Too Deep errors.
+                                      latest_ruby_version
+                                    end
         end
 
         def latest_ruby_version

--- a/spec/support/packaged_install.rb
+++ b/spec/support/packaged_install.rb
@@ -7,6 +7,7 @@ RSpec.shared_context 'packaged install' do
     allow(File).to receive(:exist?).with(%r{bundle(\.bat)?$}).and_return(true)
     allow(PDK::Util).to receive(:package_cachedir).and_return(package_cachedir)
     allow(PDK::Util::RubyVersion).to receive(:versions).and_return('2.4.4' => '2.4.0')
+    allow(PDK::Util::RubyVersion).to receive(:default_ruby_version).and_return('2.4.4')
   end
 end
 


### PR DESCRIPTION
Previously the default version of ruby selected in packaged PDK instances was
hardcoded to 2.4.5 which caused issues when updating ruby runtimes and did not
reflect that the default should really by ruby 2.5 and Puppet 6.  This commit
modifies the default ruby detection to instead use the ruby environment for the
latest Puppet Gem in the PDK package install.  Non-pkged installs are not
affected.

This commit also memoizes the default value to slightly speed up default ruby
selection.