### PR TITLE
(maint) Clear Gemfile overrides before pdk update test

### DIFF
--- a/package-testing/spec/package/update_module_spec.rb
+++ b/package-testing/spec/package/update_module_spec.rb
@@ -25,6 +25,15 @@ describe 'Updating an existing module' do
           create_remote_file(get_working_node, File.join(module_dir, 'metadata.json'), metadata.to_json)
 
           sync_yaml = YAML.safe_load(open("https://raw.githubusercontent.com/#{mod}/master/.sync.yml").read)
+
+          sync_yaml['Gemfile'].each_key do |gem_type|
+            sync_yaml['Gemfile'][gem_type].each_key do |group|
+              sync_yaml['Gemfile'][gem_type][group].reject! do |gem|
+                gem['gem'] !~ %r{\Apuppet-module-(?:posix|win)-system}
+              end
+            end
+          end
+
           sync_yaml['Gemfile']['required'][':system_tests'] << { 'gem' => 'nokogiri', 'version' => '1.8.5' }
           create_remote_file(get_working_node, File.join(module_dir, '.sync.yml'), sync_yaml.to_yaml)
         end

--- a/package-testing/spec/package/update_module_spec.rb
+++ b/package-testing/spec/package/update_module_spec.rb
@@ -28,8 +28,8 @@ describe 'Updating an existing module' do
 
           sync_yaml['Gemfile'].each_key do |gem_type|
             sync_yaml['Gemfile'][gem_type].each_key do |group|
-              sync_yaml['Gemfile'][gem_type][group].reject! do |gem|
-                gem['gem'] !~ %r{\Apuppet-module-(?:posix|win)-system}
+              sync_yaml['Gemfile'][gem_type][group].select! do |gem|
+                gem['gem'] =~ %r{\Apuppet-module-(?:posix|win)-system}
               end
             end
           end


### PR DESCRIPTION
The two modules we test `pdk update` with in the package tests pull in
additional modules which then pull in unsupported gems with compiled
extensions, causing the tests to fail.

By removing these gems from the `Gemfile` before running the tests, we can
get the tests working again while retaining the original purpose of the
tests (testing that packages that depend on beaker can be updated and
run without needing a compilation environment).

This PR combined with puppetlabs/pdk-vanagon#208 fixes up the Jenkins pipeline (see https://jenkins-master-prod-1.delivery.puppetlabs.net/view/PDK/view/adhoc/job/platform_pdk_adhoc_pdk-int-sys-testing_adhoc/16/)