### PR TITLE
Loosening of minitar dependency

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'hitimes', '1.3.0'
   spec.add_runtime_dependency 'json-schema', '2.8.0'
   spec.add_runtime_dependency 'json_pure', '~> 2.1.0'
-  spec.add_runtime_dependency 'minitar', '~> 0.6'
+  spec.add_runtime_dependency 'minitar', '>= 0.6', '< 1.0'
   spec.add_runtime_dependency 'pathspec', '~> 0.2.1'
   spec.add_runtime_dependency 'tty-prompt', '~> 0.13'
   spec.add_runtime_dependency 'tty-spinner', '~> 0.5'


### PR DESCRIPTION
Puppet has moved to using minitar `~> 0.9`, but pdk and bolt still have minitar as `~> 0.6`. That's a problem as users can't use them all in module testing.

Loosening constraint to accept any version before 1.0

```
Resolving dependencies...
Bundler could not find compatible versions for gem "minitar":
  In snapshot (Gemfile.lock):
    minitar (= 0.6.1)
  In Gemfile:
puppet-module-posix-dev-r2.5 (~> 0.3) was resolved to 0.4.2, which depends
on
      puppet_litmus (>= 0.4.0, < 1.0.0) was resolved to 0.12.0, which depends on
        pdk (>= 1.10.0, < 2.0.0) was resolved to 1.14.0, which depends on
          minitar (~> 0.6.1)
puppet-module-posix-dev-r2.5 (~> 0.3) was resolved to 0.4.2, which depends
on
      puppet_pot_generator (~> 1.0) was resolved to 1.0.1, which depends on
        puppet was resolved to 6.10.1, which depends on
          minitar (~> 0.9) x64-mingw32
Running `bundle update` will rebuild your snapshot from scratch, using only
```
Ref: https://ci.appveyor.com/project/cardil/puppet-passless/builds/28325323/job/p2dihyb39jwp9hil