### PR TITLE
Handle deleted template files for new module

### DIFF
--- a/lib/pdk/generate/module.rb
+++ b/lib/pdk/generate/module.rb
@@ -58,7 +58,8 @@ module PDK
 
         begin
           PDK::Module::TemplateDir.new(template_uri, metadata.data, true) do |templates|
-            templates.render do |file_path, file_content|
+            templates.render do |file_path, file_content, file_status|
+              next if file_status == :delete
               file = Pathname.new(temp_target_dir) + file_path
               file.dirname.mkpath
               write_file(file, file_content)

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -97,7 +97,7 @@ describe PDK::Generate::Module do
         allow(described_class).to receive(:prepare_module_directory).with(temp_target_dir)
         allow(File).to receive(:open).with(%r{pdk-test-writable}, anything) { raise Errno::EACCES unless target_parent_writeable }
         allow(FileUtils).to receive(:rm_f).with(%r{pdk-test-writable})
-        allow(test_template_dir).to receive(:render).and_yield('test_file_path', 'test_file_content')
+        allow(test_template_dir).to receive(:render).and_yield('test_file_path', 'test_file_content', :manage)
       end
 
       context 'when the parent directory of the target is not writable' do
@@ -122,7 +122,7 @@ describe PDK::Generate::Module do
         let(:content) { 'test_file_content' }
 
         before(:each) do
-          allow(test_template_dir).to receive(:render).and_yield('test_file_path', content)
+          allow(test_template_dir).to receive(:render).and_yield('test_file_path', content, :manage)
         end
 
         it 'writes the rendered files from the template to the temporary directory' do
@@ -130,6 +130,36 @@ describe PDK::Generate::Module do
 
           test_template_file.rewind
           expect(test_template_file.read).to eq(content + "\n")
+        end
+      end
+
+      context 'when the module template contains unmanaged template files' do
+        let(:content) { 'test_file_content' }
+
+        before(:each) do
+          allow(test_template_dir).to receive(:render).and_yield('test_file_path', content, :unmanage)
+        end
+
+        it 'writes the rendered files from the template to the temporary directory' do
+          described_class.invoke(invoke_opts)
+
+          test_template_file.rewind
+          expect(test_template_file.read).to eq(content + "\n")
+        end
+      end
+
+      context 'when the module template contains files with delete option set' do
+        let(:content) { 'test_file_content' }
+
+        before(:each) do
+          allow(test_template_dir).to receive(:render).and_yield('test_file_path', content, :delete)
+        end
+
+        it 'does not writes the deleted files from the template to the temporary directory' do
+          described_class.invoke(invoke_opts)
+
+          test_template_file.rewind
+          expect(test_template_file.read).to eq('')
         end
       end
 


### PR DESCRIPTION
When using `pdk new module` to create a new module, handle the
situation where the template used contains one or more files
with `delete: true` in `config_defaults.yml` instead of causing
an error.