### PR TITLE
(maint) Run acceptance:local tests in parallel during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - rvm: 2.4.3
       env: CHECK=rubocop
     - rvm: 2.4.3
-      env: CHECK=acceptance:local
+      env: CHECK=acceptance:local_parallel
     - rvm: 2.4.3
       env: CHECK=spec:coverage
     - rvm: 2.4.3

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :test do
     gem 'rubyzip', '< 2.0.0'
   end
   gem 'parallel', '= 1.13.0'
+  gem 'parallel_tests', '~> 2.24.0'
   gem 'parser', '~> 2.5.1.2'
   gem 'rake', '~> 10.0'
   gem 'rspec', '~> 3.0'

--- a/Rakefile
+++ b/Rakefile
@@ -57,6 +57,13 @@ namespace :acceptance do
     t.pattern = 'spec/acceptance/**.rb'
   end
   task local: [:binstubs]
+
+  task local_parallel: [:binstubs] do
+    require 'parallel_tests'
+
+    specs = Rake::FileList['spec/acceptance/**/*_spec.rb'].to_a
+    ParallelTests::CLI.new.run(['-t', 'rspec'] + specs)
+  end
 end
 
 RuboCop::RakeTask.new(:rubocop) do |task|

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
     #   BUNDLE_JOBS: 4
     - RUBY_VERSION: 24-x64
       USE_MSYS: true
-      SUITES: "acceptance:local"
+      SUITES: "acceptance:local_parallel"
       BUNDLE_JOBS: 4
     - RUBY_VERSION: 24-x64
       USE_MSYS: true


### PR DESCRIPTION
No significant change on the run time on Travis, but the run time on Appveyor dropped from 40 minutes to 26 minutes