### PR TITLE
(maint) Remove Hipchat notifications

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,11 +68,3 @@ test_script:
 # debugging purposes.
 # on_finish:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-
-notifications:
-  - provider: HipChat
-    auth_token:
-      secure: W9FwcoLtq+0XUqE3lM6m8zGdPdIOfHNafvdVD0qtoG0ra3C3hkseSaHR6uO8h/h2
-    room: 3519749
-    template: >
-      {{repositoryName}}#{{buildNumber}} ({{#isPullRequest}}PR {{pullRequestId}}{{/isPullRequest}}{{^isPullRequest}}{{branch}}{{/isPullRequest}} - {{commitId}} : {{commitAuthor}}): {{status}} (<a href="{{buildUrl}}">Details</a>{{#isPullRequest}} | <a href="https://github.com/{{repositoryName}}/pull/{{pullRequestId}}">PR</a>{{/isPullRequest}})


### PR DESCRIPTION
We no longer use Hipchat, so the notifications in Appveyor can be removed.