### PR TITLE
tty-prompt usage

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -1,4 +1,5 @@
 require 'cri'
+require 'tty-prompt'
 
 require 'pdk'
 require 'pdk/cli/errors'

--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -1,8 +1,12 @@
 require 'cri'
-require 'tty-prompt'
 
 require 'pdk'
 require 'pdk/cli/errors'
+
+module TTY
+  autoload :Prompt, 'tty/prompt'
+  autoload :TestPrompt, 'tty/test_prompt'
+end
 
 class Cri::Command::CriExitException
   def initialize(is_error:)

--- a/lib/pdk/cli/module/generate.rb
+++ b/lib/pdk/cli/module/generate.rb
@@ -10,6 +10,7 @@ module PDK::CLI
 
     run do |opts, args, _cmd|
       require 'pdk/generate/module'
+      require 'tty/prompt'
 
       module_name = args[0]
 

--- a/lib/pdk/cli/module/generate.rb
+++ b/lib/pdk/cli/module/generate.rb
@@ -10,7 +10,6 @@ module PDK::CLI
 
     run do |opts, args, _cmd|
       require 'pdk/generate/module'
-      require 'tty-prompt'
 
       module_name = args[0]
 

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -6,6 +6,8 @@ module PDK
       autoload :CommandRedirector, 'pdk/cli/util/command_redirector'
       autoload :OptionNormalizer, 'pdk/cli/util/option_normalizer'
       autoload :OptionValidator, 'pdk/cli/util/option_validator'
+      autoload :Interview, 'pdk/cli/util/interview'
+      autoload :Spinner, 'pdk/cli/util/spinner'
 
       # Ensures the calling code is being run from inside a module directory.
       #
@@ -37,6 +39,8 @@ module PDK
       module_function :spinner_opts_for_platform
 
       def prompt_for_yes(question_text, opts = {})
+        require 'tty/prompt'
+
         prompt = opts[:prompt] || TTY::Prompt.new(help_color: :cyan)
         validator = proc { |value| [true, false].include?(value) || value =~ %r{\A(?:yes|y|no|n)\Z}i }
         response = nil
@@ -46,7 +50,7 @@ module PDK
             q.default opts[:default] unless opts[:default].nil?
             q.validate(validator, _('Answer "Y" to continue or "n" to cancel.'))
           end
-        rescue TTY::Prompt::Reader::InputInterrupt
+        rescue PDK::CLI::Util::Interview::READER::InputInterrupt
           PDK.logger.info opts[:cancel_message] if opts[:cancel_message]
         end
 

--- a/lib/pdk/cli/util/command_redirector.rb
+++ b/lib/pdk/cli/util/command_redirector.rb
@@ -1,5 +1,5 @@
-require 'pdk'
 require 'tty-prompt'
+require 'pdk'
 
 module PDK
   module CLI

--- a/lib/pdk/cli/util/command_redirector.rb
+++ b/lib/pdk/cli/util/command_redirector.rb
@@ -1,5 +1,5 @@
-require 'tty-prompt'
 require 'pdk'
+require 'tty/prompt'
 
 module PDK
   module CLI
@@ -18,7 +18,7 @@ module PDK
         def run
           @prompt.puts _('Did you mean \'%{command}\'?') % { command: pastel.bold(@command) }
           @prompt.yes?('-->')
-        rescue TTY::Prompt::Reader::InputInterrupt
+        rescue PDK::CLI::Util::Interview::READER::InputInterrupt
           nil
         end
       end

--- a/lib/pdk/cli/util/interview.rb
+++ b/lib/pdk/cli/util/interview.rb
@@ -1,4 +1,4 @@
-require 'tty-prompt'
+require 'tty/prompt'
 require 'pdk'
 
 module PDK


### PR DESCRIPTION
After #778, update and probably other commands were broken by missing tty-prompt.

```
Traceback (most recent call last):
        9: from /opt/local/bin/pdk:23:in `<main>'
        8: from /opt/local/bin/pdk:23:in `load'
        7: from /opt/local/lib/ruby2.5/gems/2.5.0/gems/pdk-1.15.0.pre/exe/pdk:6:in `<top (required)>'
        6: from /opt/local/lib/ruby2.5/gems/2.5.0/gems/pdk-1.15.0.pre/lib/pdk/cli.rb:47:in `run'
        5: from /opt/local/lib/ruby2.5/gems/2.5.0/gems/cri-2.15.9/lib/cri/command.rb:314:in `run'
        4: from /opt/local/lib/ruby2.5/gems/2.5.0/gems/cri-2.15.9/lib/cri/command.rb:296:in `run'
        3: from /opt/local/lib/ruby2.5/gems/2.5.0/gems/cri-2.15.9/lib/cri/command.rb:360:in `run_this'
        2: from /opt/local/lib/ruby2.5/gems/2.5.0/gems/pdk-1.15.0.pre/lib/pdk/cli/update.rb:51:in `block (2 levels) in <module:CLI>'
        1: from /opt/local/lib/ruby2.5/gems/2.5.0/gems/pdk-1.15.0.pre/lib/pdk/module/update.rb:33:in `run'
/opt/local/lib/ruby2.5/gems/2.5.0/gems/pdk-1.15.0.pre/lib/pdk/cli/util.rb:40:in `prompt_for_yes': uninitialized constant TTY::Prompt (NameError)
```

As tty-prompt is used extensively in the CLI, I've moved the require statement up to `pdk/cli.rb`.