### PR TITLE
(PDK-1465) Remove net-ssh from gemspec

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'json-schema', '2.8.0'
   spec.add_runtime_dependency 'json_pure', '~> 2.1.0'
   spec.add_runtime_dependency 'minitar', '~> 0.6.1'
-  spec.add_runtime_dependency 'net-ssh', '~> 4.2.0'
   spec.add_runtime_dependency 'pathspec', '~> 0.2.1'
   spec.add_runtime_dependency 'tty-prompt', '~> 0.13'
   spec.add_runtime_dependency 'tty-spinner', '~> 0.5'


### PR DESCRIPTION
Previously the net-ssh gem was required for beaker on older ruby versions
however this dependency is being moved to the module metagems.  This commit
removes the gem from the gemspec.