### PR TITLE
(PDK-421) Update acceptance tests for EPP Validation

### DIFF
--- a/package-testing/spec/package/update_module_spec.rb
+++ b/package-testing/spec/package/update_module_spec.rb
@@ -54,7 +54,7 @@ describe 'Updating an existing module' do
           subject { super().stdout.split("\n") }
 
           it 'does not output any unexpected errors' do
-            is_expected.to all(match(%r{^(?:info|warning|error): (?:puppet-lint|rubocop|task-metadata-lint|task-name)}))
+            is_expected.to all(match(%r{^(?:info|warning|error): (?:puppet-lint|rubocop|task-metadata-lint|task-name|puppet-epp)}))
           end
         end
       end


### PR DESCRIPTION
Previously in commit ea789ac02797706 the EPP validator was added however the
acceptance tests were failing.  This commit updates the acceptance test, adding
the missing validator name.