### PR TITLE
(PDK-1363) Apply init templates during module convert

### DIFF
--- a/lib/pdk/module/convert.rb
+++ b/lib/pdk/module/convert.rb
@@ -74,7 +74,7 @@ module PDK
 
           if options[:noop] && new_metadata.nil?
             update_manager.add_file(metadata_path, '')
-          elsif File.file?(metadata_path)
+          elsif PDK::Util::Filesystem.file?(metadata_path)
             update_manager.modify_file(metadata_path, new_metadata.to_json)
           else
             update_manager.add_file(metadata_path, new_metadata.to_json)
@@ -86,7 +86,7 @@ module PDK
             elsif file_status == :delete
               update_manager.remove_file(file_path)
             elsif file_status == :manage
-              if File.exist? file_path
+              if PDK::Util::Filesystem.exist?(file_path)
                 update_manager.modify_file(file_path, file_content)
               else
                 update_manager.add_file(file_path, file_content)
@@ -107,8 +107,8 @@ module PDK
       end
 
       def update_metadata(metadata_path, template_metadata)
-        if File.file?(metadata_path)
-          unless File.readable?(metadata_path)
+        if PDK::Util::Filesystem.file?(metadata_path)
+          unless PDK::Util::Filesystem.readable?(metadata_path)
             raise PDK::CLI::ExitWithError, _('Unable to update module metadata; %{path} exists but it is not readable.') % {
               path: metadata_path,
             }
@@ -124,7 +124,7 @@ module PDK
           rescue ArgumentError
             metadata = PDK::Generate::Module.prepare_metadata(options) unless options[:noop]
           end
-        elsif File.exist?(metadata_path)
+        elsif PDK::Util::Filesystem.exist?(metadata_path)
           raise PDK::CLI::ExitWithError, _('Unable to update module metadata; %{path} exists but it is not a file.') % {
             path: metadata_path,
           }

--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -94,16 +94,16 @@ module PDK
           raise ArgumentError, _('Cannot read metadata from file: no path to file was given.')
         end
 
-        unless File.file?(metadata_json_path)
+        unless PDK::Util::Filesystem.file?(metadata_json_path)
           raise ArgumentError, _("'%{file}' does not exist or is not a file.") % { file: metadata_json_path }
         end
 
-        unless File.readable?(metadata_json_path)
+        unless PDK::Util::Filesystem.readable?(metadata_json_path)
           raise ArgumentError, _("Unable to open '%{file}' for reading.") % { file: metadata_json_path }
         end
 
         begin
-          data = JSON.parse(File.read(metadata_json_path))
+          data = JSON.parse(PDK::Util::Filesystem.read_file(metadata_json_path))
         rescue JSON::JSONError => e
           raise ArgumentError, _('Invalid JSON in metadata.json: %{msg}') % { msg: e.message }
         end

--- a/lib/pdk/module/templatedir.rb
+++ b/lib/pdk/module/templatedir.rb
@@ -122,7 +122,12 @@ module PDK
           PDK.logger.debug(_("Rendering '%{template}'...") % { template: template_file })
           dest_path = template_file.sub(%r{\.erb\Z}, '')
           config = config_for(dest_path)
-          dest_status = :manage
+
+          dest_status = if template_loc.start_with?(@moduleroot_init)
+                          :init
+                        else
+                          :manage
+                        end
 
           if config['unmanaged']
             dest_status = :unmanage

--- a/lib/pdk/util/filesystem.rb
+++ b/lib/pdk/util/filesystem.rb
@@ -49,6 +49,11 @@ module PDK
         File.fnmatch(*args)
       end
       module_function :fnmatch
+
+      def readable?(*args)
+        File.readable?(*args)
+      end
+      module_function :readable?
       #:nocov:
     end
   end

--- a/lib/pdk/util/filesystem.rb
+++ b/lib/pdk/util/filesystem.rb
@@ -54,6 +54,11 @@ module PDK
         File.readable?(*args)
       end
       module_function :readable?
+
+      def exist?(*args)
+        File.exist?(*args)
+      end
+      module_function :exist?
       #:nocov:
     end
   end

--- a/spec/acceptance/convert_spec.rb
+++ b/spec/acceptance/convert_spec.rb
@@ -135,4 +135,21 @@ describe 'pdk convert', module_command: true do
       it { is_expected.not_to be_file }
     end
   end
+
+  context 'when an init-only templated file is missing' do
+    include_context 'in a new module', 'init_missing', template: template_repo
+
+    before(:all) do
+      FileUtils.rm_f('README.md')
+    end
+
+    describe command("#{pdk_convert_base} --force --skip-interview") do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stderr) { is_expected.to have_no_output }
+      its(:stdout) { is_expected.to match(%r{-+files to be added-+\nREADME\.md}mi) }
+      describe file('README.md') do
+        it { is_expected.to be_file }
+      end
+    end
+  end
 end

--- a/spec/acceptance/update_spec.rb
+++ b/spec/acceptance/update_spec.rb
@@ -62,5 +62,21 @@ describe 'pdk update', module_command: true do
         end
       end
     end
+
+    context 'that is missing an init-only templated file' do
+      before(:all) do
+        FileUtils.rm_f('README.md')
+      end
+
+      describe command('pdk update --force') do
+        its(:exit_status) { is_expected.to eq(0) }
+        its(:stderr) { is_expected.to have_no_output }
+        its(:stdout) { is_expected.to match(%r{no changes required}i) }
+
+        describe file('README.md') do
+          it { is_expected.not_to be_file }
+        end
+      end
+    end
   end
 end

--- a/spec/unit/pdk/module/convert_spec.rb
+++ b/spec/unit/pdk/module/convert_spec.rb
@@ -120,7 +120,7 @@ describe PDK::Module::Convert do
       include_context 'no changes in the summary'
 
       before(:each) do
-        allow(File).to receive(:exist?).with('a/path/to/file').and_return(true)
+        allow(PDK::Util::Filesystem).to receive(:exist?).with('a/path/to/file').and_return(true)
         allow(update_manager).to receive(:changes?).and_return(false)
         allow(template_dir).to receive(:render)
         allow(PDK::Module::TemplateDir).to receive(:files_in_template).and_return({})
@@ -141,7 +141,7 @@ describe PDK::Module::Convert do
       include_context 'completes a convert'
 
       before(:each) do
-        allow(File).to receive(:exist?).with('a/path/to/file').and_return(true)
+        allow(PDK::Util::Filesystem).to receive(:exist?).with('a/path/to/file').and_return(true)
         allow(update_manager).to receive(:modify_file).with(any_args)
         allow(update_manager).to receive(:changes?).and_return(true)
         allow($stdout).to receive(:puts).with(['Gemfile'])
@@ -182,7 +182,7 @@ describe PDK::Module::Convert do
       include_context 'completes a convert'
 
       before(:each) do
-        allow(File).to receive(:exist?).with('a/path/to/file').and_return(true)
+        allow(PDK::Util::Filesystem).to receive(:exist?).with('a/path/to/file').and_return(true)
         allow(update_manager).to receive(:modify_file).with(any_args)
         allow(update_manager).to receive(:changes?).and_return(true)
         allow($stdout).to receive(:puts).with(['some/file'])
@@ -274,7 +274,7 @@ describe PDK::Module::Convert do
       end
 
       before(:each) do
-        allow(File).to receive(:exist?).with('a/path/to/file').and_return(false)
+        allow(PDK::Util::Filesystem).to receive(:exist?).with('a/path/to/file').and_return(false)
         allow(update_manager).to receive(:changes?).and_return(true)
         allow($stdout).to receive(:puts).with(['path/to/file'])
 
@@ -396,18 +396,18 @@ describe PDK::Module::Convert do
 
     context 'when the metadata file exists' do
       before(:each) do
-        allow(File).to receive(:exist?).with(metadata_path).and_return(true)
+        allow(PDK::Util::Filesystem).to receive(:exist?).with(metadata_path).and_return(true)
       end
 
       context 'and is a file' do
         before(:each) do
-          allow(File).to receive(:file?).with(metadata_path).and_return(true)
+          allow(PDK::Util::Filesystem).to receive(:file?).with(metadata_path).and_return(true)
         end
 
         context 'and is readable' do
           before(:each) do
-            allow(File).to receive(:readable?).with(metadata_path).and_return(true)
-            allow(File).to receive(:read).with(metadata_path).and_return(existing_metadata)
+            allow(PDK::Util::Filesystem).to receive(:readable?).with(metadata_path).and_return(true)
+            allow(PDK::Util::Filesystem).to receive(:read_file).with(metadata_path).and_return(existing_metadata)
           end
 
           let(:existing_metadata) do
@@ -453,7 +453,7 @@ describe PDK::Module::Convert do
 
         context 'and is not readable' do
           before(:each) do
-            allow(File).to receive(:readable?).with(metadata_path).and_return(false)
+            allow(PDK::Util::Filesystem).to receive(:readable?).with(metadata_path).and_return(false)
           end
 
           it 'exits with an error' do
@@ -466,7 +466,7 @@ describe PDK::Module::Convert do
 
       context 'and is not a file' do
         before(:each) do
-          allow(File).to receive(:file?).with(metadata_path).and_return(false)
+          allow(PDK::Util::Filesystem).to receive(:file?).with(metadata_path).and_return(false)
         end
 
         it 'exits with an error' do

--- a/spec/unit/pdk/module/metadata_spec.rb
+++ b/spec/unit/pdk/module/metadata_spec.rb
@@ -15,18 +15,18 @@ describe PDK::Module::Metadata do
     end
 
     it 'can populate itself from a metadata.json file on disk' do
-      allow(File).to receive(:file?).with(metadata_json_path).and_return(true)
-      allow(File).to receive(:readable?).with(metadata_json_path).and_return(true)
+      allow(PDK::Util::Filesystem).to receive(:file?).with(metadata_json_path).and_return(true)
+      allow(PDK::Util::Filesystem).to receive(:readable?).with(metadata_json_path).and_return(true)
       allow(PDK::Util).to receive(:package_install?).and_return(false)
-      allow(File).to receive(:read).with(metadata_json_path).and_return(metadata_json_content)
+      allow(PDK::Util::Filesystem).to receive(:read_file).with(metadata_json_path).and_return(metadata_json_content)
 
       expect(described_class.from_file(metadata_json_path).data).to include('name' => 'foo-bar', 'version' => '0.1.0')
     end
 
     it 'can populate itself from a metadata.json file on disk with a trailing newline' do
-      allow(File).to receive(:file?).with(metadata_json_path).and_return(true)
-      allow(File).to receive(:readable?).with(metadata_json_path).and_return(true)
-      allow(File).to receive(:read).with(metadata_json_path).and_return(metadata_json_content + "\n")
+      allow(PDK::Util::Filesystem).to receive(:file?).with(metadata_json_path).and_return(true)
+      allow(PDK::Util::Filesystem).to receive(:readable?).with(metadata_json_path).and_return(true)
+      allow(PDK::Util::Filesystem).to receive(:read_file).with(metadata_json_path).and_return(metadata_json_content + "\n")
 
       expect(described_class.from_file(metadata_json_path).data).to include('name' => 'foo-bar', 'version' => '0.1.0')
     end
@@ -36,21 +36,21 @@ describe PDK::Module::Metadata do
     end
 
     it 'raises an ArgumentError if the file does not exist' do
-      allow(File).to receive(:file?).with(metadata_json_path).and_return(false)
+      allow(PDK::Util::Filesystem).to receive(:file?).with(metadata_json_path).and_return(false)
       expect { described_class.from_file(metadata_json_path) }.to raise_error(ArgumentError, %r{'#{metadata_json_path}'.*not exist})
     end
 
     it 'raises an ArgumentError if the file exists but is not readable' do
-      allow(File).to receive(:file?).with(metadata_json_path).and_return(true)
-      allow(File).to receive(:readable?).with(metadata_json_path).and_return(false)
+      allow(PDK::Util::Filesystem).to receive(:file?).with(metadata_json_path).and_return(true)
+      allow(PDK::Util::Filesystem).to receive(:readable?).with(metadata_json_path).and_return(false)
 
       expect { described_class.from_file(metadata_json_path) }.to raise_error(ArgumentError, %r{Unable to open '#{metadata_json_path}'})
     end
 
     it 'raises an ArgumentError if the file contains invalid JSON' do
-      allow(File).to receive(:file?).with(metadata_json_path).and_return(true)
-      allow(File).to receive(:readable?).with(metadata_json_path).and_return(true)
-      allow(File).to receive(:read).with(metadata_json_path).and_return('{"foo": }')
+      allow(PDK::Util::Filesystem).to receive(:file?).with(metadata_json_path).and_return(true)
+      allow(PDK::Util::Filesystem).to receive(:readable?).with(metadata_json_path).and_return(true)
+      allow(PDK::Util::Filesystem).to receive(:read_file).with(metadata_json_path).and_return('{"foo": }')
 
       expect { described_class.from_file(metadata_json_path) }.to raise_error(ArgumentError, %r{Invalid JSON.*unexpected token})
     end

--- a/spec/unit/pdk/module/update_spec.rb
+++ b/spec/unit/pdk/module/update_spec.rb
@@ -344,4 +344,10 @@ describe PDK::Module::Update do
       end
     end
   end
+
+  describe '#convert?' do
+    subject { described_class.new.convert? }
+
+    it { is_expected.to be_falsey }
+  end
 end


### PR DESCRIPTION
During `pdk convert`, if there are init-only templates for files that do not exist in the module, create them as would be done during `pdk new module`.

Coverage dropped a bit because there isn't much in the way of unit tests for `PDK::Module::TemplateDir` currently and I don't want this change to get bogged down working on that.