### PR TITLE
(PDK-1414) Detect common CI environments and set non-interactive

### DIFF
--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -48,9 +48,30 @@ module PDK
       end
       module_function :prompt_for_yes
 
+      # Uses environment variables to detect if the current process is running in common
+      # Continuous Integration (CI) environments
+      # @return [Boolean] Whether the PDK is in a CI based environment
+      def ci_environment?
+        [
+          'APPVEYOR_BUILD_FOLDER', # AppVeyor CI
+          'GITLAB_CI',             # GitLab CI
+          'JENKINS_URL',           # Jenkins
+          'BUILD_DEFINITIONNAME',  # Azure Pipelines
+          'TEAMCITY_VERSION',      # Team City
+          'BAMBOO_BUILDKEY',       # Bamboo
+          'GOCD_SERVER_URL',       # Go CD
+          'TRAVIS',                # Travis CI
+          'GITHUB_WORKFLOW'        # GitHub Actions
+        ].each { |name| return true if ENV.key?(name) }
+
+        false
+      end
+      module_function :ci_environment?
+
       def interactive?
         return false if PDK.logger.debug?
         return !ENV['PDK_FRONTEND'].casecmp('noninteractive').zero? if ENV['PDK_FRONTEND']
+        return false if ci_environment?
         return false unless $stderr.isatty
 
         true

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -53,18 +53,18 @@ module PDK
       # @return [Boolean] Whether the PDK is in a CI based environment
       def ci_environment?
         [
-          'APPVEYOR_BUILD_FOLDER', # AppVeyor CI
-          'GITLAB_CI',             # GitLab CI
-          'JENKINS_URL',           # Jenkins
-          'BUILD_DEFINITIONNAME',  # Azure Pipelines
-          'TEAMCITY_VERSION',      # Team City
-          'BAMBOO_BUILDKEY',       # Bamboo
-          'GOCD_SERVER_URL',       # Go CD
-          'TRAVIS',                # Travis CI
-          'GITHUB_WORKFLOW'        # GitHub Actions
-        ].each { |name| return true if ENV.key?(name) }
-
-        false
+          'CI',                     # Generic
+          'CONTINUOUS_INTEGRATION', # Generic
+          'APPVEYOR_BUILD_FOLDER',  # AppVeyor CI
+          'GITLAB_CI',              # GitLab CI
+          'JENKINS_URL',            # Jenkins
+          'BUILD_DEFINITIONNAME',   # Azure Pipelines
+          'TEAMCITY_VERSION',       # Team City
+          'BAMBOO_BUILDKEY',        # Bamboo
+          'GOCD_SERVER_URL',        # Go CD
+          'TRAVIS',                 # Travis CI
+          'GITHUB_WORKFLOW',        # GitHub Actions
+        ].any? { |name| ENV.key?(name) }
       end
       module_function :ci_environment?
 

--- a/spec/unit/pdk/cli/exec/command_spec.rb
+++ b/spec/unit/pdk/cli/exec/command_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe PDK::CLI::Exec::Command do
   subject(:command) { described_class.new('/bin/echo', 'foo') }
 
+  before(:each) do
+    allow(PDK::CLI::Util).to receive(:ci_environment?).and_return(false)
+  end
+
   describe '.context=' do
     context 'when setting to an expected value' do
       it 'accepts :system' do

--- a/spec/unit/pdk/cli/util_spec.rb
+++ b/spec/unit/pdk/cli/util_spec.rb
@@ -64,6 +64,7 @@ describe PDK::CLI::Util do
     before(:each) do
       allow(PDK.logger).to receive(:debug?).and_return(false)
       allow($stderr).to receive(:isatty).and_return(true)
+      allow(PDK::CLI::Util).to receive(:ci_environment?).and_return(false) # rubocop:disable RSpec/DescribedClass This reads better
       ENV.delete('PDK_FRONTEND')
     end
 
@@ -82,6 +83,14 @@ describe PDK::CLI::Util do
     context 'when PDK_FRONTEND env var is set to noninteractive' do
       before(:each) do
         ENV['PDK_FRONTEND'] = 'noninteractive'
+      end
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when in a Continuous Integration environment' do
+      before(:each) do
+        allow(PDK::CLI::Util).to receive(:ci_environment?).and_return(true) # rubocop:disable RSpec/DescribedClass This reads better
       end
 
       it { is_expected.to be_falsey }


### PR DESCRIPTION
Previously PDK detected whether a session was interactive by using the isatty
method on STDERR. However it is still possible to create TTY based STDERR in
CI environments such as Travis.  This commit adds additional Environment
Variable checks for common CI systems to ensure that PDK is non-interactive in
CI.