### PR TITLE
lib/pdk/cli.rb needs to require pdk/version 

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -115,7 +115,6 @@ module PDK::CLI
     default_subcommand 'help'
 
     flag nil, :version, _('Show version of pdk.') do |_, _|
-      require 'pdk/version'
       puts PDK::Util::Version.version_string
       exit 0
     end
@@ -156,6 +155,7 @@ module PDK::CLI
   require 'pdk/cli/validate'
   require 'pdk/cli/module'
   require 'pdk/cli/console'
+  require 'pdk/version'
 
   @base_cmd.add_command Cri::Command.new_basic_help
 end

--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -13,7 +13,6 @@ require 'pdk/report'
 require 'pdk/util/version'
 require 'pdk/util/puppet_version'
 require 'pdk/util/filesystem'
-require 'pdk/version'
 
 class Cri::Command::CriExitException
   def initialize(is_error:)
@@ -116,6 +115,7 @@ module PDK::CLI
     default_subcommand 'help'
 
     flag nil, :version, _('Show version of pdk.') do |_, _|
+      require 'pdk/version'
       puts PDK::Util::Version.version_string
       exit 0
     end

--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -13,6 +13,7 @@ require 'pdk/report'
 require 'pdk/util/version'
 require 'pdk/util/puppet_version'
 require 'pdk/util/filesystem'
+require 'pdk/version'
 
 class Cri::Command::CriExitException
   def initialize(is_error:)


### PR DESCRIPTION
lib/pdk/cli.rb needs to require pdk/version to fix pdk cli 'uninitialized constant PDK::VERSION' when executing pdk functions like `pdk validate` or `pdk update` from ruby gem install.