### PR TITLE
(MAINT) Allow use of RSPEC_PATTERN env var when running package tests

### DIFF
--- a/package-testing/Rakefile
+++ b/package-testing/Rakefile
@@ -82,7 +82,7 @@ namespace :acceptance do
   desc 'Run acceptance tests against a pdk package'
   RSpec::Core::RakeTask.new(:package) do |t|
     t.rspec_opts = ['--format documentation']
-    t.pattern = 'spec/package/**/*_spec.rb'
+    t.pattern = ENV['RSPEC_PATTERN'] || 'spec/package/**/*_spec.rb'
   end
   task package: [:hostgen]
 


### PR DESCRIPTION
Lets you run a single file or test through the package-testing rake tasks.