### PR TITLE
(maint) Raise error when template content is empty or nil

### DIFF
--- a/lib/pdk/util/filesystem.rb
+++ b/lib/pdk/util/filesystem.rb
@@ -4,7 +4,8 @@ module PDK
   module Util
     module Filesystem
       def write_file(path, content)
-        raise ArgumentError unless path.is_a?(String) || path.respond_to?(:to_path)
+        raise ArgumentError, _('content must be a String') unless content.is_a?(String)
+        raise ArgumentError, _('path must be a String or Pathname') unless path.is_a?(String) || path.respond_to?(:to_path)
 
         # Harmonize newlines across platforms.
         content = content.encode(universal_newline: true)

--- a/spec/unit/pdk/util/filesystem_spec.rb
+++ b/spec/unit/pdk/util/filesystem_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'pdk/util/filesystem'
+require 'stringio'
 
 describe PDK::Util::Filesystem do
   describe '.read_file' do
@@ -43,6 +44,52 @@ describe PDK::Util::Filesystem do
         it 'returns nil' do
           expect(read_file).to be_nil
         end
+      end
+    end
+  end
+
+  describe '.write_file' do
+    subject(:write_file) { described_class.write_file(path, content) }
+
+    let(:dummy_file) { StringIO.new }
+    let(:path) { nil }
+
+    before(:each) do
+      allow(File).to receive(:open).and_call_original
+      allow(File).to receive(:open).with(path, 'wb').and_yield(dummy_file)
+    end
+
+    context 'when content is a String' do
+      let(:content) { 'something' }
+
+      context 'and the path is a String' do
+        let(:path) { File.join('path', 'to', 'my', 'file') }
+
+        it 'does not raise an error' do
+          expect { write_file }.not_to raise_error
+        end
+      end
+
+      context 'and the path is a Pathname' do
+        let(:path) { Pathname.new(File.join('path', 'to', 'my', 'file')) }
+
+        it 'does not raise an error' do
+          expect { write_file }.not_to raise_error
+        end
+      end
+
+      context 'and the path is neither a String nor Pathname' do
+        it 'raises an ArgumentError' do
+          expect { write_file }.to raise_error(ArgumentError, %r{String or Pathname})
+        end
+      end
+    end
+
+    context 'when content is not a String' do
+      let(:content) { nil }
+
+      it 'raises an ArgumentError' do
+        expect { write_file }.to raise_error(ArgumentError, %r{content must be a String})
       end
     end
   end


### PR DESCRIPTION
I can't push to the original PR and I want to ensure that this gets into the upcoming release so I've opened this PR to supercede #782 and address the review left by @glennsarti.

---

  * Throws and error if the content is nil.  This fixes a problem
    when a template cannot be rendered correctly due to some filesytem
    issue.

    This was originally seen when config_defaults.yml had a
      delte: true set for any of the files.

    The error message previously thrown was confusing so this is meant
    to throw a better error message.