### PR TITLE
Fixes gh-759 ruby 2.1.9 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,9 @@ gemspec
 
 if RUBY_VERSION < '2.3.0'
   # avoid newer versions that do not support ruby 2.1 anymore
+  gem 'addressable', '2.6.0'
   gem 'cri', '>= 2.10.1', '< 2.11.0'
+  gem 'net-ssh', '4.2.0'
   gem 'nokogiri', '1.7.2'
 else
   gem 'nokogiri', '~> 1.10.4' # rubocop:disable Bundler/DuplicatedGem
@@ -34,7 +36,7 @@ group :test do
   end
   gem 'parallel', '= 1.13.0'
   gem 'parser', '~> 2.5.1.2'
-  gem 'rake', '~> 10.0'
+  gem 'rake', '>= 10.0', '<= 12.3.3' # rake 13.0 forces ruby 2.2
   gem 'rspec', '~> 3.0'
   gem 'rspec-xsd'
   gem 'rubocop', '~> 0.57.2'

--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -3,25 +3,26 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'pdk/version'
 
 Gem::Specification.new do |spec|
-  spec.name    = 'pdk'
+  spec.name = 'pdk'
   spec.version = PDK::VERSION
   spec.authors = ['Puppet, Inc.']
-  spec.email   = ['pdk-maintainers@puppet.com']
+  spec.email = ['pdk-maintainers@puppet.com']
 
-  spec.summary     = 'A key part of the Puppet Development Kit, the shortest path to better modules'
+  spec.summary = 'A key part of the Puppet Development Kit, the shortest path to better modules'
   spec.description = 'A CLI to facilitate easy, unified development workflows for Puppet modules.'
-  spec.homepage    = 'https://github.com/puppetlabs/pdk'
+  spec.homepage = 'https://github.com/puppetlabs/pdk'
 
-  spec.files         = Dir['CHANGELOG.md', 'README.md', 'LICENSE', 'lib/**/*', 'exe/**/*', 'locales/**/*']
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files = Dir['CHANGELOG.md', 'README.md', 'LICENSE', 'lib/**/*', 'exe/**/*', 'locales/**/*']
+  spec.bindir = 'exe'
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.1.9'
 
+  spec.add_runtime_dependency 'addressable', '2.6.0'
   spec.add_runtime_dependency 'bundler', '>= 1.15.0', '< 3.0.0'
   spec.add_runtime_dependency 'childprocess', '~> 0.7.1'
-  spec.add_runtime_dependency 'cri', '~> 2.10'
+  spec.add_runtime_dependency 'cri', '= 2.10.1'
   spec.add_runtime_dependency 'diff-lcs', '1.3'
   spec.add_runtime_dependency 'ffi', '~> 1.9.0'
   spec.add_runtime_dependency 'gettext-setup', '~> 0.24'


### PR DESCRIPTION
  * previously the pdk gem was able to be installed
    under ruby 2.1.9.  However, there were some recent
    upstream dependency changes that dropped support for 2.1.9
    which caused pdk to be no longer installable.

    This fixes the gem dependency issue by backing down some gems
    that were forcing a newer ruby version.