### PR TITLE
(#806) Use ASCII quotes instead of Unicode quotes

### DIFF
--- a/lib/pdk/cli/module/build.rb
+++ b/lib/pdk/cli/module/build.rb
@@ -5,7 +5,7 @@ module PDK::CLI
     summary _('This command is now \'pdk build\'.')
 
     run do |_opts, _args, _cmd|
-      PDK.logger.warn(_('Modules are built using the ‘pdk build’ command.'))
+      PDK.logger.warn(_("Modules are built using the 'pdk build' command."))
       exit 1
     end
   end

--- a/lib/pdk/cli/module/generate.rb
+++ b/lib/pdk/cli/module/generate.rb
@@ -21,7 +21,7 @@ module PDK::CLI
 
       PDK::CLI::Util.validate_template_opts(opts)
 
-      PDK.logger.info(_('New modules are created using the ‘pdk new module’ command.'))
+      PDK.logger.info(_("New modules are created using the 'pdk new module' command."))
       prompt = TTY::Prompt.new(help_color: :cyan)
       redirect = PDK::CLI::Util::CommandRedirector.new(prompt)
       redirect.target_command('pdk new module')

--- a/spec/unit/pdk/cli/module/build_spec.rb
+++ b/spec/unit/pdk/cli/module/build_spec.rb
@@ -6,7 +6,7 @@ describe 'Running pdk module build' do
 
   describe 'when called' do
     it do
-      expect(logger).to receive(:warn).with(%r{Modules are built using the ‘pdk build’ command}i)
+      expect(logger).to receive(:warn).with(%r{Modules are built using the 'pdk build' command}i)
       expect {
         PDK::CLI.run(%w[module build])
       }.to exit_nonzero

--- a/spec/unit/pdk/cli/module/generate_spec.rb
+++ b/spec/unit/pdk/cli/module/generate_spec.rb
@@ -19,7 +19,7 @@ describe 'Running pdk module generate' do
       redirector = instance_double('PDK::CLI::Util::CommandRedirector')
       allow(redirector).to receive(:target_command)
       allow(redirector).to receive(:run).and_return(true)
-      expect(logger).to receive(:info).with(%r{New modules are created using the ‘pdk new module’ command}i)
+      expect(logger).to receive(:info).with(%r{New modules are created using the 'pdk new module' command}i)
       expect(PDK::CLI::Util::CommandRedirector).to receive(:new).and_return(redirector)
     end
 


### PR DESCRIPTION
Added a custom RuboCop cop to detect any smart quotes that sneak in in the future. It can automatically fix smart single quotes, fixing double quotes can be implemented if needed in the future.

Fixes #806 