### PR TITLE
(FIXUP) Bypass shell invocation for PDK::CLI::Exec::InteractiveCommand

### DIFF
--- a/lib/pdk/cli/exec/interactive_command.rb
+++ b/lib/pdk/cli/exec/interactive_command.rb
@@ -81,8 +81,7 @@ module PDK
 
           start_time = Time.now
 
-          # Use the string form of command to ensure command is invoked via a shell
-          system(@resolved_env, command_string)
+          system(@resolved_env, *argv)
 
           exit_code = child_status.exitstatus
           duration = Time.now - start_time


### PR DESCRIPTION
Changing the Kernel#system call to invoke the command directly instead
of through a shell seems to fix the missing output issue on Windows when
Powershell is invoked through Cygwin.