### PR TITLE
(fixup) Fix Bundle CLI lazy load

### DIFF
--- a/lib/pdk/cli/bundle.rb
+++ b/lib/pdk/cli/bundle.rb
@@ -19,11 +19,14 @@ EOF
 
       PDK::CLI::Util.analytics_screen_view('bundle')
 
-      # Ensure that the correct Ruby is activated before running commend.
+      # Ensure that the correct Ruby is activated before running command.
       puppet_env = PDK::CLI::Util.puppet_from_opts_or_env({})
       PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
 
       gemfile_env = PDK::Util::Bundler::BundleHelper.gemfile_env(puppet_env[:gemset])
+
+      require 'pdk/cli/exec'
+      require 'pdk/cli/exec/interactive_command'
 
       command = PDK::CLI::Exec::InteractiveCommand.new(PDK::CLI::Exec.bundle_bin, *args).tap do |c|
         c.context = :pwd

--- a/package-testing/Gemfile
+++ b/package-testing/Gemfile
@@ -19,6 +19,11 @@ gem 'beaker-vmpooler', '= 1.3.3'
 gem 'nokogiri', '= 1.10.4'
 gem 'rake', '= 12.3.2'
 
+# net-ping has a implicit dependency on win32-security
+if File::ALT_SEPARATOR
+  gem 'win32-security', require: false
+end
+
 group :development do
   gem 'pry-byebug', '~> 3.4'
 end


### PR DESCRIPTION
Previously the lazy loading of files missed the pdk/cli/exec classes.  This
commit updates the PDK CLI Bundle class to require the needed libraries.