### PR TITLE
(maint) Use same rspec pattern in acceptance suite

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,7 +54,7 @@ namespace :acceptance do
   desc 'Run acceptance tests against current code'
   RSpec::Core::RakeTask.new(:local) do |t|
     t.rspec_opts = '--tag ~package' # Exclude package specific examples
-    t.pattern = 'spec/acceptance/**.rb'
+    t.pattern = 'spec/acceptance/**/*_spec.rb'
   end
   task local: [:binstubs]
 


### PR DESCRIPTION
Previously the rspec pattern between local and parallel tests was different.
This commit changes the local pattern to match that of the parallel.