### PR TITLE
(PDK-1530) Disable schema validation of config files

### DIFF
--- a/lib/pdk/config/validator.rb
+++ b/lib/pdk/config/validator.rb
@@ -1,0 +1,31 @@
+module PDK
+  class Config
+    # A collection of predefined validators for use with {PDK::Config::Value}.
+    #
+    # @example
+    #   value :enabled do
+    #     validate PDK::Config::Validator.boolean
+    #   end
+    module Validator
+      # @return [Hash{Symbol => [Proc,String]}] a {PDK::Config::Value}
+      #   validator that ensures that the value is either a TrueClass or
+      #   FalseClass.
+      def self.boolean
+        {
+          proc:    ->(value) { [true, false].include?(value) },
+          message: _('must be a boolean: true or false'),
+        }
+      end
+
+      # @return [Hash{Symbol => [Proc,String]}] a {PDK::Config::Value}
+      #   validator that ensures that the value is a String that matches the
+      #   regex for a version 4 UUID.
+      def self.uuid
+        {
+          proc:    ->(value) { value.match(%r{\A\h{8}(?:-\h{4}){3}-\h{12}\z}) },
+          message: _('must be a version 4 UUID'),
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Reference - #777 

Previously the PDK Analytics configuration file had a JSON schema enabled,
however the json-schema gem is causing issues.  This commit disables the schema
validation, while retaining the schema code.  Later commits will use the updated
json_schemer gem once EOL Rubies support is dropped.