### PR TITLE
(fixup) Missing require from lazy load PR

### DIFF
--- a/lib/pdk/util/bundler.rb
+++ b/lib/pdk/util/bundler.rb
@@ -109,6 +109,7 @@ module PDK
         def lock!
           require 'pdk/util'
           require 'fileutils'
+          require 'pdk/util/ruby_version'
 
           if PDK::Util.package_install?
             # In packaged installs, use vendored Gemfile.lock as a starting point.


### PR DESCRIPTION
This didn't show up during the acceptance testing unfortunately.

https://jenkins-master-prod-1.delivery.puppetlabs.net/view/PDK/view/adhoc/job/platform_pdk_adhoc_pdk-van-build_adhoc/79/