### PR TITLE
(FIXUP) Avoid attempting to append nokogiri pin to nil in package tests

### DIFF
--- a/package-testing/spec/package/update_module_spec.rb
+++ b/package-testing/spec/package/update_module_spec.rb
@@ -34,7 +34,9 @@ describe 'Updating an existing module' do
             end
           end
 
+          sync_yaml['Gemfile']['required'][':system_tests'] ||= []
           sync_yaml['Gemfile']['required'][':system_tests'] << { 'gem' => 'nokogiri', 'version' => '1.8.5' }
+
           create_remote_file(get_working_node, File.join(module_dir, '.sync.yml'), sync_yaml.to_yaml)
         end
 


### PR DESCRIPTION
Avoid undefined method `<<` on a possibly nil value during package tests.