### PR TITLE
(maint) Fix typo in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,5 +76,5 @@ Gemfile.local
 /archive/
 /sut-files.tgz
 
-+# Puppet packaging files
- +/ext/packaging/
+# Puppet packaging files
+/ext/packaging/


### PR DESCRIPTION
The /ext/packaging directory was not being excluded correctly as there appeared
to be a typo in the text.  This commit removes the `+ ` text.

[ci skip]