### PR TITLE
(#764) Ensure --puppet-dev checkout is always updated

### DIFF
--- a/lib/pdk/cli/new/test.rb
+++ b/lib/pdk/cli/new/test.rb
@@ -33,7 +33,6 @@ module PDK::CLI
       end
 
       puppet_env = PDK::CLI::Util.puppet_from_opts_or_env(opts)
-      PDK::Util::PuppetVersion.fetch_puppet_dev if opts[:'puppet-dev']
       PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
       PDK::Util::Bundler.ensure_bundle!(puppet_env[:gemset])
 

--- a/lib/pdk/cli/test/unit.rb
+++ b/lib/pdk/cli/test/unit.rb
@@ -37,7 +37,6 @@ module PDK::CLI
 
       # Ensure that the bundled gems are up to date and correct Ruby is activated before running or listing tests.
       puppet_env = PDK::CLI::Util.puppet_from_opts_or_env(opts)
-      PDK::Util::PuppetVersion.fetch_puppet_dev if opts[:'puppet-dev']
       PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
 
       opts.merge!(puppet_env[:gemset])

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -144,6 +144,7 @@ module PDK
         begin
           puppet_env =
             if use_puppet_dev
+              PDK::Util::PuppetVersion.fetch_puppet_dev(run: :once)
               PDK::Util::PuppetVersion.puppet_dev_env
             elsif desired_puppet_version
               PDK::Util::PuppetVersion.find_gem_for(desired_puppet_version)

--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -96,7 +96,6 @@ module PDK::CLI
 
       # Ensure that the bundled gems are up to date and correct Ruby is activated before running any validations.
       puppet_env = PDK::CLI::Util.puppet_from_opts_or_env(opts)
-      PDK::Util::PuppetVersion.fetch_puppet_dev if opts[:'puppet-dev']
       PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
 
       options.merge!(puppet_env[:gemset])

--- a/lib/pdk/util/puppet_version.rb
+++ b/lib/pdk/util/puppet_version.rb
@@ -44,7 +44,13 @@ module PDK
         latest
       end
 
-      def fetch_puppet_dev
+      def puppet_dev_fetched?
+        !@puppet_dev_fetched.nil?
+      end
+
+      def fetch_puppet_dev(options = {})
+        return if options[:run] == :once && puppet_dev_fetched?
+
         require 'pdk/util/git'
         require 'fileutils'
 
@@ -76,6 +82,8 @@ module PDK
 
         # Reset local repo to latest
         reset_result = PDK::Util::Git.git('-C', puppet_dev_path, 'reset', '--hard', 'origin/master')
+
+        @puppet_dev_fetched = true
         return if reset_result[:exit_code].zero?
 
         PDK.logger.error reset_result[:stdout]

--- a/spec/unit/pdk/cli/util_spec.rb
+++ b/spec/unit/pdk/cli/util_spec.rb
@@ -201,6 +201,7 @@ describe PDK::CLI::Util do
       before(:each) do
         allow(PDK::Util::PuppetVersion).to receive(:puppet_dev_path).and_return(puppet_version)
         allow(PDK::Util::PuppetVersion).to receive(:puppet_dev_env).and_return(version_result)
+        allow(PDK::Util::PuppetVersion).to receive(:fetch_puppet_dev)
       end
 
       it_behaves_like 'it returns a puppet environment'
@@ -222,6 +223,7 @@ describe PDK::CLI::Util do
         allow(PDK::Util::PuppetVersion).to receive(:puppet_dev_path).and_return(puppet_version)
         allow(PDK::Util::PuppetVersion).to receive(:puppet_dev_env).and_return(version_result)
         allow(PDK::Util::Env).to receive(:[]).with('PDK_PUPPET_DEV').and_return('true')
+        allow(PDK::Util::PuppetVersion).to receive(:fetch_puppet_dev)
       end
 
       it_behaves_like 'it returns a puppet environment'

--- a/spec/unit/pdk/util/puppet_version_spec.rb
+++ b/spec/unit/pdk/util/puppet_version_spec.rb
@@ -96,6 +96,31 @@ describe PDK::Util::PuppetVersion do
   end
 
   describe '.fetch_puppet_dev' do
+    context 'if puppet source has already been fetched' do
+      before(:each) do
+        allow(described_class.instance).to receive(:puppet_dev_fetched?).and_return(true)
+      end
+
+      context 'when run with :run => :once' do
+        it 'does not perform any git operations' do
+          expect(PDK::Util::Git).not_to receive(:git)
+
+          described_class.fetch_puppet_dev(run: :once)
+        end
+      end
+
+      context 'when not run with :run => :once' do
+        it 'performs the git operations' do
+          allow(PDK::Util::Git).to receive(:remote_repo?).with(anything).and_return(true)
+          allow(PDK::Util).to receive(:cachedir).and_return(File.join('path', 'to'))
+
+          expect(PDK::Util::Git).to receive(:git).with(any_args).and_return(exit_code: 0).twice
+
+          described_class.fetch_puppet_dev
+        end
+      end
+    end
+
     context 'if puppet source is not cloned yet' do
       before(:each) do
         allow(PDK::Util::Git).to receive(:remote_repo?).with(anything).and_return(false)


### PR DESCRIPTION
The original issue was that `pdk console --puppet-dev` didn't update the
checkout before using it. This is because the CLI for `pdk console`
didn't call `PDK::Util::PuppetVersion.fetch_puppet_dev`. Rather than add
that, I've opted to add this call to the logic in
`PDK::CLI::Util.puppet_from_opts_or_env` so that it happens
automatically when setting up the environment for puppet-dev.

---

First run to seed the checkout
```
$ pdk console --puppet-dev
pdk (WARN): Module fixtures not found, please run pdk bundle exec rake spec_prep.
[✔] Installing missing Gemfile dependencies.
Ruby Version: 2.4.7
Puppet Version: 6.10.1
Puppet Debugger Version: 0.15.1
Created by: NWOps <corey@nwops.io>
Type "commands" for a list of debugger commands
or "help" to show the help screen.

1:>>
```

Manually switch the checkout to Puppet 6.9.0
```
$ git -C ~/.pdk/cache/src/puppet checkout 6.9.0
Note: switching to '6.9.0'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at c2ccdd4efe Merge pull request #7706 from gimmyxd/PUP-10016
```

Second run, showing that the checkout has been updated to the HEAD of
origin/master (at time of writing, Puppet 6.10.1)
```
$ pdk console --puppet-dev
pdk (WARN): Module fixtures not found, please run pdk bundle exec rake spec_prep.
[✔] Installing missing Gemfile dependencies.
Ruby Version: 2.4.7
Puppet Version: 6.10.1
Puppet Debugger Version: 0.15.1
Created by: NWOps <corey@nwops.io>
Type "commands" for a list of debugger commands
or "help" to show the help screen.

1:>>
```

Fixes #764