### PR TITLE
(PDK-1415) Allow analytics opt-out prompt to be disabled via ENV

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -51,7 +51,7 @@ module PDK::CLI
 
   def self.run(args)
     @args = args
-    PDK::Config.analytics_config_interview! unless PDK::Config.analytics_config_exist?
+    PDK::Config.analytics_config_interview! unless ENV['PDK_DISABLE_ANALYTICS'] || PDK::Config.analytics_config_exist?
     @base_cmd.run(args)
   rescue PDK::CLI::ExitWithError => e
     PDK.logger.send(e.log_level, e.message)


### PR DESCRIPTION
Previously the code would only skip the prompt if the config file
already existed or the session was deemed to be "non-interactive". This
change allows the interview to also be bypassed by setting
"PDK_DISABLE_ANALYTICS=true" and adds some tests around the opt-out
prompt behavior.