### PR TITLE
(GH-722) Do not emit nil targets for validators against a directory

### DIFF
--- a/lib/pdk/validate/base_validator.rb
+++ b/lib/pdk/validate/base_validator.rb
@@ -52,14 +52,9 @@ module PDK
             if PDK::Util::Filesystem.directory?(target)
               target_root = PDK::Util.module_root
               pattern_glob = Array(pattern).map { |p| PDK::Util::Filesystem.glob(File.join(target_root, p), File::FNM_DOTMATCH) }
-              target_list = pattern_glob.flatten.map do |file|
-                if PDK::Util::Filesystem.fnmatch(File.join(PDK::Util::Filesystem.expand_path(PDK::Util.canonical_path(target)), '*'), file, File::FNM_DOTMATCH)
-                  Pathname.new(file).relative_path_from(Pathname.new(PDK::Util.module_root)).to_s
-                else
-                  PDK.logger.debug(_('%{validator}: Skipped \'%{target}\'. Target directory does not exist.') % { validator: name, target: target })
-                  nil
-                end
-              end
+              target_list = pattern_glob.flatten
+                                        .select { |glob| PDK::Util::Filesystem.fnmatch(File.join(PDK::Util::Filesystem.expand_path(PDK::Util.canonical_path(target)), '*'), glob, File::FNM_DOTMATCH) }
+                                        .map { |glob| Pathname.new(glob).relative_path_from(Pathname.new(PDK::Util.module_root)).to_s }
 
               ignore_list = ignore_pathspec
               target_list = target_list.reject { |file| ignore_list.match(file) }


### PR DESCRIPTION
Fixes #722 

Previously if the user passed a valid directory to a validator which did not
have a pattern glob which included that directory it emitted nil targets which
then broke the validator when it tried to actually use nil.

This commit:
* Changes the directory target list from a map to a select-map to only emit
valid directory targets, instead of emitting nils.
* Removes the debug message as the actual message was incorrect. Also the file
based codepath doesn't emit debug messages, so this brings the codepath into
alignment with that.
* Adds a unit test for the scenario of passing file and directory targets into
a validator with a pattern which doesn't match any of the targets.