### PR TITLE
[PDK-421] Validate EPP syntax (WIP)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -7,6 +7,7 @@ RSpec/FilePath:
   Exclude:
     - 'spec/unit/pdk/validate/metadata/metadata_json_lint_spec.rb'
     - 'spec/unit/pdk/validate/metadata/metadata_syntax_spec.rb'
+    - 'spec/unit/pdk/validate/puppet/puppet_epp_spec.rb'
     - 'spec/unit/pdk/validate/puppet/puppet_lint_spec.rb'
     - 'spec/unit/pdk/validate/puppet/puppet_syntax_spec.rb'
     - 'spec/unit/pdk/validate/ruby/rubocop_spec.rb'

--- a/lib/pdk/validate/puppet/puppet_epp.rb
+++ b/lib/pdk/validate/puppet/puppet_epp.rb
@@ -36,7 +36,7 @@ module PDK
       end
 
       def self.pattern
-        '**/**.epp'
+        '**/*.epp'
       end
 
       def self.pattern_ignore

--- a/lib/pdk/validate/puppet/puppet_epp.rb
+++ b/lib/pdk/validate/puppet/puppet_epp.rb
@@ -1,0 +1,137 @@
+require 'pdk'
+require 'pdk/cli/exec'
+require 'pdk/validate/base_validator'
+require 'fileutils'
+require 'tmpdir'
+
+module PDK
+  module Validate
+    class PuppetEPP < BaseValidator
+      # In Puppet >= 5.3.4, the error context formatting was changed to facilitate localization
+      ERROR_CONTEXT = %r{(?:file:\s(?<file>.+?)|line:\s(?<line>.+?)|column:\s(?<column>.+?))}
+      # In Puppet < 5.3.3, the error context was formatted in these variations:
+      #   - "at file_path:line_num:col_num"
+      #   - "at file_path:line_num"
+      #   - "at line line_num"
+      #   - "in file_path"
+      ERROR_CONTEXT_LEGACY = %r{(?:at\sline\s(?<line>\d+)|at\s(?<file>.+?):(?<line>\d+):(?<column>\d+)|at\s(?<file>.+?):(?<line>\d+)|in\s(?<file>.+?))}
+
+      PUPPET_LOGGER_PREFIX = %r{^(debug|info|notice|warning|error|alert|critical):\s.+?$}i
+      PUPPET_SYNTAX_PATTERN = %r{^
+        (?<severity>.+?):\s
+        (?<message>.+?)
+        (?:
+          \s\(#{ERROR_CONTEXT}(,\s#{ERROR_CONTEXT})*\)| # attempt to match the new localisation friendly location
+          \s#{ERROR_CONTEXT_LEGACY}| # attempt to match the old " at file:line:column" location
+          $                                               # handle cases where the output has no location
+        )
+      $}x
+
+      def self.name
+        'puppet-epp'
+      end
+
+      def self.cmd
+        'puppet'
+      end
+
+      def self.pattern
+        '**/**.epp'
+      end
+
+      def self.pattern_ignore
+        ''
+      end
+
+      def self.spinner_text(_targets = nil)
+        _('Checking Puppet EPP syntax (%{pattern}).') % { pattern: pattern }
+      end
+
+      def self.parse_options(_options, targets)
+        # Due to PDK-1266 we need to run `puppet parser validate` with an empty
+        # modulepath. On *nix, Ruby treats `/dev/null` as an empty directory
+        # however it doesn't do so with `NUL` on Windows. The workaround for
+        # this to ensure consistent behaviour is to create an empty temporary
+        # directory and use that as the modulepath.
+        ['epp', 'validate', '--config', null_file, '--modulepath', validate_tmpdir].concat(targets)
+      end
+
+      def self.invoke(report, options)
+        super
+      ensure
+        remove_validate_tmpdir
+      end
+
+      def self.validate_tmpdir
+        @validate_tmpdir ||= Dir.mktmpdir('puppet-epp-validate')
+      end
+
+      def self.remove_validate_tmpdir
+        return unless @validate_tmpdir
+        return unless File.directory?(@validate_tmpdir)
+
+        FileUtils.remove_entry_secure(@validate_tmpdir)
+        @validate_tmpdir = nil
+      end
+
+      def self.null_file
+        Gem.win_platform? ? 'NUL' : '/dev/null'
+      end
+
+      def self.parse_output(report, result, targets)
+        # Due to PUP-7504, we will have to programmatically construct the json
+        # object from the text output for now.
+        output = result[:stderr].split("\n").reject { |entry| entry.empty? }
+
+        results_data = []
+        output.each do |offense|
+          offense_data = parse_offense(offense)
+          results_data << offense_data
+        end
+
+        # puppet parser validate does not include files without problems in its
+        # output, so we need to go through the list of targets and add passing
+        # events to the report for any target not listed in the output.
+        targets.reject { |target| results_data.any? { |j| j[:file] =~ %r{#{target}} } }.each do |target|
+          report.add_event(
+            file:     target,
+            source:   name,
+            severity: :ok,
+            state:    :passed,
+          )
+        end
+
+        results_data.each do |offense|
+          report.add_event(offense)
+        end
+      end
+
+      def self.parse_offense(offense)
+        sanitize_console_output(offense)
+
+        offense_data = {
+          source:  name,
+          state:  :failure,
+        }
+
+        if offense.match(PUPPET_LOGGER_PREFIX)
+          attributes = offense.match(PUPPET_SYNTAX_PATTERN)
+
+          unless attributes.nil?
+            attributes.names.each do |name|
+              offense_data[name.to_sym] = attributes[name] unless attributes[name].nil?
+            end
+          end
+        else
+          offense_data[:message] = offense
+        end
+
+        offense_data
+      end
+
+      def self.sanitize_console_output(line)
+        line.gsub!(%r{\e\[([;\d]+)?m}, '')
+      end
+    end
+  end
+end

--- a/lib/pdk/validate/puppet_validator.rb
+++ b/lib/pdk/validate/puppet_validator.rb
@@ -3,6 +3,7 @@ require 'pdk/cli/exec'
 require 'pdk/validate/base_validator'
 require 'pdk/validate/puppet/puppet_lint'
 require 'pdk/validate/puppet/puppet_syntax'
+require 'pdk/validate/puppet/puppet_epp'
 
 module PDK
   module Validate
@@ -12,7 +13,7 @@ module PDK
       end
 
       def self.puppet_validators
-        [PuppetSyntax, PuppetLint]
+        [PuppetSyntax, PuppetLint, PuppetEPP]
       end
 
       def self.invoke(report, options = {})

--- a/spec/acceptance/validate_puppet_spec.rb
+++ b/spec/acceptance/validate_puppet_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper_acceptance'
 require 'fileutils'
 
 describe 'pdk validate puppet', module_command: true do
+  let(:epp_spinner_text) { %r{checking puppet EPP syntax}i }
   let(:syntax_spinner_text) { %r{checking puppet manifest syntax}i }
   let(:lint_spinner_text) { %r{checking puppet manifest style}i }
 
@@ -16,12 +17,14 @@ describe 'pdk validate puppet', module_command: true do
     context 'with no .pp files' do
       describe command('pdk validate puppet --format text:stdout --format junit:report.xml') do
         its(:exit_status) { is_expected.to eq(0) }
+        its(:stderr) { is_expected.not_to match(epp_spinner_text) }
         its(:stderr) { is_expected.not_to match(syntax_spinner_text) }
         its(:stderr) { is_expected.not_to match(lint_spinner_text) }
         its(:stdout) { is_expected.to match(%r{Target does not contain any files to validate}) }
 
         describe file('report.xml') do
           its(:content) { is_expected.to contain_valid_junit_xml }
+          its(:content) { is_expected.to have_junit_testcase.in_testsuite('puppet-epp').that_was_skipped }
           its(:content) { is_expected.to have_junit_testcase.in_testsuite('puppet-syntax').that_was_skipped }
           its(:content) { is_expected.to have_junit_testcase.in_testsuite('puppet-lint').that_was_skipped }
         end
@@ -45,12 +48,14 @@ class foo {
 
       describe command('pdk validate puppet --format text:stdout --format junit:report.xml') do
         its(:exit_status) { is_expected.to eq(0) }
+        its(:stderr) { is_expected.not_to match(epp_spinner_text) }
         its(:stderr) { is_expected.to match(syntax_spinner_text) }
         its(:stderr) { is_expected.to match(lint_spinner_text) }
         its(:stdout) { is_expected.to match(%r{Target does not contain any files to validate}) }
 
         describe file('report.xml') do
           its(:content) { is_expected.to contain_valid_junit_xml }
+          its(:content) { is_expected.to have_junit_testsuite('puppet-epp') }
           its(:content) { is_expected.to have_junit_testsuite('puppet-syntax') }
           its(:content) { is_expected.to have_junit_testsuite('puppet-lint') }
         end
@@ -77,6 +82,7 @@ class foo {
 
       describe command('pdk validate puppet --format text:stdout --format junit:report.xml') do
         its(:exit_status) { is_expected.to eq(0) }
+        its(:stderr) { is_expected.not_to match(epp_spinner_text) }
         its(:stderr) { is_expected.to match(syntax_spinner_text) }
         its(:stderr) { is_expected.to match(lint_spinner_text) }
 
@@ -185,6 +191,7 @@ class foo {
       describe command('pdk validate puppet --format text:stdout --format junit:report.xml') do
         its(:exit_status) { is_expected.to eq(0) }
         its(:stdout) { is_expected.to match(%r{^warning:.*#{Regexp.escape(init_pp)}.+class not documented}i) }
+        its(:stderr) { is_expected.not_to match(epp_spinner_text) }
         its(:stderr) { is_expected.to match(syntax_spinner_text) }
         its(:stderr) { is_expected.to match(lint_spinner_text) }
 
@@ -240,6 +247,7 @@ class foo {
 
       describe command('pdk validate puppet --format text:stdout --format junit:report.xml') do
         its(:exit_status) { is_expected.not_to eq(0) }
+        its(:stderr) { is_expected.not_to match(epp_spinner_text) }
         its(:stderr) { is_expected.to match(syntax_spinner_text) }
         its(:stderr) { is_expected.not_to match(lint_spinner_text) }
 
@@ -295,6 +303,7 @@ class foo {
       describe command('pdk validate puppet --format text:stdout --format junit:report.xml') do
         its(:exit_status) { is_expected.not_to eq(0) }
         its(:stdout) { is_expected.to match(%r{#{Regexp.escape(example_pp)}.+autoload module layout}i) }
+        its(:stderr) { is_expected.not_to match(epp_spinner_text) }
         its(:stderr) { is_expected.to match(syntax_spinner_text) }
         its(:stderr) { is_expected.to match(lint_spinner_text) }
 
@@ -334,6 +343,7 @@ class foo {
         describe command("pdk validate puppet --format text:stdout --format junit:report.xml #{clean_pp}") do
           its(:exit_status) { is_expected.to eq(0) }
           its(:stdout) { is_expected.to match(%r{Target does not contain any files to validate}) }
+          its(:stderr) { is_expected.not_to match(epp_spinner_text) }
           its(:stderr) { is_expected.to match(syntax_spinner_text) }
           its(:stderr) { is_expected.to match(lint_spinner_text) }
 
@@ -388,6 +398,7 @@ class foo {
 
         describe command("pdk validate puppet --format text:stdout --format junit:report.xml #{another_problem_dir}") do
           its(:exit_status) { is_expected.not_to eq(0) }
+          its(:stderr) { is_expected.not_to match(epp_spinner_text) }
           its(:stderr) { is_expected.to match(syntax_spinner_text) }
           its(:stderr) { is_expected.to match(lint_spinner_text) }
           its(:stdout) { is_expected.to match(%r{#{Regexp.escape(another_problem_pp)}}) }

--- a/spec/acceptance/validate_puppet_spec.rb
+++ b/spec/acceptance/validate_puppet_spec.rb
@@ -47,7 +47,7 @@ class foo {
         its(:exit_status) { is_expected.to eq(0) }
         its(:stderr) { is_expected.to match(syntax_spinner_text) }
         its(:stderr) { is_expected.to match(lint_spinner_text) }
-        its(:stdout) { is_expected.to have_no_output }
+        its(:stdout) { is_expected.to match(%r{Target does not contain any files to validate}) }
 
         describe file('report.xml') do
           its(:content) { is_expected.to contain_valid_junit_xml }
@@ -167,7 +167,7 @@ class foo {
 
       describe command('pdk validate puppet') do
         its(:exit_status) { is_expected.to eq(0) }
-        its(:stdout) { is_expected.to have_no_output }
+        its(:stdout) { is_expected.to match(%r{Target does not contain any files to validate}) }
       end
     end
 
@@ -333,7 +333,7 @@ class foo {
 
         describe command("pdk validate puppet --format text:stdout --format junit:report.xml #{clean_pp}") do
           its(:exit_status) { is_expected.to eq(0) }
-          its(:stdout) { is_expected.to have_no_output }
+          its(:stdout) { is_expected.to match(%r{Target does not contain any files to validate}) }
           its(:stderr) { is_expected.to match(syntax_spinner_text) }
           its(:stderr) { is_expected.to match(lint_spinner_text) }
 
@@ -439,7 +439,7 @@ class foo {
 
       describe command('pdk validate puppet') do
         its(:exit_status) { is_expected.to eq(0) }
-        its(:stdout) { is_expected.to have_no_output }
+        its(:stdout) { is_expected.to match(%r{Target does not contain any files to validate}) }
       end
     end
   end

--- a/spec/support/it_accepts_epp_targets.rb
+++ b/spec/support/it_accepts_epp_targets.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples_for 'it accepts .epp targets' do
+  describe '.pattern' do
+    it 'matches EPP files' do
+      expect(described_class.pattern).to include('**/*.epp')
+    end
+  end
+end

--- a/spec/unit/pdk/validate/puppet/puppet_epp_spec.rb
+++ b/spec/unit/pdk/validate/puppet/puppet_epp_spec.rb
@@ -19,12 +19,6 @@ describe PDK::Validate::PuppetEPP do
 
   it_behaves_like 'it accepts .epp targets'
 
-  describe '.pattern_ignore' do
-    it 'does not match plan files' do
-      expect(described_class.pattern_ignore).to eq('')
-    end
-  end
-
   describe '.invoke' do
     context 'when the validator runs correctly' do
       before(:each) do

--- a/spec/unit/pdk/validate/puppet/puppet_epp_spec.rb
+++ b/spec/unit/pdk/validate/puppet/puppet_epp_spec.rb
@@ -1,0 +1,319 @@
+require 'spec_helper'
+
+describe PDK::Validate::PuppetEPP do
+  let(:module_root) { File.join('path', 'to', 'test', 'module') }
+  let(:tmpdir) { File.join('/', 'tmp', 'puppet-epp-validate') }
+
+  before(:each) do
+    allow(Dir).to receive(:mktmpdir).with('puppet-epp-validate').and_return(tmpdir)
+    allow(FileUtils).to receive(:remove_entry_secure).with(tmpdir)
+  end
+
+  it 'defines the base validator attributes' do
+    expect(described_class).to have_attributes(
+      name:         'puppet-epp',
+      cmd:          'puppet',
+      spinner_text: a_string_matching(%r{puppet EPP syntax}i),
+    )
+  end
+
+  it_behaves_like 'it accepts .epp targets'
+
+  describe '.pattern_ignore' do
+    it 'does not match plan files' do
+      expect(described_class.pattern_ignore).to eq('')
+    end
+  end
+
+  describe '.invoke' do
+    context 'when the validator runs correctly' do
+      before(:each) do
+        allow(described_class).to receive(:parse_targets).with(anything).and_return([[], [], []])
+      end
+
+      it 'cleans up the temp dir after invoking' do
+        expect(described_class).to receive(:remove_validate_tmpdir)
+        described_class.invoke(PDK::Report.new, {})
+      end
+    end
+
+    context 'when the validator raises an exception' do
+      before(:each) do
+        allow(described_class).to receive(:parse_targets).with(anything).and_raise(PDK::CLI::FatalError)
+      end
+
+      it 'cleans up the temp dir after invoking' do
+        expect(described_class).to receive(:remove_validate_tmpdir)
+        expect {
+          described_class.invoke(PDK::Report.new, {})
+        }.to raise_error(PDK::CLI::FatalError)
+      end
+    end
+  end
+
+  describe '.remove_validate_tmpdir' do
+    after(:each) do
+      described_class.remove_validate_tmpdir
+    end
+
+    context 'when no temp dir has been created' do
+      before(:each) do
+        described_class.instance_variable_set('@validate_tmpdir', nil)
+      end
+
+      it 'does not attempt to remove the directory' do
+        expect(FileUtils).not_to receive(:remove_entry_secure)
+      end
+    end
+
+    context 'when a temp dir has been created' do
+      before(:each) do
+        described_class.validate_tmpdir
+        allow(File).to receive(:directory?).and_call_original
+      end
+
+      context 'and the path is a directory' do
+        before(:each) do
+          allow(File).to receive(:directory?).with(tmpdir).and_return(true)
+        end
+
+        it 'removes the directory' do
+          expect(FileUtils).to receive(:remove_entry_secure).with(tmpdir)
+        end
+      end
+
+      context 'but the path is not a directory' do
+        before(:each) do
+          allow(File).to receive(:directory?).with(tmpdir).and_return(false)
+        end
+
+        it 'does not attempt to remove the directory' do
+          expect(FileUtils).not_to receive(:remove_entry_secure)
+        end
+      end
+    end
+  end
+
+  describe '.parse_options' do
+    subject(:command_args) { described_class.parse_options(options, targets) }
+
+    let(:options) { {} }
+    let(:targets) { %w[target1 target2.epp] }
+
+    before(:each) do
+      allow(Gem).to receive(:win_platform?).and_return(false)
+    end
+
+    it 'invokes `puppet epp validate`' do
+      expect(command_args.first(2)).to eq(%w[epp validate])
+    end
+
+    it 'appends the targets to the command arguments' do
+      expect(command_args.last(targets.count)).to eq(targets)
+    end
+
+    context 'when auto-correct is enabled' do
+      let(:options) { { auto_correct: true } }
+
+      it 'has no effect' do
+        expect(command_args).to eq(%w[epp validate --config /dev/null --modulepath].push(tmpdir).concat(targets))
+      end
+    end
+  end
+
+  describe '.parse_output' do
+    subject(:parse_output) do
+      described_class.parse_output(report, { stderr: validate_output }, targets)
+    end
+
+    let(:report) { PDK::Report.new }
+    let(:validate_output) do
+      [
+        mock_validate('fail.epp', 1, 2, 'test message 1', 'error'),
+        mock_validate('fail.epp', 1, nil, 'test message 2', 'error'),
+        mock_validate('fail.epp', nil, nil, 'test message 3', 'error'),
+        mock_validate(nil, 1, nil, 'test message 4', 'error'),
+        "error: 5.3.4 test-type-1 (file: warning.epp, line: 34, column: 45)\n",
+        "error: 5.3.4 test-type-2 (file: warning.epp, line: 34)\n",
+        "error: 5.3.4 test-type-3 (line: 34, column: 45)\n",
+        "error: 5.3.4 test-type-4 (line: 34)\n",
+        "error: 5.3.4 test-type-5 (file: warning.epp)\n",
+        "error: language validaton logged 2 errors. giving up\n",
+      ].join('')
+    end
+
+    let(:targets) { ['pass.epp', 'fail.epp'] }
+
+    def mock_validate(file, line, column, message, severity)
+      output = "#{severity}: #{message}"
+      if file && line && column
+        output << " at #{file}:#{line}:#{column}\n"
+      elsif file && line
+        output << " at #{file}:#{line}\n"
+      elsif line
+        output << " at line #{line}\n"
+      elsif file
+        output << " in #{file}\n"
+      end
+
+      output
+    end
+
+    before(:each) do
+      allow(report).to receive(:add_event)
+    end
+
+    after(:each) do
+      parse_output
+    end
+
+    context 'when the output contains no references to a target' do
+      it 'adds a passing event for the target to the report' do
+        expect(report).to receive(:add_event).with(
+          file:     'pass.epp',
+          source:   described_class.name,
+          state:    :passed,
+          severity: :ok,
+        )
+      end
+    end
+
+    context 'with Puppet <= 5.3.3' do
+      it 'handles syntax error locations with a file, line, and column' do
+        expect(report).to receive(:add_event).with(
+          file:     'fail.epp',
+          source:   described_class.name,
+          state:    :failure,
+          message:  'test message 1',
+          severity: 'error',
+          column:   '2',
+          line:     '1',
+        )
+      end
+
+      it 'handles syntax error locations with a file and line' do
+        expect(report).to receive(:add_event).with(
+          file:     'fail.epp',
+          source:   described_class.name,
+          state:    :failure,
+          message:  'test message 2',
+          severity: 'error',
+          line:     '1',
+        )
+      end
+
+      it 'handles syntax error locations with a file' do
+        expect(report).to receive(:add_event).with(
+          file:     'fail.epp',
+          source:   described_class.name,
+          state:    :failure,
+          message:  'test message 3',
+          severity: 'error',
+        )
+      end
+
+      it 'handles syntax error locations with a line' do
+        expect(report).to receive(:add_event).with(
+          source:   described_class.name,
+          state:    :failure,
+          message:  'test message 4',
+          severity: 'error',
+          line:     '1',
+        )
+      end
+    end
+
+    context 'with Puppet >= 5.3.4' do
+      it 'handles syntax error locations with a file, line, and column' do
+        expect(report).to receive(:add_event).with(
+          file:     'warning.epp',
+          source:   described_class.name,
+          state:    :failure,
+          message:  '5.3.4 test-type-1',
+          severity: 'error',
+          column:   '45',
+          line:     '34',
+        )
+      end
+
+      it 'handles syntax error locations with a file and line' do
+        expect(report).to receive(:add_event).with(
+          file:     'warning.epp',
+          source:   described_class.name,
+          state:    :failure,
+          message:  '5.3.4 test-type-2',
+          severity: 'error',
+          line:     '34',
+        )
+      end
+
+      it 'handles syntax error locations with a line and column' do
+        expect(report).to receive(:add_event).with(
+          source:   described_class.name,
+          state:    :failure,
+          message:  '5.3.4 test-type-3',
+          severity: 'error',
+          column:   '45',
+          line:     '34',
+        )
+      end
+
+      it 'handles syntax error locations with a line' do
+        expect(report).to receive(:add_event).with(
+          source:   described_class.name,
+          state:    :failure,
+          message:  '5.3.4 test-type-4',
+          severity: 'error',
+          line:     '34',
+        )
+      end
+
+      it 'handles syntax error locations with a file' do
+        expect(report).to receive(:add_event).with(
+          file:     'warning.epp',
+          source:   described_class.name,
+          state:    :failure,
+          message:  '5.3.4 test-type-5',
+          severity: 'error',
+        )
+      end
+    end
+
+    context 'Parser encounters a Ruby error' do
+      let(:targets) { ['ruby_error.epp'] }
+      let(:validate_output) do
+        "C:/PWKit/Puppet/sys/ruby/lib/ruby/gems/2.4.0/gems/puppet-5.5.2-x64-mingw32/lib/puppet/environments.rb:38:in \`"\
+        "get!': Could not find a directory environment named 'PUPPET_MASTER_SERVER=' anywhere in the path: "\
+        "C:/ProgramData/PuppetLabs/code/environments. Does the directory exist? (Puppet::Environments::EnvironmentNotFound)\n"
+      end
+
+      it 'handles the Ruby error and prints it out as the message' do
+        expect(report).to receive(:add_event).with(
+          source:   described_class.name,
+          state:    :failure,
+          message:  validate_output.split("\n").first,
+        )
+      end
+    end
+  end
+
+  describe '.null_file' do
+    subject { described_class.null_file }
+
+    context 'on a Windows host' do
+      before(:each) do
+        allow(Gem).to receive(:win_platform?).and_return(true)
+      end
+
+      it { is_expected.to eq('NUL') }
+    end
+
+    context 'on a POSIX host' do
+      before(:each) do
+        allow(Gem).to receive(:win_platform?).and_return(false)
+      end
+
+      it { is_expected.to eq('/dev/null') }
+    end
+  end
+end


### PR DESCRIPTION
This is a base implementation for validating EPP templates. I essentially copy/pasted the Puppet validate one, so it probably needs some pruning, but it works.