### PR TITLE
(PDK-1309) Ensure file modes in built modules are sane

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :test do
 end
 
 group :acceptance do
+  gem 'minitar-cli'
   gem 'serverspec'
 end
 


### PR DESCRIPTION
When building module tarballs for publishing, we need to sanitise the modes of the tarball entries. Directories should have at least 0755 and files should have at least 0644.