### PR TITLE
(maint) Update beaker in package tests

### DIFF
--- a/package-testing/Gemfile
+++ b/package-testing/Gemfile
@@ -13,11 +13,11 @@ end
 gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '= 4.10.0')
 gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '= 0.5.0')
 gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '= 1.1.31')
-gem 'beaker-rspec', '= 6.2.4'
-gem 'rake', '= 12.3.2'
-gem 'nokogiri', '= 1.10.3'
-gem 'beaker-vmpooler', '= 1.3.3'
 gem 'beaker-puppet', '= 1.18.5'
+gem 'beaker-rspec', '= 6.2.4'
+gem 'beaker-vmpooler', '= 1.3.3'
+gem 'nokogiri', '= 1.10.3'
+gem 'rake', '= 12.3.2'
 
 group :development do
   gem 'pry-byebug', '~> 3.4'

--- a/package-testing/Gemfile
+++ b/package-testing/Gemfile
@@ -10,11 +10,14 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.34')
-gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.2')
-gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '~> 1.1.8')
-gem 'beaker-rspec'
-gem 'rake', '~> 10.1'
+gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '= 4.10.0')
+gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '= 0.5.0')
+gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '= 1.1.31')
+gem 'beaker-rspec', '= 6.2.4'
+gem 'rake', '= 12.3.2'
+gem 'nokogiri', '= 1.10.3'
+gem 'beaker-vmpooler', '= 1.3.3'
+gem 'beaker-puppet', '= 1.18.5'
 
 group :development do
   gem 'pry-byebug', '~> 3.4'

--- a/package-testing/spec/package/support/install_pdk.rb
+++ b/package-testing/spec/package/support/install_pdk.rb
@@ -1,4 +1,7 @@
 module PackageHelpers
+  extend Beaker::DSL::InstallUtils::FOSSUtils
+  extend Beaker::DSL::InstallUtils::Puppet5
+
   module_function
 
   def install_pdk_on(host)

--- a/package-testing/spec/spec_helper_package.rb
+++ b/package-testing/spec/spec_helper_package.rb
@@ -1,4 +1,5 @@
 require 'beaker-rspec'
+require 'beaker-puppet'
 
 Dir['./spec/package/support/*.rb'].sort.each { |f| require f }
 


### PR DESCRIPTION
Updates beaker and friends to 4.10.0 so that we can run tests against the latest platforms like RHEL8. The gem versions are all pinned because I'm paranoid about the pipeline breaking due to unrelated changes to any of these packages.

I'll link the result of the Jenkins run here once it has finished.