### PR TITLE
(PDK-680) Make `pdk test unit` interactive by default

### DIFF
--- a/lib/pdk/cli/test/unit.rb
+++ b/lib/pdk/cli/test/unit.rb
@@ -70,8 +70,10 @@ module PDK::CLI
 
         report = PDK::Report.new
         report_formats = if opts[:format]
+                           opts[:interactive] = false
                            PDK::CLI::Util::OptionNormalizer.report_formats(opts[:format])
                          else
+                           opts[:interactive] = true
                            [{
                              method: PDK::Report.default_format,
                              target: PDK::Report.default_target,

--- a/spec/acceptance/new_class_spec.rb
+++ b/spec/acceptance/new_class_spec.rb
@@ -14,8 +14,8 @@ describe 'pdk new class', module_command: true do
 
     describe command('pdk test unit') do
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stderr) { is_expected.to match(%r{0 failures}) }
-      its(:stderr) { is_expected.not_to match(%r{no examples found}i) }
+      its(:stdout) { is_expected.to match(%r{0 failures}) }
+      its(:stdout) { is_expected.not_to match(%r{no examples found}i) }
     end
   end
 

--- a/spec/acceptance/new_defined_type_spec.rb
+++ b/spec/acceptance/new_defined_type_spec.rb
@@ -14,8 +14,8 @@ describe 'pdk new defined_type', module_command: true do
 
     describe command('pdk test unit') do
       its(:exit_status) { is_expected.to eq(0) }
-      its(:stderr) { is_expected.to match(%r{0 failures}) }
-      its(:stderr) { is_expected.not_to match(%r{no examples found}i) }
+      its(:stdout) { is_expected.to match(%r{0 failures}) }
+      its(:stdout) { is_expected.not_to match(%r{no examples found}i) }
     end
   end
 

--- a/spec/acceptance/new_provider_spec.rb
+++ b/spec/acceptance/new_provider_spec.rb
@@ -75,8 +75,8 @@ SYNC
         end
 
         describe command('pdk test unit') do
-          its(:stderr) { is_expected.to match(%r{0 failures}) }
-          its(:stderr) { is_expected.not_to match(%r{no examples found}i) }
+          its(:stdout) { is_expected.to match(%r{0 failures}) }
+          its(:stdout) { is_expected.not_to match(%r{no examples found}i) }
           its(:exit_status) { is_expected.to eq(0) }
         end
       end

--- a/spec/acceptance/new_transport_spec.rb
+++ b/spec/acceptance/new_transport_spec.rb
@@ -85,8 +85,8 @@ SYNC
         end
 
         describe command('pdk test unit') do
-          its(:stderr) { is_expected.to match(%r{0 failures}) }
-          its(:stderr) { is_expected.not_to match(%r{no examples found}i) }
+          its(:stdout) { is_expected.to match(%r{0 failures}) }
+          its(:stdout) { is_expected.not_to match(%r{no examples found}i) }
           its(:exit_status) { is_expected.to eq(0) }
         end
       end

--- a/spec/acceptance/test_unit_spec.rb
+++ b/spec/acceptance/test_unit_spec.rb
@@ -15,17 +15,14 @@ describe 'pdk test unit', module_command: true do
     describe command('pdk test unit') do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to match(%r{preparing to run the unit tests}i) }
-      its(:stderr) { is_expected.to match(%r{running unit tests}i) }
-      its(:stderr) { is_expected.to match(%r{no examples found}i) }
-      its(:stderr) { is_expected.to match(%r{evaluated 0 tests}i) }
+      its(:stdout) { is_expected.to match(%r{no examples found}i) }
+      its(:stdout) { is_expected.to match(%r{0 examples, 0 failures}i) }
     end
 
     describe command('pdk test unit --parallel') do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to match(%r{preparing to run the unit tests}i) }
-      its(:stderr) { is_expected.to match(%r{running unit tests in parallel}i) }
-      its(:stderr) { is_expected.to match(%r{no examples found}i) }
-      its(:stderr) { is_expected.to match(%r{evaluated 0 tests}i) }
+      its(:stderr) { is_expected.to match(%r{No files for parallel_spec to run against}i) }
     end
 
     context 'with passing tests' do
@@ -61,13 +58,13 @@ describe 'pdk test unit', module_command: true do
       describe command('pdk test unit') do
         its(:exit_status) { is_expected.to eq(0) }
         its(:stderr) { is_expected.to match(%r{preparing to run the unit tests}i) }
-        its(:stderr) { is_expected.to match(%r{running unit tests.*[1-9]\d* tests.*0 failures}im) }
+        its(:stdout) { is_expected.to match(%r{[1-9]\d* examples?.*0 failures}im) }
       end
 
       describe command('pdk test unit --parallel') do
         its(:exit_status) { is_expected.to eq(0) }
         its(:stderr) { is_expected.to match(%r{preparing to run the unit tests}i) }
-        its(:stderr) { is_expected.to match(%r{running unit tests in parallel.*[1-9]\d* tests.*0 failures}im) }
+        its(:stdout) { is_expected.to match(%r{[1-9]\d* examples?.*0 failures}im) }
       end
     end
 
@@ -94,7 +91,7 @@ describe 'pdk test unit', module_command: true do
       describe command('pdk test unit') do
         its(:exit_status) { is_expected.not_to eq(0) }
         its(:stdout) { is_expected.to match(%r{failed.*expected: true.*got: false}im) }
-        its(:stderr) { is_expected.to match(%r{running unit tests.*1 tests.*1 failures}im) }
+        its(:stdout) { is_expected.to match(%r{1 examples?.*1 failures?}im) }
       end
     end
 
@@ -121,7 +118,7 @@ describe 'pdk test unit', module_command: true do
 
       describe command('pdk test unit') do
         its(:exit_status) { is_expected.to eq(0) }
-        its(:stderr) { is_expected.to match(%r{running unit tests.*1 tests.*0 failures.*1 pending}im) }
+        its(:stdout) { is_expected.to match(%r{1 examples?.*0 failures.*1 pending}im) }
       end
     end
 
@@ -157,8 +154,8 @@ describe 'pdk test unit', module_command: true do
 
       describe command('pdk test unit') do
         its(:exit_status) { is_expected.not_to eq(0) }
-        its(:stderr) { is_expected.to match(%r{An error occurred while loading.*syntax_spec.rb}) }
-        its(:stderr) { is_expected.to match(%r{SyntaxError}) }
+        its(:stdout) { is_expected.to match(%r{An error occurred while loading.*syntax_spec.rb}) }
+        its(:stdout) { is_expected.to match(%r{SyntaxError}) }
       end
     end
 
@@ -204,12 +201,13 @@ describe 'pdk test unit', module_command: true do
 
       describe command('pdk test unit') do
         its(:exit_status) { is_expected.to eq(0) }
-        its(:stderr) { is_expected.to match(%r{running unit tests.*[1-9]\d* tests.*0 failures}im) }
+        its(:stdout) { is_expected.to match(%r{[1-9]\d* examples?.*0 failures}im) }
       end
 
       describe command('pdk test unit --parallel') do
         its(:exit_status) { is_expected.to eq(0) }
-        its(:stderr) { is_expected.to match(%r{running unit tests in parallel.*[1-9]\d* tests.*0 failures}im) }
+        its(:stdout) { is_expected.to match(%r{[1-9]\d* processes for [1-9]\d* specs}m) }
+        its(:stdout) { is_expected.to match(%r{[1-9]\d* examples?.*0 failures}im) }
       end
     end
 

--- a/spec/unit/pdk/cli/test/unit_spec.rb
+++ b/spec/unit/pdk/cli/test/unit_spec.rb
@@ -127,7 +127,16 @@ describe '`pdk test unit`' do
 
       context 'when passed --clean-fixtures' do
         it 'invokes the command with :clean-fixtures => true' do
-          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, hash_with_defaults_including(:puppet => puppet_version, :tests => anything, :'clean-fixtures' => true)).once.and_return(0)
+          expect(PDK::Test::Unit).to receive(:invoke).with(
+            reporter,
+            hash_with_defaults_including(
+              :puppet           => puppet_version,
+              :tests            => anything,
+              :'clean-fixtures' => true,
+              :interactive      => true,
+            ),
+          ).once.and_return(0)
+
           expect {
             test_unit_cmd.run_this(['--clean-fixtures'])
           }.to exit_zero
@@ -149,7 +158,7 @@ describe '`pdk test unit`' do
 
       context 'when not passed --clean-fixtures' do
         it 'invokes the command without :clean-fixtures' do
-          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, hash_with_defaults_including(puppet: puppet_version, tests: anything)).once.and_return(0)
+          expect(PDK::Test::Unit).to receive(:invoke).with(reporter, hash_with_defaults_including(puppet: puppet_version, tests: anything, interactive: true)).once.and_return(0)
           expect {
             test_unit_cmd.run_this([])
           }.to exit_zero
@@ -169,11 +178,9 @@ describe '`pdk test unit`' do
       end
 
       context 'when tests pass' do
-        before(:each) do
+        it 'exits cleanly' do
           expect(PDK::Test::Unit).to receive(:invoke).with(reporter, hash_with_defaults_including(tests: anything)).once.and_return(0)
-        end
 
-        it do
           expect { test_unit_cmd.run_this([]) }.to exit_zero
         end
 
@@ -192,6 +199,7 @@ describe '`pdk test unit`' do
         context 'with a format option' do
           before(:each) do
             expect(PDK::CLI::Util::OptionNormalizer).to receive(:report_formats).with(['text:results.txt']).and_return([{ method: :write_text, target: 'results.txt' }]).at_least(:twice)
+            expect(PDK::Test::Unit).to receive(:invoke).with(reporter, hash_with_defaults_including(tests: anything, interactive: false)).once.and_return(0)
           end
 
           it do
@@ -216,6 +224,7 @@ describe '`pdk test unit`' do
 
           before(:each) do
             expect(PDK::CLI::Util::OptionValidator).to receive(:comma_separated_list?).with(tests).and_return(true)
+            expect(PDK::Test::Unit).to receive(:invoke).with(reporter, hash_with_defaults_including(tests: anything, interactive: true)).once.and_return(0)
           end
 
           it do

--- a/spec/unit/pdk/test/unit_spec.rb
+++ b/spec/unit/pdk/test/unit_spec.rb
@@ -278,6 +278,7 @@ describe PDK::Test::Unit do
 
   describe '.invoke' do
     let(:report) { PDK::Report.new }
+    let(:rspec_json_output) { '{}' }
 
     before(:each) do
       allow(PDK::Util::Bundler).to receive(:ensure_bundle!)
@@ -287,6 +288,30 @@ describe PDK::Test::Unit do
       allow(described_class).to receive(:tear_down)
       allow_any_instance_of(PDK::CLI::Exec::Command).to receive(:execute!).and_return(stdout: rspec_json_output, exit_code: -1)
       allow(described_class).to receive(:parse_output)
+    end
+
+    context 'when running interactively' do
+      subject(:exit_code) do
+        described_class.invoke(report, interactive: true)
+      end
+
+      before(:each) do
+        allow(PDK::CLI::Exec::InteractiveCommand).to receive(:new)
+          .and_return(command)
+      end
+
+      let(:command) do
+        instance_double(
+          PDK::CLI::Exec::InteractiveCommand,
+          :context=     => true,
+          :environment= => true,
+        )
+      end
+
+      it 'runs the rake task interactively' do
+        expect(command).to receive(:execute!).and_return(exit_code: 0)
+        expect(exit_code).to eq(0)
+      end
     end
 
     context 'in parallel without examples' do


### PR DESCRIPTION
```
semirhage :0: pdk/foo (git:pdk-680 → origin {3} ?:1!)$ ../bin/pdk test unit --interactive
pdk (INFO): Using Ruby 2.4.6
pdk (INFO): Using Puppet 6.8.1
[✔] Preparing to run the unit tests.
/home/tsharpe/.rbenv/versions/2.4.6/bin/ruby -I/home/tsharpe/.pdk/cache/ruby/2.4.0/gems/rspec-core-3.8.2/lib:/home/tsharpe/.pdk/cache/ruby/2.4.0/gems/rspec-support-3.8.2/lib /home/tsharpe/.pdk/cache/ruby/2.4.0/gems/rspec-core-3.8.2/exe/rspec --pattern spec/\{aliases,classes,defines,functions,hosts,integration,plans,tasks,type_aliases,types,unit\}/\*\*/\*_spec.rb
Failed to retrieve Augeas version: cannot load such file -- augeas
Run options: exclude {:bolt=>true}

foo::bar
  on oraclelinux-7-x86_64

From: /home/tsharpe/code/puppetlabs/pdk/foo/spec/classes/bar_spec.rb @ line 9 :

     4: describe 'foo::bar' do
     5:   on_supported_os.each do |os, os_facts|
     6:     context "on #{os}" do
     7:       let(:facts) { os_facts }
     8:
 =>  9:       it { binding.pry; is_expected.to compile }
    10:     end
    11:   end
    12: end

[1] pry(#<RSpec::ExampleGroups::FooBar::OnOraclelinux7X8664>)>
```