### PR TITLE
(PDK-1525) Use less restrictive minitar version

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'hitimes', '1.3.0'
   spec.add_runtime_dependency 'json-schema', '2.8.0'
   spec.add_runtime_dependency 'json_pure', '~> 2.1.0'
-  spec.add_runtime_dependency 'minitar', '~> 0.6.1'
+  spec.add_runtime_dependency 'minitar', '~> 0.6'
   spec.add_runtime_dependency 'pathspec', '~> 0.2.1'
   spec.add_runtime_dependency 'tty-prompt', '~> 0.13'
   spec.add_runtime_dependency 'tty-spinner', '~> 0.5'


### PR DESCRIPTION
Previously the PDK used the minitar restriction similar to that of the Puppet
Windows build (~> 0.6.1).  However, from Puppet 6.10.1 this version pin
changed to `~> 0.9`. This means that using PDK as a gem on Windows, is causing
bundler to choose old versions of gems (e.g. doesn't include Litmus).

This commit changes the minitar pin to still be compatible with older Puppet
gems and still allow later Puppet too.