### PR TITLE
(maint) Expect pdk test unit to run more than 1 test

### DIFF
--- a/package-testing/spec/package/unit_test_a_new_module_spec.rb
+++ b/package-testing/spec/package/unit_test_a_new_module_spec.rb
@@ -26,7 +26,7 @@ describe 'Generate a module for unit testing' do
       let(:cwd) { module_name }
 
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stderr) { is_expected.to match(%r{evaluated 18 tests.*0 failures}im) }
+      its(:stderr) { is_expected.to match(%r{evaluated [1-9]\d* tests.*0 failures}im) }
     end
   end
 
@@ -35,7 +35,7 @@ describe 'Generate a module for unit testing' do
       let(:cwd) { module_name }
 
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stderr) { is_expected.to match(%r{evaluated 18 tests.*0 failures}im) }
+      its(:stderr) { is_expected.to match(%r{evaluated [1-9]\d* tests.*0 failures}im) }
     end
   end
 end


### PR DESCRIPTION
Relax this expectation a bit so that changes in the default operatingsystem list doesn't cause false failures.