### PR TITLE
(PDK-1434) Gracefully handle unparsable bolt analytics config

### DIFF
--- a/lib/pdk/config.rb
+++ b/lib/pdk/config.rb
@@ -34,7 +34,14 @@ module PDK
     end
 
     def self.bolt_analytics_config
-      PDK::Config::YAML.new(file: File.expand_path('~/.puppetlabs/bolt/analytics.yaml'))
+      file = File.expand_path('~/.puppetlabs/bolt/analytics.yaml')
+      PDK::Config::YAML.new(file: file)
+    rescue PDK::Config::LoadError => e
+      PDK.logger.debug _('Unable to load %{file}: %{message}') % {
+        file:    file,
+        message: e.message,
+      }
+      PDK::Config::YAML.new
     end
 
     def self.analytics_config_path


### PR DESCRIPTION
This issue was found because the classroom Windows instances created the
`~/puppetlabs/bolt/analytics.yaml` manually with UTF-16LE encoding which
Psych on Windows is unable to parse, causing
`PDK::Config.bolt_analytics_config` to raise `PDK::Config::LoadError`.

The classroom bootstrap scripts have been fixed to generate the file as
UTF-8 now, but we should still gracefully handle this case and have PDK
behave as if the file doesn't exist and use the default values.