### PR TITLE
(PDK-1333) Fix command_spec rake task for newer CRI versions

### DIFF
--- a/rakelib/command_spec.rake
+++ b/rakelib/command_spec.rake
@@ -20,6 +20,12 @@ def describe_command(cri_command)
   }
 end
 
+def cri_option_is_a_hash?
+  return @cri_option_is_a_hash unless @cri_option_is_a_hash.nil?
+  @cri_option_is_a_hash = Gem::Version.new(Cri::VERSION) <= Gem::Version.new('2.11.0')
+  @cri_option_is_a_hash
+end
+
 def describe_option(cri_option)
-  cri_option.reject { |k, _| k == :block }
+  (cri_option_is_a_hash? ? cri_option : cri_option.to_h).reject { |k, _| k == :block }
 end


### PR DESCRIPTION
Previously the command_spec rake task only worked for older CRI version
(<= 2.11.0) because the cri_options used to be passed as a hash, but is now it's
own object type. This commit updates the conversion process to optionally
convert the object to hash on newer CRI versions.