### PR TITLE
(MAINT) Fix new provider error message

### DIFF
--- a/lib/pdk/generate/provider.rb
+++ b/lib/pdk/generate/provider.rb
@@ -21,7 +21,7 @@ module PDK
 
       def raise_precondition_error(error)
         raise PDK::CLI::ExitWithError, _('%{error}: Creating a provider needs some local configuration in your module.' \
-          ' Please follow the docs at https://github.com/puppetlabs/puppet-resource_api#getting-started.') % { error: error }
+          ' Please follow the docs at https://puppet.com/docs/puppet/latest/create_types_and_providers_resource_api.html.') % { error: error }
       end
 
       def check_preconditions


### PR DESCRIPTION
Prior to this commit, if a user creates a module with
the PDK, then tries to create a provider, they get an
error - but the error leads to an anchor on the docs
for the resource_api readme which does not exist.

This commit corrects the URL of the error message,
pointing the user to the actual instructions they need
to follow to move forward.