### PR TITLE
(maint) Raise error when template content is empty

### DIFF
--- a/lib/pdk/util/filesystem.rb
+++ b/lib/pdk/util/filesystem.rb
@@ -2,6 +2,7 @@ module PDK
   module Util
     module Filesystem
       def write_file(path, content)
+        raise ArgumentError, "#{path} is empty" unless content
         raise ArgumentError unless path.is_a?(String) || path.respond_to?(:to_path)
 
         # Harmonize newlines across platforms.


### PR DESCRIPTION
  * Throws and error if the content is nil.  This fixes a problem
    when a template cannot be rendered correctly due to some filesytem
    issue.

    This was originally seen when config_defaults.yml had a
      delte: true set for any of the files.

    The error message previously thrown was confusing so this is meant
    to throw a better error message.