### PR TITLE
(feat) - Add new utility method for fixtures dir

### DIFF
--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -132,6 +132,14 @@ module PDK
     end
     module_function :module_root
 
+    # The module's fixtures directory for spec testing
+    # @return [String] - the path to the module's fixtures directory
+    def module_fixtures_dir
+      dir = module_root
+      File.join(module_root, 'spec', 'fixtures') unless dir.nil?
+    end
+    module_function :module_fixtures_dir
+
     # Returns true or false depending on if any of the common directories in a module
     # are found in the current directory
     #

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -300,6 +300,33 @@ describe PDK::Util do
     end
   end
 
+  describe '.module_fixtures_dir' do
+    subject { described_class.module_fixtures_dir }
+
+    before(:each) do
+      allow(described_class).to receive(:find_upwards).with('metadata.json').and_return(metadata_path)
+      allow(described_class).to receive(:in_module_root?).and_return(in_module_root)
+    end
+
+    context 'inside a module' do
+      let(:metadata_path) { '/path/to/the/module/metadata.json' }
+      let(:in_module_root) { true }
+
+      it 'valid fixtures dir' do
+        is_expected.to eq(File.join(File.dirname(metadata_path), 'spec', 'fixtures'))
+      end
+    end
+
+    context 'outside a module' do
+      let(:metadata_path) { nil }
+      let(:in_module_root) { false }
+
+      it 'invalid fixtures dir' do
+        is_expected.to be_nil
+      end
+    end
+  end
+
   describe '.module_root' do
     subject { described_class.module_root }
 


### PR DESCRIPTION
  * Without this, a developer would have to piece together
    the same code in multiple places to create the fixtures path
    for the module.  This adds a new util method called
    module_fixtures_dir that returns the ./spec/fixtures directory
    of the module.