### PR TITLE
Extend version range for net-ssh

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'json-schema', '2.8.0'
   spec.add_runtime_dependency 'json_pure', '~> 2.1.0'
   spec.add_runtime_dependency 'minitar', '~> 0.6.1'
-  spec.add_runtime_dependency 'net-ssh', '~> 4.2.0'
+  spec.add_runtime_dependency 'net-ssh', '>= 4.2.0', '< 6.0.0'
   spec.add_runtime_dependency 'pathspec', '~> 0.2.1'
   spec.add_runtime_dependency 'tty-prompt', '0.13.1'
   spec.add_runtime_dependency 'tty-spinner', '0.5.0'


### PR DESCRIPTION
There is a dependency conflict between `pdk` and `beaker`
since beaker `>= 4.7.0` requires `net-ssh ~> 5.0` and
`pdk` is still tied to `~> 4.2.0`.

All tests still pass when extending the version range:

https://travis-ci.org/leoarnold/pdk/jobs/555337752