### PR TITLE
(PDK-641) Make `pdk bundle` fully interactive

### DIFF
--- a/lib/pdk/cli/bundle.rb
+++ b/lib/pdk/cli/bundle.rb
@@ -25,15 +25,12 @@ EOF
 
       gemfile_env = PDK::Util::Bundler::BundleHelper.gemfile_env(puppet_env[:gemset])
 
-      command = PDK::CLI::Exec::Command.new(PDK::CLI::Exec.bundle_bin, *args).tap do |c|
+      command = PDK::CLI::Exec::InteractiveCommand.new(PDK::CLI::Exec.bundle_bin, *args).tap do |c|
         c.context = :pwd
         c.update_environment(gemfile_env)
       end
 
       result = command.execute!
-
-      $stderr.puts result[:stdout]
-      $stderr.puts result[:stderr]
 
       exit result[:exit_code]
     end

--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -13,7 +13,7 @@ module PDK
   module CLI
     module Exec
       require 'pdk/cli/exec/command'
-      require 'pdk/cli/exec/command/interactive'
+      require 'pdk/cli/exec/interactive_command'
 
       def self.execute(*cmd)
         Command.new(*cmd).execute!

--- a/lib/pdk/cli/exec.rb
+++ b/lib/pdk/cli/exec.rb
@@ -1,5 +1,6 @@
 require 'bundler'
 require 'childprocess'
+require 'English'
 require 'tempfile'
 require 'tty-spinner'
 require 'tty-which'
@@ -11,12 +12,23 @@ require 'pdk/util/ruby_version'
 module PDK
   module CLI
     module Exec
+      require 'pdk/cli/exec/command'
+      require 'pdk/cli/exec/command/interactive'
+
       def self.execute(*cmd)
         Command.new(*cmd).execute!
       end
 
       def self.execute_with_env(env, *cmd)
         Command.new(*cmd).tap { |c| c.environment = env }.execute!
+      end
+
+      def self.execute_interactive(*cmd)
+        InteractiveCommand.new(*cmd).execute!
+      end
+
+      def self.execute_interactive_with_env(env, *cmd)
+        InteractiveCommand.new(*cmd).tap { |c| c.environment = env }.execute!
       end
 
       def self.ensure_bin_present!(bin_path, bin_name)
@@ -60,213 +72,6 @@ module PDK
 
         PDK.logger.debug(_("Using '%{vendored_bin}' from PDK package.") % { vendored_bin: vendored_bin_full_path })
         vendored_bin_full_path
-      end
-
-      # TODO: decide how/when to connect stdin to child process for things like pry
-      # TODO: need a way to set callbacks on new stdout/stderr data
-      class Command
-        attr_reader :argv
-        attr_reader :context
-        attr_accessor :timeout
-        attr_accessor :environment
-        attr_writer :exec_group
-
-        def initialize(*argv)
-          @argv = argv
-
-          @process = ChildProcess.build(*@argv)
-          @process.leader = true
-
-          @stdout = Tempfile.new('stdout').tap { |io| io.sync = true }
-          @stderr = Tempfile.new('stderr').tap { |io| io.sync = true }
-
-          @process.io.stdout = @stdout
-          @process.io.stderr = @stderr
-
-          # Default to running things in the system context.
-          @context = :system
-
-          # Extra environment vars to add to base set.
-          @environment = {}
-
-          # Register the ExecGroup when running in parallel
-          @exec_group = nil
-        end
-
-        def context=(new_context)
-          unless [:system, :module, :pwd].include?(new_context)
-            raise ArgumentError, _("Expected execution context to be :system or :module but got '%{context}'.") % { context: new_context }
-          end
-
-          @context = new_context
-        end
-
-        def register_spinner(spinner, opts = {})
-          return unless PDK::CLI::Util.interactive?
-          @success_message = opts.delete(:success)
-          @failure_message = opts.delete(:failure)
-
-          @spinner = spinner
-        end
-
-        def add_spinner(message, opts = {})
-          return unless PDK::CLI::Util.interactive?
-          @success_message = opts.delete(:success)
-          @failure_message = opts.delete(:failure)
-
-          @spinner = TTY::Spinner.new("[:spinner] #{message}", opts.merge(PDK::CLI::Util.spinner_opts_for_platform))
-        end
-
-        def update_environment(additional_env)
-          @environment.merge!(additional_env)
-        end
-
-        def check_for_legacy_env_vars
-          if ENV['PUPPET_GEM_VERSION']
-            PDK.logger.warn_once _(
-              'PUPPET_GEM_VERSION is not supported by PDK. ' \
-              'Use the --puppet-version option on your PDK command ' \
-              'or set the PDK_PUPPET_VERSION environment variable instead',
-            )
-            @process.environment['PUPPET_GEM_VERSION'] = nil
-          end
-
-          %w[FACTER HIERA].each do |gem|
-            if ENV["#{gem}_GEM_VERSION"]
-              PDK.logger.warn_once _('%{varname} is not supported by PDK.') % { varname: "#{gem}_GEM_VERSION" }
-              @process.environment["#{gem}_GEM_VERSION"] = nil
-            end
-          end
-        end
-
-        def execute!
-          # Start spinning if configured.
-          @spinner.auto_spin if @spinner
-
-          # Add custom env vars.
-          @environment.each do |k, v|
-            @process.environment[k] = v
-          end
-
-          check_for_legacy_env_vars
-
-          @process.environment['BUNDLE_IGNORE_CONFIG'] = '1'
-
-          if [:module, :pwd].include?(context)
-            @process.environment['GEM_HOME'] = PDK::Util::RubyVersion.gem_home
-            @process.environment['GEM_PATH'] = PDK::Util::RubyVersion.gem_path
-
-            # Make sure invocation of Ruby prefers our private installation.
-            package_binpath = PDK::Util.package_install? ? File.join(PDK::Util.pdk_package_basedir, 'bin') : nil
-            @process.environment['PATH'] = [
-              PDK::Util::RubyVersion.bin_path,
-              File.join(@process.environment['GEM_HOME'], 'bin'),
-              PDK::Util::RubyVersion.gem_paths_raw.map { |gem_path| File.join(gem_path, 'bin') },
-              package_binpath,
-              PDK::Util.package_install? ? PDK::Util::Git.git_paths : nil,
-              ENV['PATH'],
-            ].compact.flatten.join(File::PATH_SEPARATOR)
-
-            mod_root = PDK::Util.module_root
-
-            unless mod_root
-              @spinner.error if @spinner
-
-              raise PDK::CLI::FatalError, _('Current working directory is not part of a module. (No metadata.json was found.)')
-            end
-
-            if Dir.pwd == mod_root || context == :pwd
-              run_process_in_clean_env!
-            else
-              Dir.chdir(mod_root) do
-                run_process_in_clean_env!
-              end
-            end
-          else
-            run_process!
-          end
-
-          # Stop spinning when done (if configured).
-          stop_spinner
-
-          @stdout.rewind
-          @stderr.rewind
-
-          process_data = {
-            stdout: @stdout.read,
-            stderr: @stderr.read,
-            exit_code: @process.exit_code,
-            duration: @duration,
-          }
-
-          PDK.logger.debug _('STDOUT: %{output}') % {
-            output: process_data[:stdout].empty? ? 'N/A' : "\n#{process_data[:stdout]}",
-          }
-          PDK.logger.debug _('STDERR: %{output}') % {
-            output: process_data[:stderr].empty? ? 'N/A' : "\n#{process_data[:stderr]}",
-          }
-
-          process_data
-        ensure
-          @stdout.close
-          @stderr.close
-        end
-
-        protected
-
-        def stop_spinner
-          return unless @spinner
-
-          # If it is a single spinner, we need to send it a success/error message
-          if @process.exit_code.zero?
-            @spinner.success(@success_message || '')
-          else
-            @spinner.error(@failure_message || '')
-          end
-        end
-
-        def run_process_in_clean_env!
-          ::Bundler.with_clean_env do
-            run_process!
-          end
-        end
-
-        def run_process!
-          command_string = argv.join(' ')
-
-          PDK.logger.debug(_("Executing '%{command}'") % { command: command_string })
-
-          if context == :module
-            PDK.logger.debug(_('Command environment:'))
-            @process.environment.each do |var, val|
-              PDK.logger.debug("  #{var}: #{val}")
-            end
-          end
-
-          start_time = Time.now
-
-          begin
-            @process.start
-          rescue ChildProcess::LaunchError => e
-            raise PDK::CLI::FatalError, _("Failed to execute '%{command}': %{message}") % { command: command_string, message: e.message }
-          end
-
-          if timeout
-            begin
-              @process.poll_for_exit(timeout)
-            rescue ChildProcess::TimeoutError
-              @process.stop # tries increasingly harsher methods to kill the process.
-            end
-          else
-            # Wait indfinitely if no timeout set.
-            @process.wait
-          end
-
-          @duration = Time.now - start_time
-
-          PDK.logger.debug(_("Execution of '%{command}' complete (duration: %{duration_in_seconds}s; exit code: %{exit_code})") %
-            { command: command_string, duration_in_seconds: @duration, exit_code: @process.exit_code })
-        end
       end
     end
   end

--- a/lib/pdk/cli/exec/command.rb
+++ b/lib/pdk/cli/exec/command.rb
@@ -1,0 +1,233 @@
+require 'bundler'
+require 'childprocess'
+require 'English'
+require 'tempfile'
+require 'tty-spinner'
+require 'tty-which'
+
+require 'pdk/util'
+require 'pdk/util/git'
+require 'pdk/util/ruby_version'
+
+module PDK
+  module CLI
+    module Exec
+      class Command
+        attr_reader :argv
+        attr_reader :context
+        attr_accessor :timeout
+        attr_accessor :environment
+        attr_writer :exec_group
+
+        def initialize(*argv)
+          @argv = argv
+
+          @process = ChildProcess.build(*@argv)
+          @process.leader = true
+
+          @stdout = Tempfile.new('stdout').tap { |io| io.sync = true }
+          @stderr = Tempfile.new('stderr').tap { |io| io.sync = true }
+
+          @process.io.stdout = @stdout
+          @process.io.stderr = @stderr
+
+          # Default to running things in the system context.
+          @context = :system
+
+          # Extra environment vars to add to base set.
+          @environment = {}
+
+          # Register the ExecGroup when running in parallel
+          @exec_group = nil
+        end
+
+        def context=(new_context)
+          unless [:system, :module, :pwd].include?(new_context)
+            raise ArgumentError, _("Expected execution context to be :system or :module but got '%{context}'.") % { context: new_context }
+          end
+
+          @context = new_context
+        end
+
+        def register_spinner(spinner, opts = {})
+          return unless PDK::CLI::Util.interactive?
+          @success_message = opts.delete(:success)
+          @failure_message = opts.delete(:failure)
+
+          @spinner = spinner
+        end
+
+        def add_spinner(message, opts = {})
+          return unless PDK::CLI::Util.interactive?
+          @success_message = opts.delete(:success)
+          @failure_message = opts.delete(:failure)
+
+          @spinner = TTY::Spinner.new("[:spinner] #{message}", opts.merge(PDK::CLI::Util.spinner_opts_for_platform))
+        end
+
+        def update_environment(additional_env)
+          @environment.merge!(additional_env)
+        end
+
+        def execute!
+          # Start spinning if configured.
+          @spinner.auto_spin if @spinner
+
+          # Set env for child process
+          resolved_env_for_command.each { |k, v| @process.environment[k] = v }
+
+          if [:module, :pwd].include?(context)
+            mod_root = PDK::Util.module_root
+
+            unless mod_root
+              @spinner.error if @spinner
+
+              raise PDK::CLI::FatalError, _('Current working directory is not part of a module. (No metadata.json was found.)')
+            end
+
+            if Dir.pwd == mod_root || context == :pwd
+              run_process_in_clean_env!
+            else
+              Dir.chdir(mod_root) do
+                run_process_in_clean_env!
+              end
+            end
+          else
+            run_process!
+          end
+
+          # Stop spinning when done (if configured).
+          stop_spinner
+
+          @stdout.rewind
+          @stderr.rewind
+
+          process_data = {
+            stdout: @stdout.read,
+            stderr: @stderr.read,
+            exit_code: @process.exit_code,
+            duration: @duration,
+          }
+
+          PDK.logger.debug _('STDOUT: %{output}') % {
+            output: process_data[:stdout].empty? ? 'N/A' : "\n#{process_data[:stdout]}",
+          }
+          PDK.logger.debug _('STDERR: %{output}') % {
+            output: process_data[:stderr].empty? ? 'N/A' : "\n#{process_data[:stderr]}",
+          }
+
+          process_data
+        ensure
+          @stdout.close
+          @stderr.close
+        end
+
+        protected
+
+        def warn_on_legacy_env_vars!
+          if ENV['PUPPET_GEM_VERSION']
+            PDK.logger.warn_once _(
+              'PUPPET_GEM_VERSION is not supported by PDK. ' \
+              'Use the --puppet-version option on your PDK command ' \
+              'or set the PDK_PUPPET_VERSION environment variable instead',
+            )
+          end
+
+          %w[FACTER HIERA].each do |gem|
+            if ENV["#{gem}_GEM_VERSION"]
+              PDK.logger.warn_once _('%{varname} is not supported by PDK.') % { varname: "#{gem}_GEM_VERSION" }
+            end
+          end
+        end
+
+        def resolved_env_for_command
+          warn_on_legacy_env_vars!
+
+          resolved_env = {}
+
+          resolved_env['TERM'] = ENV['TERM']
+          resolved_env['PUPPET_GEM_VERSION'] = nil
+          resolved_env['FACTER_GEM_VERSION'] = nil
+          resolved_env['HIERA_GEM_VERSION'] = nil
+
+          resolved_env.merge!(@environment.dup)
+
+          resolved_env['BUNDLE_IGNORE_CONFIG'] = '1'
+
+          if [:module, :pwd].include?(context)
+            resolved_env['GEM_HOME'] = PDK::Util::RubyVersion.gem_home
+            resolved_env['GEM_PATH'] = PDK::Util::RubyVersion.gem_path
+
+            # Make sure invocation of Ruby prefers our private installation.
+            package_binpath = PDK::Util.package_install? ? File.join(PDK::Util.pdk_package_basedir, 'bin') : nil
+
+            resolved_env['PATH'] = [
+              PDK::Util::RubyVersion.bin_path,
+              File.join(resolved_env['GEM_HOME'], 'bin'),
+              PDK::Util::RubyVersion.gem_paths_raw.map { |gem_path| File.join(gem_path, 'bin') },
+              package_binpath,
+              PDK::Util.package_install? ? PDK::Util::Git.git_paths : nil,
+              ENV['PATH'],
+            ].compact.flatten.join(File::PATH_SEPARATOR)
+          end
+
+          resolved_env
+        end
+
+        def stop_spinner
+          return unless @spinner
+
+          # If it is a single spinner, we need to send it a success/error message
+          if @process.exit_code.zero?
+            @spinner.success(@success_message || '')
+          else
+            @spinner.error(@failure_message || '')
+          end
+        end
+
+        def run_process_in_clean_env!
+          ::Bundler.with_clean_env do
+            run_process!
+          end
+        end
+
+        def run_process!
+          command_string = argv.join(' ')
+
+          PDK.logger.debug(_("Executing '%{command}'") % { command: command_string })
+
+          if context == :module
+            PDK.logger.debug(_('Command environment:'))
+            @process.environment.each do |var, val|
+              PDK.logger.debug("  #{var}: #{val}")
+            end
+          end
+
+          start_time = Time.now
+
+          begin
+            @process.start
+          rescue ChildProcess::LaunchError => e
+            raise PDK::CLI::FatalError, _("Failed to execute '%{command}': %{message}") % { command: command_string, message: e.message }
+          end
+
+          if timeout
+            begin
+              @process.poll_for_exit(timeout)
+            rescue ChildProcess::TimeoutError
+              @process.stop # tries increasingly harsher methods to kill the process.
+            end
+          else
+            # Wait indfinitely if no timeout set.
+            @process.wait
+          end
+
+          @duration = Time.now - start_time
+
+          PDK.logger.debug(_("Execution of '%{command}' complete (duration: %{duration_in_seconds}s; exit code: %{exit_code})") %
+            { command: command_string, duration_in_seconds: @duration, exit_code: @process.exit_code })
+        end
+      end
+    end
+  end
+end

--- a/lib/pdk/cli/exec/command/interactive.rb
+++ b/lib/pdk/cli/exec/command/interactive.rb
@@ -1,0 +1,101 @@
+require 'pdk/cli/exec/command'
+
+module PDK
+  module CLI
+    module Exec
+      class InteractiveCommand < Command
+        def initialize(*argv)
+          @argv = argv
+
+          # Default to running things in the system context.
+          @context = :system
+
+          # Extra environment vars to add to base set.
+          @environment = {}
+        end
+
+        def register_spinner(_spinner, _opts = {})
+          raise _('This method is not implemented for PDK::CLI::Exec::InteractiveCommand')
+        end
+
+        def add_spinner(_message, _opts = {})
+          raise _('This method is not implemented for PDK::CLI::Exec::InteractiveCommand')
+        end
+
+        def timeout
+          raise _('This method is not implemented for PDK::CLI::Exec::InteractiveCommand')
+        end
+
+        def timeout=(_val)
+          raise _('This method is not implemented for PDK::CLI::Exec::InteractiveCommand')
+        end
+
+        def exec_group=(_val)
+          raise _('This method is not implemented for PDK::CLI::Exec::InteractiveCommand')
+        end
+
+        def execute!
+          @resolved_env = resolved_env_for_command
+
+          if [:module, :pwd].include?(context)
+            mod_root = PDK::Util.module_root
+
+            unless mod_root
+              raise PDK::CLI::FatalError, _('Current working directory is not part of a module. (No metadata.json was found.)')
+            end
+
+            unless context == :pwd || Dir.pwd == mod_root
+              orig_workdir = Dir.pwd
+              Dir.chdir(mod_root)
+            end
+
+            result = run_process_in_clean_env!
+          else
+            result = run_process!
+          end
+
+          {
+            interactive: true,
+            stdout: nil,
+            stderr: nil,
+            exit_code: result[:exit_code],
+            duration: result[:duration],
+          }
+        ensure
+          Dir.chdir(orig_workdir) if orig_workdir
+        end
+
+        protected
+
+        # TODO: debug logging
+        def run_process!
+          command_string = argv.join(' ')
+          PDK.logger.debug(_("Executing '%{command}' interactively") % { command: command_string })
+
+          if context == :module
+            PDK.logger.debug(_('Command environment:'))
+            @resolved_env.each do |var, val|
+              PDK.logger.debug("  #{var}: #{val}")
+            end
+          end
+
+          start_time = Time.now
+
+          # Use the string form of command to ensure command is invoked via a shell
+          system(@resolved_env, command_string)
+
+          duration = Time.now - start_time
+
+          PDK.logger.debug(_("Execution of '%{command}' complete (duration: %{duration_in_seconds}s; exit code: %{exit_code})") %
+            { command: command_string, duration_in_seconds: duration, exit_code: $CHILD_STATUS.exitstatus })
+
+          { exit_code: $CHILD_STATUS.exitstatus, duration: duration }
+        end
+
+        def stop_spinner
+          raise _('This method is not implemented for PDK::CLI::Exec::InteractiveCommand')
+        end
+      end
+    end
+  end
+end

--- a/lib/pdk/cli/exec/interactive_command.rb
+++ b/lib/pdk/cli/exec/interactive_command.rb
@@ -84,12 +84,22 @@ module PDK
           # Use the string form of command to ensure command is invoked via a shell
           system(@resolved_env, command_string)
 
+          exit_code = child_status.exitstatus
           duration = Time.now - start_time
 
-          PDK.logger.debug(_("Execution of '%{command}' complete (duration: %{duration_in_seconds}s; exit code: %{exit_code})") %
-            { command: command_string, duration_in_seconds: duration, exit_code: $CHILD_STATUS.exitstatus })
+          PDK.logger.debug(_("Execution of '%{command}' complete (duration: \
+                              %{duration_in_seconds}s; exit code: %{exit_code})") %
+                              {
+                                command: command_string,
+                                exit_code: exit_code,
+                                duration_in_seconds: duration,
+                              })
 
-          { exit_code: $CHILD_STATUS.exitstatus, duration: duration }
+          { exit_code: exit_code, duration: duration }
+        end
+
+        def child_status
+          $CHILD_STATUS
         end
 
         def stop_spinner

--- a/package-testing/spec/package/version_selection_spec.rb
+++ b/package-testing/spec/package/version_selection_spec.rb
@@ -33,13 +33,13 @@ describe 'Test puppet & ruby version selection' do
       describe command('pdk bundle exec puppet --version') do
         its(:exit_status) { is_expected.to eq(0) }
         its(:stderr) { is_expected.to match(%r{using puppet (#{expected_puppets})}im) }
-        its(:stderr) { is_expected.to match(%r{^(#{expected_puppets})$}im) }
+        its(:stdout) { is_expected.to match(%r{^(#{expected_puppets})$}im) }
       end
 
       describe command('pdk bundle exec ruby --version') do
         its(:exit_status) { is_expected.to eq(0) }
         its(:stderr) { is_expected.to match(%r{using ruby #{Regexp.escape(test_case[:expected_ruby])}[\.0-9]*}im) }
-        its(:stderr) { is_expected.to match(%r{^ruby #{Regexp.escape(test_case[:expected_ruby])}[\.0-9]*p}im) }
+        its(:stdout) { is_expected.to match(%r{^ruby #{Regexp.escape(test_case[:expected_ruby])}[\.0-9]*p}im) }
       end
     end
   end

--- a/spec/acceptance/bundle_spec.rb
+++ b/spec/acceptance/bundle_spec.rb
@@ -12,8 +12,7 @@ describe 'pdk bundle' do
 
     describe command('pdk bundle env') do
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stdout) { is_expected.to have_no_output }
-      its(:stderr) { is_expected.to match(%r{## Environment}) }
+      its(:stdout) { is_expected.to match(%r{## Environment}) }
     end
 
     context 'when running in a subdirectory of the module root' do
@@ -27,8 +26,7 @@ describe 'pdk bundle' do
 
       describe command('pdk bundle exec puppet-lint init.pp') do
         its(:exit_status) { is_expected.to eq(0) }
-        its(:stdout) { is_expected.to have_no_output }
-        its(:stderr) { is_expected.to match(%r{double quoted string}im) }
+        its(:stdout) { is_expected.to match(%r{double quoted string}im) }
       end
     end
 

--- a/spec/unit/pdk/cli/exec/interactive_command_spec.rb
+++ b/spec/unit/pdk/cli/exec/interactive_command_spec.rb
@@ -1,0 +1,178 @@
+require 'spec_helper'
+
+describe PDK::CLI::Exec::InteractiveCommand do
+  subject(:command) { described_class.new('/bin/echo', 'foo') }
+
+  before(:each) do
+    allow(PDK::CLI::Util).to receive(:ci_environment?).and_return(false)
+  end
+
+  describe '.context=' do
+    context 'when setting to an expected value' do
+      it 'accepts :system' do
+        expect { command.context = :system }.not_to raise_error
+        expect(command.context).to eq :system
+      end
+
+      it 'accepts :module' do
+        expect { command.context = :module }.not_to raise_error
+        expect(command.context).to eq :module
+      end
+
+      it 'rejects other values' do
+        expect { command.context = :foo }.to raise_error ArgumentError
+      end
+    end
+  end
+
+  describe '.add_spinner' do
+    it 'raises an exception' do
+      expect { command.add_spinner('test') }.to raise_error %r{method.*not implemented}i
+    end
+  end
+
+  describe '.register_spinner' do
+    let(:spinner) { instance_double('spinner') }
+
+    it 'raises an exception' do
+      expect { command.register_spinner(spinner) }.to raise_error %r{method.*not implemented}i
+    end
+  end
+
+  describe '.timeout=' do
+    it 'raises an exception' do
+      expect { command.timeout = 10 }.to raise_error %r{method.*not implemented}i
+    end
+  end
+
+  describe '.timeout' do
+    it 'raises an exception' do
+      expect { command.timeout }.to raise_error %r{method.*not implemented}i
+    end
+  end
+
+  describe '.exec_group=' do
+    let(:exec_group) { instance_double('exec_group') }
+
+    it 'raises an exception' do
+      expect { command.exec_group = exec_group }.to raise_error %r{method.*not implemented}i
+    end
+  end
+
+  describe '.execute!' do
+    let(:environment) { {} }
+
+    let(:exitstatus) { 0 }
+    let(:child_status) { instance_double(Process::Status, exitstatus: exitstatus) }
+
+    before(:each) do
+      # rubocop:disable RSpec/SubjectStub
+      allow(command).to receive(:resolved_env_for_command).and_return(environment)
+      allow(command).to receive(:system) # Kernel is a mixed-in module
+      allow(command).to receive(:child_status).and_return(child_status)
+      # rubocop:enable RSpec/SubjectStub
+    end
+
+    context 'when running in the :system context' do
+      before(:each) do
+        command.context = :system
+      end
+
+      it "executes in parent process' bundler env" do
+        expect(::Bundler).not_to receive(:with_clean_env)
+
+        command.execute!
+      end
+
+      it "returns child process' exit status" do
+        result = command.execute!
+
+        expect(result[:exit_code]).to eq(exitstatus)
+      end
+
+      context 'when child process exits non-zero' do
+        let(:exitstatus) { 1 }
+
+        it "returns child process' exit status" do
+          result = command.execute!
+
+          expect(result[:exit_code]).to eq(exitstatus)
+        end
+      end
+    end
+
+    context 'when running in the :module context' do
+      before(:each) do
+        command.context = :module
+      end
+
+      it 'changes into the modroot path and then returns to original pwd' do
+        allow(PDK::Util).to receive(:module_root).with(no_args).and_return('/modroot_path')
+        allow(Dir).to receive(:pwd).and_return('/current_path')
+
+        expect(Dir).to receive(:chdir).with('/modroot_path').ordered
+        expect(Dir).to receive(:chdir).with('/current_path').ordered
+
+        command.execute!
+      end
+
+      it "executes in module's bundler env" do
+        expect(::Bundler).to receive(:with_clean_env).and_call_original
+
+        command.execute!
+      end
+
+      it "returns child process' exit status" do
+        result = command.execute!
+
+        expect(result[:exit_code]).to eq(exitstatus)
+      end
+
+      context 'when child process exits non-zero' do
+        let(:exitstatus) { 1 }
+
+        it "returns child process' exit status" do
+          result = command.execute!
+
+          expect(result[:exit_code]).to eq(exitstatus)
+        end
+      end
+    end
+
+    context 'when running in the :pwd context' do
+      before(:each) do
+        command.context = :pwd
+      end
+
+      it 'does not change out of pwd' do
+        allow(PDK::Util).to receive(:module_root).with(no_args).and_return('/modroot_path')
+
+        expect(Dir).not_to receive(:chdir)
+
+        command.execute!
+      end
+
+      it "executes in module's bundler env" do
+        expect(::Bundler).to receive(:with_clean_env).and_call_original
+
+        command.execute!
+      end
+
+      it "returns child process' exit status" do
+        result = command.execute!
+
+        expect(result[:exit_code]).to eq(exitstatus)
+      end
+
+      context 'when child process exits non-zero' do
+        let(:exitstatus) { 1 }
+
+        it "returns child process' exit status" do
+          result = command.execute!
+
+          expect(result[:exit_code]).to eq(exitstatus)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously, the subprocess invoked by `pdk bundle` had its output
streams buffered as a side effect of the subprocess infrastructure used
for other commands. Additionally, the input stream was not connected to
the subprocess at all.

This commit adds a new subclass of `PDK::CLI::Exec::Command` called
`PDK::CLI::Exec::InteractiveCommand` that bypasses all of the output
buffering, spinners, etc. that the parent class implements and instead
uses Ruby's built-in `Kernel.system` method to run the subprocess fully
interactively. The `pdk bundle` subcommand is also updated to use this
new class for invoking Bundler.

If this approach proves successful, it will likely be conditionally
extended to certain invocations of `pdk test unit` in a future PR.