### PR TITLE
(PDK-1464) Update nokogiri due to CVE-2019-5477

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ if RUBY_VERSION < '2.4.0'
   gem 'cri', '>= 2.10.1', '< 2.11.0'
   gem 'nokogiri', '1.7.2'
 else
-  gem 'nokogiri', '~> 1.8.5' # rubocop:disable Bundler/DuplicatedGem
+  gem 'nokogiri', '~> 1.10.4' # rubocop:disable Bundler/DuplicatedGem
 end
 
 group :development do


### PR DESCRIPTION
This commit updates the minimum nokogiri version to 1.10.4 to mitigate against
CVE-2019-5477.  The PDK package will be updated in a separate commit.