### PR TITLE
(#773) Respect --verbose in interactive pdk test unit

### DIFF
--- a/lib/pdk/cli/test/unit.rb
+++ b/lib/pdk/cli/test/unit.rb
@@ -66,8 +66,6 @@ module PDK::CLI
           end
         end
       else
-        PDK.logger.info _('--verbose has no effect when not used with --list') if opts[:verbose]
-
         report = PDK::Report.new
         report_formats = if opts[:format]
                            opts[:interactive] = false

--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -40,9 +40,7 @@ module PDK
 
         command = PDK::CLI::Exec::InteractiveCommand.new(*cmd_with_args(task)).tap do |c|
           c.context = :module
-          c.environment = environment.reject do |key, _|
-            key == 'CI_SPEC_OPTIONS'
-          end
+          c.environment = environment
         end
 
         command.execute!
@@ -97,6 +95,11 @@ module PDK
         spinner_msg = options[:parallel] ? _('Running unit tests in parallel.') : _('Running unit tests.')
 
         if options[:interactive]
+          environment['CI_SPEC_OPTIONS'] = if options[:verbose]
+                                             '--format documentation'
+                                           else
+                                             '--format progress'
+                                           end
           result = interactive_rake(cmd(tests, options), environment)
           return result[:exit_code]
         end

--- a/spec/acceptance/test_unit_spec.rb
+++ b/spec/acceptance/test_unit_spec.rb
@@ -90,7 +90,7 @@ describe 'pdk test unit', module_command: true do
 
       describe command('pdk test unit') do
         its(:exit_status) { is_expected.not_to eq(0) }
-        its(:stdout) { is_expected.to match(%r{failed.*expected: true.*got: false}im) }
+        its(:stdout) { is_expected.to match(%r{expected: true.*got: false}im) }
         its(:stdout) { is_expected.to match(%r{1 examples?.*1 failures?}im) }
       end
     end


### PR DESCRIPTION
`pdk test unit` will now use the `progress` formatter (dots) and `pdk
test unit --verbose` will now use the `documentation` formatter.

Fixes #773