### PR TITLE
(maint) Loosen tests for puppet-dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,10 @@ end
 group :test do
   gem 'coveralls'
   gem 'license_finder', '~> 3.0.4'
+  if RUBY_VERSION < '2.4'
+    # license_finder depends on rubyzip which requires Ruby 2.4 in 2.x
+    gem 'rubyzip', '< 2.0.0'
+  end
   gem 'parallel', '= 1.13.0'
   gem 'parser', '~> 2.5.1.2'
   gem 'rake', '~> 10.0'

--- a/spec/acceptance/version_changer_spec.rb
+++ b/spec/acceptance/version_changer_spec.rb
@@ -80,13 +80,15 @@ end
         its(:stderr) { is_expected.not_to match(%r{Using Puppet file://}i) }
       end
 
+      # Note that there is no guarantee that the master branch of puppet is compatible with the PDK under test
+      # so we can only test that the validate command is using the expected puppet gem location
       describe command('pdk validate --puppet-dev') do
         its(:stderr) { is_expected.to match(%r{Using Puppet file://}i) }
-        its(:exit_status) { is_expected.to eq(0) }
       end
 
+      # Note that there is no guarantee that the master branch of puppet is compatible with the PDK under test
+      # so we can only test that the test command is using the expected puppet gem location
       describe command('pdk test unit --puppet-dev') do
-        its(:exit_status) { is_expected.to eq(0) }
         its(:stderr) { is_expected.to match(%r{Using Puppet file://}i) }
       end
     end


### PR DESCRIPTION
Previously the test and validate acceptance tests could fail even though the
PDK was behaving correctly, for example, incompatible Gemfile specifications
between master on Puppet and the currently released stable Puppet gem.  This
commit removes the exit code status test and instead ensures that PDK is using
the expected Puppet gem location.

---

rubyzip 2.x requires Ruby 2.4. This commit adds an upper bound in the Gemfile
for Ruby less than 2.4.