### PR TITLE
(PDK-1107) Add pdk config get CLI command

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -143,6 +143,7 @@ module PDK::CLI
 
   require 'pdk/cli/bundle'
   require 'pdk/cli/build'
+  require 'pdk/cli/config'
   require 'pdk/cli/convert'
   require 'pdk/cli/new'
   require 'pdk/cli/test'

--- a/lib/pdk/cli/config.rb
+++ b/lib/pdk/cli/config.rb
@@ -1,0 +1,20 @@
+module PDK::CLI
+  @config_cmd = @base_cmd.define_command do
+    name 'config'
+    usage _('config [subcommand] [options]')
+    summary _('Configure the Puppet Development Kit.')
+    default_subcommand 'help'
+
+    run do |_opts, args, _cmd|
+      if args == ['help']
+        PDK::CLI.run(%w[config --help])
+        exit 0
+      end
+
+      PDK::CLI.run(%w[config help]) if args.empty?
+    end
+  end
+  @config_cmd.add_command Cri::Command.new_basic_help
+end
+
+require 'pdk/cli/config/get'

--- a/lib/pdk/cli/config/get.rb
+++ b/lib/pdk/cli/config/get.rb
@@ -1,0 +1,24 @@
+module PDK::CLI
+  @config_get_cmd = @config_cmd.define_command do
+    name 'get'
+    usage _('config get [name]')
+    summary _('Retrieve the configuration for <name>. If not specified, retrieve all configuration settings')
+
+    run do |_opts, args, _cmd|
+      item_name = args[0]
+      resolved_config = PDK.config.resolve(item_name)
+      # If the user wanted to know a setting but it doesn't exist, raise an error
+      if resolved_config.empty? && !item_name.nil?
+        PDK.logger.error(_("Configuration item '%{name}' does not exist") % { name: item_name })
+        exit 1
+      end
+      # If the user requested a setting and it's the only one resolved, then just output the value
+      if resolved_config.count == 1 && resolved_config.keys[0] == item_name
+        puts _('%{value}') % { value: resolved_config.values[0] }
+        exit 0
+      end
+      # Otherwise just output everything
+      resolved_config.keys.sort.each { |key| puts _('%{name}=%{value}') % { name: key, value: resolved_config[key] } }
+    end
+  end
+end

--- a/lib/pdk/config.rb
+++ b/lib/pdk/config.rb
@@ -33,6 +33,14 @@ module PDK
       end
     end
 
+    # Resolves *all* filtered settings from all namespaces
+    #
+    # @param filter [String] Only resolve setting names which match the filter. See PDK::Config::Namespace.be_resolved? for matching rules
+    # @return [Hash{String => Object}] All resolved settings for example {'user.module_defaults.author' => 'johndoe'}
+    def resolve(filter = nil)
+      user.resolve(filter)
+    end
+
     def self.bolt_analytics_config
       file = File.expand_path('~/.puppetlabs/bolt/analytics.yaml')
       PDK::Config::YAML.new(file: file)

--- a/spec/acceptance/config_get_spec.rb
+++ b/spec/acceptance/config_get_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper_acceptance'
+require 'fileutils'
+
+describe 'pdk config get' do
+  include_context 'with a fake TTY'
+
+  context 'when run outside of a module' do
+    describe command('pdk config get') do
+      its(:exit_status) { is_expected.to eq 0 }
+      # This setting should appear in all pdk versions
+      its(:stdout) { is_expected.to match(%r{user\.analytics\.user-id=}) }
+      its(:stderr) { is_expected.to have_no_output }
+    end
+
+    describe command('pdk config get user.analytics.disabled') do
+      its(:exit_status) { is_expected.to eq 0 }
+      # This setting, and only, this setting should appear in output
+      its(:stdout) { is_expected.to eq("true\n") }
+      its(:stderr) { is_expected.to have_no_output }
+    end
+
+    describe command('pdk config get user.analytics') do
+      its(:exit_status) { is_expected.to eq 0 }
+      # There should be two configuration items returned
+      its(:stdout) { expect(is_expected.target.split("\n").count).to eq(2) }
+      its(:stdout) do
+        result = is_expected.target.split("\n").sort
+        expect(result[0]).to match('user.analytics.disabled=true')
+        expect(result[1]).to match(%r{user.analytics.user-id=.+})
+      end
+      its(:stderr) { is_expected.to have_no_output }
+    end
+
+    describe command('pdk config get does.not.exist') do
+      its(:exit_status) { is_expected.not_to eq(0) }
+      its(:stdout) { is_expected.to have_no_output }
+      its(:stderr) { is_expected.to match(%r{does\.not\.exist}) }
+    end
+  end
+end

--- a/spec/acceptance/config_spec.rb
+++ b/spec/acceptance/config_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper_acceptance'
+require 'fileutils'
+
+describe 'pdk config' do
+  include_context 'with a fake TTY'
+
+  context 'when run outside of a module' do
+    describe command('pdk config') do
+      its(:exit_status) { is_expected.to eq 0 }
+      # Should show the command help
+      its(:stdout) { is_expected.to match(%r{pdk config \[subcommand\] \[options\]}) }
+      its(:stderr) { is_expected.to have_no_output }
+    end
+  end
+end

--- a/spec/unit/pdk/config_spec.rb
+++ b/spec/unit/pdk/config_spec.rb
@@ -96,6 +96,11 @@ describe PDK::Config do
       end
     end
 
+    def uuid_regex(uuid)
+      # Depending on the YAML or JSON generator, it may, or may not have quotes
+      %r{user-id: (?:#{uuid}|'#{uuid}'|\"#{uuid}\")}
+    end
+
     context 'default value' do
       context 'when there is no pre-existing bolt configuration' do
         it 'generates a new UUID' do
@@ -107,7 +112,7 @@ describe PDK::Config do
           new_id = SecureRandom.uuid
           expect(SecureRandom).to receive(:uuid).and_return(new_id)
           # Expect that the user-id is saved to the config file
-          expect(PDK::Util::Filesystem).to receive(:write_file).with(File.expand_path(described_class.analytics_config_path), %r{user-id: (?:|\'|'")#{new_id}(?:|\'|'")})
+          expect(PDK::Util::Filesystem).to receive(:write_file).with(File.expand_path(described_class.analytics_config_path), uuid_regex(new_id))
           # ... and that it returns the new id
           expect(config.user['analytics']['user-id']).to eq(new_id)
         end
@@ -123,7 +128,7 @@ describe PDK::Config do
 
         it 'saves the UUID to the analytics config file' do
           # Expect that the user-id is saved to the config file
-          expect(PDK::Util::Filesystem).to receive(:write_file).with(File.expand_path(described_class.analytics_config_path), %r{user-id: (?:|\'|'")#{uuid}(?:|\'|'")})
+          expect(PDK::Util::Filesystem).to receive(:write_file).with(File.expand_path(described_class.analytics_config_path), uuid_regex(uuid))
           config.user['analytics']['user-id']
         end
 
@@ -144,7 +149,7 @@ describe PDK::Config do
             new_id = SecureRandom.uuid
             expect(SecureRandom).to receive(:uuid).and_return(new_id)
             # Expect that the user-id is saved to the config file
-            expect(PDK::Util::Filesystem).to receive(:write_file).with(File.expand_path(described_class.analytics_config_path), %r{user-id: (?:|\'|'")#{new_id}(?:|\'|'")})
+            expect(PDK::Util::Filesystem).to receive(:write_file).with(File.expand_path(described_class.analytics_config_path), uuid_regex(new_id))
             # ... and that it returns the new id
             expect(config.user['analytics']['user-id']).to eq(new_id)
           end


### PR DESCRIPTION
- [x] ~~Needs to format as json?~~ punting. too hard and not needed
- [x] Do I need acceptance tests? wouldn't have thought so
- [x] Blocked by https://github.com/puppetlabs/pdk-planning/issues/40
- [x] ~~Add validation and schema~~  Separate PR #728 

---

Previously there was no way to display what the current configuration the PDK
was using.  This commit adds a `pdk config` command, with a single `get`
sub-command.

This commit also adds the ability to filter the settings either by a specific
name or setting treename.

This commit also adds tests for the new resolve method in the Namespace object.