### PR TITLE
(PDK-1107) Config fetch and [] should have no side effects

### DIFF
--- a/lib/pdk/config.rb
+++ b/lib/pdk/config.rb
@@ -15,7 +15,7 @@ module PDK
       @user ||= PDK::Config::JSON.new('user', file: PDK::Config.user_config_path) do
         mount :module_defaults, PDK::Config::JSON.new(file: PDK.answers.answer_file_path)
 
-        mount :analytics, PDK::Config::YAML.new(file: PDK::Config.analytics_config_path) do
+        mount :analytics, PDK::Config::YAML.new(file: PDK::Config.analytics_config_path, persistent_defaults: true) do
           value :disabled do
             validate PDK::Config::Validator.boolean
             default_to { PDK::Config.bolt_analytics_config.fetch('disabled', true) }

--- a/lib/pdk/util/filesystem.rb
+++ b/lib/pdk/util/filesystem.rb
@@ -30,6 +30,11 @@ module PDK
       end
       module_function :directory?
 
+      def mkdir_p(*args)
+        FileUtils.mkdir_p(*args)
+      end
+      module_function :mkdir_p
+
       def file?(*args)
         File.file?(*args)
       end

--- a/spec/unit/pdk/config_spec.rb
+++ b/spec/unit/pdk/config_spec.rb
@@ -45,6 +45,11 @@ describe PDK::Config do
         it 'returns true' do
           expect(config.user['analytics']['disabled']).to be_truthy
         end
+
+        it 'saves the disabled value to the analytics config file' do
+          expect(PDK::Util::Filesystem).to receive(:write_file).with(File.expand_path(described_class.analytics_config_path), %r{disabled: true})
+          config.user['analytics']['disabled']
+        end
       end
 
       context 'when there is a pre-existing bolt configuration' do
@@ -52,6 +57,11 @@ describe PDK::Config do
 
         it 'returns the value from the bolt configuration' do
           expect(config.user['analytics']['disabled']).to be_falsey
+        end
+
+        it 'saves the disabled value to the analytics config file' do
+          expect(PDK::Util::Filesystem).to receive(:write_file).with(File.expand_path(described_class.analytics_config_path), %r{disabled: false})
+          config.user['analytics']['disabled']
         end
 
         context 'and the bolt configuration is unparsable' do
@@ -64,6 +74,11 @@ describe PDK::Config do
 
           it 'returns true' do
             expect(config.user['analytics']['disabled']).to be_truthy
+          end
+
+          it 'saves the disabled value to the analytics config file' do
+            expect(PDK::Util::Filesystem).to receive(:write_file).with(File.expand_path(described_class.analytics_config_path), %r{disabled: true})
+            config.user['analytics']['disabled']
           end
         end
       end
@@ -87,6 +102,15 @@ describe PDK::Config do
           expect(SecureRandom).to receive(:uuid).and_call_original
           config.user['analytics']['user-id']
         end
+
+        it 'saves the UUID to the analytics config file' do
+          new_id = SecureRandom.uuid
+          expect(SecureRandom).to receive(:uuid).and_return(new_id)
+          # Expect that the user-id is saved to the config file
+          expect(PDK::Util::Filesystem).to receive(:write_file).with(File.expand_path(described_class.analytics_config_path), %r{user-id: (?:|\'|'")#{new_id}(?:|\'|'")})
+          # ... and that it returns the new id
+          expect(config.user['analytics']['user-id']).to eq(new_id)
+        end
       end
 
       context 'when there is a pre-existing bolt configuration' do
@@ -95,6 +119,12 @@ describe PDK::Config do
 
         it 'returns the value from the bolt configuration' do
           expect(config.user['analytics']['user-id']).to eq(uuid)
+        end
+
+        it 'saves the UUID to the analytics config file' do
+          # Expect that the user-id is saved to the config file
+          expect(PDK::Util::Filesystem).to receive(:write_file).with(File.expand_path(described_class.analytics_config_path), %r{user-id: (?:|\'|'")#{uuid}(?:|\'|'")})
+          config.user['analytics']['user-id']
         end
 
         context 'and the bolt configuration is unparsable' do
@@ -108,6 +138,15 @@ describe PDK::Config do
           it 'generates a new UUID' do
             expect(SecureRandom).to receive(:uuid).and_call_original
             config.user['analytics']['user-id']
+          end
+
+          it 'saves the UUID to the analytics config file' do
+            new_id = SecureRandom.uuid
+            expect(SecureRandom).to receive(:uuid).and_return(new_id)
+            # Expect that the user-id is saved to the config file
+            expect(PDK::Util::Filesystem).to receive(:write_file).with(File.expand_path(described_class.analytics_config_path), %r{user-id: (?:|\'|'")#{new_id}(?:|\'|'")})
+            # ... and that it returns the new id
+            expect(config.user['analytics']['user-id']).to eq(new_id)
           end
         end
       end


### PR DESCRIPTION
Previously even querying a configuration setting would save the default value to
disk. This is undesirable, and not expected as a user, because not all defaults
should persist on disk, across multiple PDK sessions/projects/modules. This
commit:

* Modifies the Config::Namespace class to have a new parameter called
  persistent_defaults.
* Modified the [] and fetch methods in Namespace to optioally call save_data
  when a default value is queried and persistent_defaults is set to true. This
  is affected in #default_config_value method.
* Added a wrapper method for mkdir_p for the FileSystem class so it could be
  mocked correctly in tests.  Currently it was creating folder structures in the
  root of the PDK project.
* Updated the namespace and config tests to ensure that the analytics settings
  use the persistent_defaults Namespace setting.