### PR TITLE
(GH-808) Implement pdk release subcommand

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -167,6 +167,7 @@ module PDK::CLI
   require 'pdk/cli/validate'
   require 'pdk/cli/module'
   require 'pdk/cli/console'
+  require 'pdk/cli/release'
 
   @base_cmd.add_command Cri::Command.new_basic_help
 end

--- a/lib/pdk/cli/release.rb
+++ b/lib/pdk/cli/release.rb
@@ -1,0 +1,179 @@
+require 'pdk/cli/util'
+require 'pdk/validate'
+require 'pdk/util/bundler'
+require 'pdk/cli/util/interview'
+require 'pdk/util/changelog_generator'
+require 'pdk/module/build'
+
+module PDK::CLI
+  @release_cmd = @base_cmd.define_command do
+    name 'release'
+    usage _('release [options]')
+    summary _('(Experimental) Release a module to the Puppet Forge.')
+
+    flag nil, :force,                _('Release the module automatically, with no prompts.')
+    flag nil, :'skip-validation',    _('Skips the module validation check.')
+    flag nil, :'skip-changelog',     _('Skips the automatic changelog generation.')
+    flag nil, :'skip-dependency',    _('Skips the module dependency check.')
+    flag nil, :'skip-documentation', _('Skips the documentation update.')
+    flag nil, :'skip-build',         _('Skips module build.')
+    flag nil, :'skip-publish',       _('Skips publishing the module to the forge.')
+
+    option nil, :'forge-upload-url', _('Set forge upload url path.'),
+           argument: :required, default: 'https://forgeapi.puppetlabs.com/v3/releases'
+
+    option nil, :'forge-token', _('Set Forge API token.'), argument: :required, default: nil
+
+    option nil, :version, _('Update the module to the specified version prior to release. When not specified, the new version will be computed from the Changelog where possible.'),
+           argument: :required
+
+    option nil, :file, _('Path to the built module to push to the Forge. This option can only be used when --skip-build is also used. Defaults to pkg/<module version>.tar.gz'),
+           argument: :required
+
+    run do |opts, _args, _cmd|
+      # Make sure build is being run in a valid module directory with a metadata.json
+      PDK::CLI::Util.ensure_in_module!(
+        message:   _('`pdk release` can only be run from inside a valid module with a metadata.json.'),
+        log_level: :info,
+      )
+
+      unless opts[:force]
+        Release.prepare_interview(opts)
+      end
+
+      # Don't pass tokens to analytics
+      PDK::CLI::Util.analytics_screen_view('release', opts.reject { |k, _| k == :'forge-token' })
+
+      release = PDK::Module::Release.new(nil, opts)
+
+      unless release.module_metadata.forge_ready?
+        if opts[:force]
+          PDK.logger.warn _(
+            'This module is missing the following fields in the metadata.json: %{fields}. ' \
+            'These missing fields may affect the visibility of the module on the Forge.',
+          ) % {
+            fields: release.module_metadata.missing_fields.join(', '),
+          }
+        else
+          release.module_metadata.interview_for_forge!
+          release.write_module_metadata!
+        end
+      end
+
+      unless release.pdk_compatible?
+        if opts[:force]
+          PDK.logger.warn _('This module is not compatible with PDK, so PDK can not validate or test this build.')
+        else
+          PDK.logger.info _('This module is not compatible with PDK, so PDK can not validate or test this build. ' \
+                            'Unvalidated modules may have errors when uploading to the Forge. ' \
+                            'To make this module PDK compatible and use validate features, cancel the build and run `pdk convert`.')
+          unless PDK::CLI::Util.prompt_for_yes(_('Continue build without converting?'))
+            PDK.logger.info _('Build cancelled; exiting.')
+            PDK::Util.exit_process(1)
+          end
+        end
+      end
+
+      release.run
+    end
+  end
+
+  module Release
+    def self.prepare_interview(opts)
+      questions = []
+
+      unless opts[:'skip-validation']
+        questions << {
+          name:     'validation',
+          question: _('Do you want to run the module validation ?'),
+          type:     :yes,
+        }
+      end
+      unless opts[:'skip-changelog']
+        questions << {
+          name:     'changelog',
+          question: _('Do you want to run the automatic changelog generation ?'),
+          type:     :yes,
+        }
+      end
+      unless opts[:version]
+        questions << {
+          name:     'setversion',
+          question: _('Do you want to set the module version ?'),
+          type:     :yes,
+        }
+      end
+      unless opts[:'skip-dependency']
+        questions << {
+          name:     'dependency',
+          question: _('Do you want to run the dependency-checker on this module?'),
+          type:     :yes,
+        }
+      end
+      unless opts[:'skip-documentation']
+        questions << {
+          name:     'documentation',
+          question: _('Do you want to update the documentation for this module?'),
+          type:     :yes,
+        }
+      end
+      unless opts[:'skip-publish']
+        questions << {
+          name:     'publish',
+          question: _('Do you want to publish the module on the Puppet Forge?'),
+          type:     :yes,
+        }
+      end
+
+      prompt = TTY::Prompt.new(help_color: :cyan)
+      interview = PDK::CLI::Util::Interview.new(prompt)
+      interview.add_questions(questions)
+      answers = interview.run
+
+      unless answers.nil?
+        opts[:'skip-validation'] = !answers['validation']
+        opts[:'skip-changelog'] = !answers['changelog']
+        opts[:'skip-dependency'] = !answers['dependency']
+        opts[:'skip-documentation'] = !answers['documentation']
+
+        prepare_version_interview(opts) if answers['setversion']
+
+        prepare_publish_interview(opts) if answers['publish']
+      end
+      answers
+    end
+
+    def self.prepare_version_interview(opts)
+      questions = [
+        {
+          name:             'version',
+          question:         _('Please set the module version'),
+          help:             _('This value is the version that will be used in the changelog generator and building of the module.'),
+          required:         true,
+          validate_pattern: %r{(\*|\d+(\.\d+){0,2}(\.\*)?)$}i,
+          validate_message: _('The version format should be in the format x.y.z where x represents the major version, y the minor version and z the build number.'),
+        },
+      ]
+      interview = PDK::CLI::Util::Interview.new(prompt)
+      interview.add_questions(questions)
+      ver_answer = interview.run
+      opts[:version] = ver_answer['version']
+    end
+
+    def self.prepare_publish_interview(opts)
+      return if opts[:'forge-token']
+      questions = [
+        {
+          name:             'apikey',
+          question:         _('Please set the api key(authorization token) to upload on the Puppet Forge'),
+          help:             _('This value is used for authentication on the Puppet Forge to upload your module tarball.'),
+          required:         true,
+        },
+      ]
+      interview = PDK::CLI::Util::Interview.new(prompt)
+      interview.add_questions(questions)
+      api_answer = interview.run
+      opts[:'forge-token'] = api_answer['apikey']
+    end
+  end
+end

--- a/lib/pdk/module.rb
+++ b/lib/pdk/module.rb
@@ -3,6 +3,7 @@ module PDK
     autoload :Build, 'pdk/module/build'
     autoload :Convert, 'pdk/module/convert'
     autoload :Metadata, 'pdk/module/metadata'
+    autoload :Release, 'pdk/module/release'
     autoload :TemplateDir, 'pdk/module/template_dir'
     autoload :UpdateManager, 'pdk/module/update_manager'
     autoload :Update, 'pdk/module/update'

--- a/lib/pdk/module/release.rb
+++ b/lib/pdk/module/release.rb
@@ -1,0 +1,260 @@
+require 'pdk'
+
+module PDK
+  module Module
+    class Release
+      def self.invoke(module_path, options = {})
+        new(module_path, options).run
+      end
+
+      attr_reader :options
+
+      attr_reader :module_path
+
+      def initialize(module_path, options = {})
+        @options = options
+
+        # TODO: Currently the release process can ONLY be run if the working directory IS the module root. However, in the future
+        # this WILL change, so we have the API arguments for it, but only accept `nil` for the first parameter
+        raise PDK::CLI::ExitWithError, _('Running the release process outside of the working directory is not supported') unless module_path.nil?
+
+        if module_path.nil?
+          module_path = PDK::Util.module_root
+          raise PDK::CLI::ExitWithError, _('The module release process requires a valid module path') % { module_path: module_path } if module_path.nil?
+        end
+        raise PDK::CLI::ExitWithError, _('%{module_path} is not a valid module') % { module_path: module_path } unless PDK::Util.in_module_root?(module_path)
+        @module_path = module_path
+      end
+
+      def run
+        # Pre-release checks
+        unless force?
+          raise PDK::CLI::ExitWithError, _('The module is not PDK compatible') if requires_pdk_compatibility? && !pdk_compatible?
+          raise PDK::CLI::ExitWithError, _('The module is not Forge compatible') if requires_forge_compatibility? && !forge_compatible?
+        end
+
+        # Note that these checks are duplicated in the run_publish method, however it's a much better
+        # experience to fail early, than going through the whole process, only to error at the end knowing full well
+        # it'll fail anyway.
+        validate_publish_options!
+
+        run_validations(options) unless skip_validation?
+
+        PDK.logger.info _('Releasing %{module_name} - from version %{module_version}') % {
+          module_name:    module_metadata.data['name'],
+          module_version: module_metadata.data['version'],
+        }
+
+        PDK::Util::ChangelogGenerator.generate_changelog unless skip_changelog?
+
+        # Calculate the new module version
+        new_version = specified_version
+        if new_version.nil? && !skip_changelog?
+          new_version = PDK::Util::ChangelogGenerator.compute_next_version(module_metadata.data['version'])
+        end
+        new_version = module_metadata.data['version'] if new_version.nil?
+
+        if new_version != module_metadata.data['version']
+          PDK.logger.info _('Updating version to %{module_version}') % {
+            module_version: new_version,
+          }
+
+          # Set the new version in metadata file
+          module_metadata.data['version'] = new_version
+          write_module_metadata!
+
+          # Update the changelog with the correct version
+          PDK::Util::ChangelogGenerator.generate_changelog unless skip_changelog?
+        end
+
+        run_documentation(options) unless skip_documentation?
+
+        run_dependency_checker(options) unless skip_dependency?
+
+        if skip_build?
+          # Even if we're skipping the build, we still need the name of the tarball
+          # Use the specified package path if set
+          package_file = specified_package if package_file.nil?
+          # Use the default as a last resort
+          package_file = default_package_filename if package_file.nil?
+        else
+          package_file = run_build(options)
+        end
+
+        run_publish(options.dup, package_file) unless skip_publish?
+      end
+
+      def module_metadata
+        @module_metada ||= PDK::Module::Metadata.from_file(File.join(module_path, 'metadata.json'))
+      end
+
+      def write_module_metadata!
+        module_metadata.write!(File.join(module_path, 'metadata.json'))
+        clear_cached_data
+      end
+
+      def default_package_filename
+        return @default_tarball_filename unless @default_tarball_filename.nil?
+        builder = PDK::Module::Build.new(module_dir: module_path)
+        @default_tarball_filename = builder.package_file
+      end
+
+      def run_validations(opts)
+        # TODO: Surely I can use a pre-existing class for this?
+        PDK::CLI::Util.validate_puppet_version_opts(opts)
+
+        PDK::CLI::Util.module_version_check
+
+        report = PDK::Report.new
+        puppet_env = PDK::CLI::Util.puppet_from_opts_or_env(opts)
+        PDK::Util::PuppetVersion.fetch_puppet_dev if opts[:'puppet-dev']
+        PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
+
+        opts = opts.merge(puppet_env[:gemset])
+
+        PDK::Util::Bundler.ensure_bundle!(puppet_env[:gemset])
+
+        validators = PDK::Validate.validators
+        validators.each do |validator|
+          validator_exit_code = validator.invoke(report, opts.dup)
+          raise PDK::CLI::ExitWithError, _('An error occured during validation') unless validator_exit_code.zero?
+        end
+      end
+
+      def run_documentation(_opts)
+        PDK.logger.info _('Updating documentation using puppet strings')
+        docs_command = PDK::CLI::Exec::InteractiveCommand.new(PDK::CLI::Exec.bundle_bin, 'exec', 'puppet', 'strings', 'generate', '--format', 'markdown', '--out', 'REFERENCE.md')
+        docs_command.context = :module
+        result = docs_command.execute!
+        raise PDK::CLI::ExitWithError, _('An error occured generating the module documentation: %{stdout}') % { stdout: result[:stdout] } unless result[:exit_code].zero?
+      end
+
+      def run_dependency_checker(_opts)
+        # run dependency-checker and output dependent modules list
+        PDK.logger.info _('Running dependency checks')
+
+        dep_command = PDK::CLI::Exec::Command.new('dependency-checker', 'metadata.json')
+        dep_command.context = :module
+        result = dep_command.execute!
+
+        raise PDK::CLI::ExitWithError, _('An error occured checking the module dependencies: %{stdout}') % { stdout: result[:stdout] } unless result[:exit_code].zero?
+      end
+
+      # @return [String] Path to the built tarball
+      def run_build(opts)
+        PDK::Module::Build.invoke(opts.dup)
+      end
+
+      def run_publish(_opts, tarball_path)
+        validate_publish_options!
+        raise PDK::CLI::ExitWithError, _('Module tarball %{tarball_path} does not exist') % { tarball_path: tarball_path } unless PDK::Util::Filesystem.file?(tarball_path)
+
+        # TODO: Replace this code when the upload functionality is added to the forge ruby gem
+        require 'base64'
+        file_data = Base64.encode64(PDK::Util::Filesystem.read_file(tarball_path, open_args: 'rb'))
+
+        PDK.logger.info _('Uploading tarball to puppet forge...')
+        uri = URI(forge_upload_url)
+        require 'net/http'
+        request = Net::HTTP::Post.new(uri.path)
+        request['Authorization'] = 'Bearer ' + forge_token
+        request['Content-Type'] = 'application/json'
+        data = { file: file_data }
+
+        request.body = data.to_json
+
+        require 'openssl'
+        use_ssl = uri.class == URI::HTTPS
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: use_ssl) do |http|
+          http.request(request)
+        end
+
+        raise PDK::CLI::ExitWithError, _('Error uploading to Puppet Forge: %{result}') % { result: response } unless response.is_a?(Net::HTTPSuccess)
+        PDK.logger.info _('Publish to Forge was successful')
+      end
+
+      def validate_publish_options!
+        return if skip_publish?
+        raise PDK::CLI::ExitWithError, _('Missing forge-upload-url option') unless forge_upload_url
+        raise PDK::CLI::ExitWithError, _('Missing forge-token option') unless forge_token
+      end
+
+      def force?
+        options[:force]
+      end
+
+      def skip_build?
+        options[:'skip-build']
+      end
+
+      def skip_changelog?
+        options[:'skip-changelog']
+      end
+
+      def skip_dependency?
+        options[:'skip-dependency']
+      end
+
+      def skip_documentation?
+        options[:'skip-documentation']
+      end
+
+      def skip_publish?
+        options[:'skip-publish']
+      end
+
+      def skip_validation?
+        options[:'skip-validation']
+      end
+
+      def specified_version
+        options[:version]
+      end
+
+      def specified_package
+        options[:file]
+      end
+
+      def forge_token
+        options[:'forge-token']
+      end
+
+      def forge_upload_url
+        options[:'forge-upload-url']
+      end
+
+      def requires_pdk_compatibility?
+        # Validation, Changelog and Dependency checks require the
+        # module to be PDK Compatible
+        !(skip_validation? && skip_changelog? && skip_dependency?)
+      end
+
+      def requires_forge_compatibility?
+        # Pushing to the for requires the metadata to be forge compatible
+        !skip_publish?
+      end
+
+      #:nocov:
+      # These are just convenience methods and are tested elsewhere
+      def forge_compatible?
+        module_metadata.forge_ready?
+      end
+
+      def pdk_compatible?
+        return @pdk_compatible unless @pdk_compatible.nil?
+
+        builder = PDK::Module::Build.new(module_dir: module_path)
+        @pdk_compatible = builder.module_pdk_compatible?
+      end
+      #:nocov:
+
+      private
+
+      def clear_cached_data
+        @module_metadata = nil
+        @pdk_compatible = nil
+        @default_tarball_filename = nil
+      end
+    end
+  end
+end

--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -10,6 +10,7 @@ autoload :Pathname, 'pathname'
 module PDK
   module Util
     autoload :Bundler, 'pdk/util/bundler'
+    autoload :ChangelogGenerator, 'pdk/util/changelog_generator'
     autoload :Env, 'pdk/util/env'
     autoload :Filesystem, 'pdk/util/filesystem'
     autoload :Git, 'pdk/util/git'
@@ -30,6 +31,16 @@ module PDK
       functions
       types
     ].freeze
+
+    #:nocov:
+    # This method just wraps core Ruby functionality and
+    # can be ignored for code coverage
+
+    # Calls Kernel.exit with an exitcode
+    def exit_process(exit_code)
+      exit exit_code
+    end
+    #:nocov:
 
     # Searches upwards from current working directory for the given target file.
     #

--- a/lib/pdk/util/changelog_generator.rb
+++ b/lib/pdk/util/changelog_generator.rb
@@ -102,10 +102,12 @@ module PDK
       end
 
       def self.changelog_file
-        @changelog_file ||= PDK::Util::Filesystem.expand_path('CHANGELOG.MD')
+        # Default Changelog file is CHANGELOG.md, but also search for the .MD prefix as well.
+        @changelog_file ||= ['CHANGELOG.md', 'CHANGELOG.MD'].map { |file| PDK::Util::Filesystem.expand_path(file) }.find { |path| PDK::Util::Filesystem.file?(path) }
       end
 
       def self.changelog_content
+        return '' if changelog_file.nil?
         PDK::Util::Filesystem.read_file(changelog_file, open_args: 'rb:utf-8')
       end
     end

--- a/lib/pdk/util/changelog_generator.rb
+++ b/lib/pdk/util/changelog_generator.rb
@@ -1,0 +1,113 @@
+require 'pdk'
+
+module PDK
+  module Util
+    module ChangelogGenerator
+      # Taken from the version regex in https://forgeapi.puppet.com/schemas/module.json
+      VERSION_REGEX = %r{^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$}
+
+      # Raises if the github_changelog_generator is not available
+      def self.github_changelog_generator_available!
+        require 'bundler'
+        raise PDK::CLI::ExitWithError, _('Unable to generate the changelog as the github_changelog_generator gem is not installed') unless Bundler.rubygems.find_name('github_changelog_generator').any?
+      end
+
+      # Runs the Changelog Generator gem (in the module's context) to automatically create a CHANGLELOG.MD file
+      #
+      # @returns [String] The content of the new Changelog
+      def self.generate_changelog
+        github_changelog_generator_available!
+
+        changelog_command = PDK::CLI::Exec::InteractiveCommand.new(PDK::CLI::Exec.bundle_bin, 'exec', 'rake', 'changelog')
+        changelog_command.context = :module
+
+        result = changelog_command.execute!
+        raise PDK::CLI::ExitWithError, _('Error generating changelog: %{stdout}' % { stdout: result[:stdout] }) unless result[:exit_code].zero?
+
+        output = changelog_content
+
+        raise PDK::CLI::ExitWithError, _('The generated changelog contains uncategorized Pull Requests. Please label them and try again. See %{changelog_file} for more details' % { changelog_file: changelog_file }) if output =~ %r{UNCATEGORIZED PRS; GO LABEL THEM} # rubocop:disable Metrics/LineLength
+        output
+      end
+
+      # Computes the next version, based on the content of a changelog
+      #
+      # @param current_version [String, Gem::Version] The current version of the module
+      # @return [String] The new version. May be the same as the current version if there are no notable changes
+      def self.compute_next_version(current_version)
+        raise PDK::CLI::ExitWithError, _('Invalid version string %{version}' % { version: current_version }) unless current_version =~ VERSION_REGEX
+        version = Gem::Version.create(current_version).segments
+        PDK.logger.info _('Determing the target version from \'%{file}\'') % { file: changelog_file }
+
+        # Grab all lines that start with ## between from the latest changes
+        # For example given the changelog below
+
+        # ```
+        # # Change log
+        #
+        # All notable changes to this project will be documented in this file.
+        #
+        # ## [v4.0.0](https://github.com/puppetlabs/puppetlabs-inifile/tree/v4.
+        #
+        # [Full Changelog](https://github.com/puppetlabs/puppetlabs-inifile/com   --+
+        #                                                                           |
+        # ### Changed                                                               |
+        #                                                                           |
+        # - pdksync - FM-8499 - remove ubuntu14 support [\#363](https://github.     |  It's this piece of text we are interested in
+        #                                                                           |
+        # ### Added                                                                 |
+        #                                                                           |
+        # - FM-8402 add debian 10 support [\#352](https://github.com/puppetlabs     |
+        #                                                                           |
+        # ## [v3.1.0](https://github.com/puppetlabs/puppetlabs-inifile/tree/v3.     |
+        #                                                                         --+
+        # [Full Changelog](https://github.com/puppetlabs/puppetlabs-inifile/com
+        #
+        # ### Added
+        #
+        # - FM-8222 - Port Module inifile to Litmus [\#344](https://github.com/
+        # - \(FM-8154\) Add Windows Server 2019 support [\#340](https://github.
+        # - \(FM-8041\) Add RedHat 8 support [\#339](https://github.com/puppetl
+        # ````
+        data = ''
+        in_changelog_entry = false
+        changelog_content.each_line do |line|
+          line.strip!
+          if line.start_with?('[')
+            # We're leaving the latest changes so we can break
+            break if in_changelog_entry
+            in_changelog_entry = true
+          end
+          if in_changelog_entry && line.start_with?('##')
+            data += line
+          end
+        end
+
+        # Check for meta headers in first two header line matches
+        if data =~ %r{^### Changed}
+          # Major Version bump
+          version[0] += 1
+          version[1] = 0
+          version[2] = 0
+        elsif data =~ %r{^### Added}
+          # Minor Version bump
+          version[1] += 1
+          version[2] = 0
+        elsif data =~ %r{^### Fixed}
+          # Patch Version bump
+          version[2] += 1
+        end
+
+        version.join('.')
+      end
+
+      def self.changelog_file
+        @changelog_file ||= PDK::Util::Filesystem.expand_path('CHANGELOG.MD')
+      end
+
+      def self.changelog_content
+        PDK::Util::Filesystem.read_file(changelog_file, open_args: 'rb:utf-8')
+      end
+    end
+  end
+end

--- a/spec/unit/pdk/cli/release_spec.rb
+++ b/spec/unit/pdk/cli/release_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'pdk/cli'
+
+describe 'PDK::CLI release' do
+  let(:help_text) { a_string_matching(%r{^USAGE\s+pdk release}m) }
+
+  context 'when not run from inside a module' do
+    include_context 'run outside module'
+
+    it 'exits with an error' do
+      expect(logger).to receive(:error).with(a_string_matching(%r{must be run from inside a valid module}))
+      expect { PDK::CLI.run(%w[release]) }.to exit_nonzero
+    end
+  end
+
+  context 'when run inside a module' do
+    let(:release_object) do
+      instance_double(
+        PDK::Module::Release,
+        pdk_compatible?: true,
+        module_metadata: mock_metadata_obj,
+      )
+    end
+
+    let(:mock_metadata_obj) do
+      instance_double(
+        PDK::Module::Metadata,
+        forge_ready?: true,
+      )
+    end
+
+    before(:each) do
+      allow(PDK::CLI::Util).to receive(:ensure_in_module!).and_return(nil)
+      allow(PDK::Module::Release).to receive(:new).and_return(release_object)
+      allow(PDK::Util).to receive(:exit_process).and_raise('exit_process mock should not be called')
+      expect(release_object).to receive(:run).and_return(nil)
+    end
+
+    it 'calls PDK::Module::Release.run' do
+      expect { PDK::CLI.run(%w[release --force]) }.not_to raise_error
+    end
+  end
+end

--- a/spec/unit/pdk/module/release_spec.rb
+++ b/spec/unit/pdk/module/release_spec.rb
@@ -1,0 +1,426 @@
+require 'spec_helper'
+require 'pdk/module/release'
+
+describe PDK::Module::Release do
+  let(:module_path) { nil }
+  let(:options) { {} }
+  let(:instance) { described_class.new(module_path, options) }
+  let(:module_root) { '/path/somewhere' }
+  let(:metadata_hash) do
+    {
+      'name' => 'mock-module',
+      'version' => '1.0.0',
+      'pdk-version' => 'mock',
+    }
+  end
+  let(:mock_metadata_object) do
+    instance_double(
+      PDK::Module::Metadata,
+      data: metadata_hash,
+      forge_ready?: true,
+      write!: nil,
+    )
+  end
+
+  before(:each) do
+    # Mimic PDK being run in the root of a module in current working directory
+    allow(PDK::Util).to receive(:find_upwards).and_return(nil)
+    allow(PDK::Util).to receive(:in_module_root?).and_return(true)
+    allow(Dir).to receive(:pwd).and_return(module_root)
+    allow(PDK::Util::ChangelogGenerator).to receive(:changelog_content).and_return('This is a changelog')
+
+    allow(PDK::Module::Metadata).to receive(:from_file).and_return(mock_metadata_object)
+  end
+
+  describe '#initialize' do
+    context 'when passed a module path' do
+      let(:module_path) { 'a/path' }
+
+      it 'raises an error' do
+        expect { instance }.to raise_error(PDK::CLI::ExitWithError)
+      end
+    end
+
+    context 'when passed a nil module path' do
+      it 'uses the module root from the current working directory' do
+        expect(instance.module_path).to eq(module_root)
+      end
+    end
+  end
+
+  describe '#run' do
+    before(:each) do
+      # Stop any of the actual worker methods from running
+      allow(instance).to receive(:run_validations)
+      allow(instance).to receive(:run_documentation)
+      allow(instance).to receive(:run_dependency_checker)
+      allow(instance).to receive(:run_build)
+      allow(instance).to receive(:run_publish)
+      allow(PDK::Util::ChangelogGenerator).to receive(:generate_changelog)
+    end
+
+    context 'when skipping everything' do
+      let(:options) do
+        {
+          :'skip-validation'    => true,
+          :'skip-changelog'     => true,
+          :'skip-documentation' => true,
+          :'skip-dependency'    => true,
+          :'skip-build'         => true,
+          :'skip-publish'       => true,
+        }
+      end
+
+      it 'does not do anything' do
+        expect(instance).to receive(:run_validations).never
+        expect(instance).to receive(:run_documentation).never
+        expect(instance).to receive(:run_dependency_checker).never
+        expect(instance).to receive(:run_build).never
+        expect(instance).to receive(:run_publish).never
+        expect(PDK::Util::ChangelogGenerator).to receive(:generate_changelog).never
+
+        instance.run
+      end
+    end
+
+    context 'when skipping nothing and forcing the release' do
+      let(:options) do
+        {
+          :force              => true,
+          :'forge-upload-url' => 'https://localhost/api',
+          :'forge-token'      => '12345',
+        }
+      end
+
+      it 'calls all release helpers' do
+        expect(instance).to receive(:run_validations).once
+        expect(instance).to receive(:run_documentation).once
+        expect(instance).to receive(:run_dependency_checker).once
+        expect(instance).to receive(:run_build).once
+        expect(instance).to receive(:run_publish).once
+        expect(PDK::Util::ChangelogGenerator).to receive(:generate_changelog).once
+
+        instance.run
+      end
+    end
+
+    context 'when not forcing the release' do
+      let(:options) { { force: false } }
+
+      context 'and the module is not PDK compatible' do
+        before(:each) do
+          allow(instance).to receive(:pdk_compatible?).and_return(false)
+        end
+
+        it 'raises an error' do
+          expect { instance.run }.to raise_error(PDK::CLI::ExitWithError, %r{PDK compatible})
+        end
+      end
+
+      context 'and the module is not Forge compatible' do
+        before(:each) do
+          allow(instance).to receive(:forge_compatible?).and_return(false)
+        end
+
+        it 'raises an error' do
+          expect { instance.run }.to raise_error(PDK::CLI::ExitWithError, %r{Forge compatible})
+        end
+      end
+
+      context 'and missing the forge url' do
+        it 'raises an error' do
+          expect { instance.run }.to raise_error(PDK::CLI::ExitWithError, %r{forge-upload-url})
+        end
+      end
+
+      context 'and missing the forge token' do
+        before(:each) do
+          allow(instance).to receive(:forge_upload_url).and_return('https://localhost')
+        end
+
+        it 'raises an error' do
+          expect { instance.run }.to raise_error(PDK::CLI::ExitWithError, %r{forge-token})
+        end
+      end
+    end
+
+    context 'when detecting the version number' do
+      let(:new_version) { '2.0.0' }
+      let(:options) { { :'skip-publish' => true } }
+
+      it 'returns a new version from Changelog Generator' do
+        expect(PDK::Util::ChangelogGenerator).to receive(:compute_next_version).with('1.0.0').and_return(new_version)
+        expect(mock_metadata_object).to receive(:write!)
+
+        instance.run
+
+        expect(instance.module_metadata.data['version']).to eq(new_version)
+      end
+
+      it 'does not save the version if it has not changed' do
+        expect(PDK::Util::ChangelogGenerator).to receive(:compute_next_version).with('1.0.0').and_return('1.0.0')
+        expect(mock_metadata_object).to receive(:write!).never
+
+        instance.run
+
+        expect(instance.module_metadata.data['version']).to eq('1.0.0')
+      end
+    end
+
+    context 'when skipping the build' do
+      before(:each) do
+        allow(instance).to receive(:skip_build?).and_return(true)
+        allow(instance).to receive(:forge_upload_url).and_return('https://localhost')
+        allow(instance).to receive(:forge_token).and_return('abc123')
+      end
+
+      it 'uses the default package filename when a file is not specified to publish' do
+        expect(instance).to receive(:default_package_filename).and_return('default_path')
+        expect(instance).to receive(:run_publish).with(Hash, 'default_path')
+        instance.run
+      end
+
+      it 'uses the file is when specified to publish' do
+        expect(instance).to receive(:specified_package).and_return('specific_path')
+        expect(instance).to receive(:run_publish).with(Hash, 'specific_path')
+        instance.run
+      end
+    end
+
+    context 'when running the build helper' do
+      before(:each) do
+        allow(instance).to receive(:skip_build?).and_return(false)
+        allow(instance).to receive(:forge_upload_url).and_return('https://localhost')
+        allow(instance).to receive(:forge_token).and_return('abc123')
+      end
+
+      it 'uses the built tarball to publish' do
+        expect(instance).to receive(:run_build).and_return('build_path')
+        expect(instance).to receive(:run_publish).with(Hash, 'build_path')
+        instance.run
+      end
+    end
+  end
+
+  describe '#module_metadata' do
+    it 'returns a PDK::Module::Metadata object' do
+      expect(instance.module_metadata).to be(mock_metadata_object)
+    end
+  end
+
+  describe '#write_module_metadata!' do
+    before(:each) do
+      expect(mock_metadata_object).to receive(:write!).and_return(nil)
+    end
+
+    it 'writes the metadata' do
+      instance.write_module_metadata!
+    end
+
+    it 'clears the cache' do
+      expect(instance).to receive(:clear_cached_data)
+      instance.write_module_metadata!
+    end
+  end
+
+  describe '#default_package_filename' do
+    let(:builder) { double(PDK::Module::Build, package_file: 'package.tar.gz') } # rubocop:disable RSpec/VerifiedDoubles
+
+    it 'calls PDK::Module::Build' do
+      expect(PDK::Module::Build).to receive(:new).with(module_dir: module_root).and_return(builder)
+      expect(instance.default_package_filename).to eq('package.tar.gz')
+    end
+  end
+
+  describe '#run_validations' do
+    let(:validator) { double(PDK::Validate::BaseValidator) } # rubocop:disable RSpec/VerifiedDoubles
+    # Note that this test setup is quite fragile and indicates that the method
+    # under test really needs to be refactored
+
+    before(:each) do
+      allow(PDK::CLI::Util).to receive(:validate_puppet_version_opts).and_return(nil)
+      allow(PDK::CLI::Util).to receive(:module_version_check).and_return(nil)
+      allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env).and_return(gemset: {}, ruby_version: '1.2.3')
+      allow(PDK::Util::PuppetVersion).to receive(:fetch_puppet_dev).and_return(nil)
+      allow(PDK::Util::RubyVersion).to receive(:use).and_return(nil)
+      allow(PDK::Util::Bundler).to receive(:ensure_bundle!).and_return(nil)
+
+      allow(PDK::Validate).to receive(:validators).and_return([validator])
+    end
+
+    it 'calls the validators' do
+      expect(validator).to receive(:invoke).and_return(0)
+      instance.run_validations({})
+    end
+
+    it 'raises when the validator returns a non-zero exit code' do
+      expect(validator).to receive(:invoke).and_return(1)
+      expect { instance.run_validations({}) }.to raise_error(PDK::CLI::ExitWithError)
+    end
+  end
+
+  describe '#run_documentation' do
+    let(:command) { double(PDK::CLI::Exec::InteractiveCommand, :context= => nil) } # rubocop:disable RSpec/VerifiedDoubles
+    let(:command_stdout) { 'Success' }
+    let(:command_exit_code) { 0 }
+
+    before(:each) do
+      expect(PDK::CLI::Exec::InteractiveCommand).to receive(:new).and_return(command)
+      expect(command).to receive(:execute!).and_return(stdout: command_stdout, exit_code: command_exit_code)
+    end
+
+    it 'executes a command in the context of the module' do
+      expect(command).to receive(:context=).with(:module)
+      instance.run_documentation(options)
+    end
+
+    context 'when the command returns a non-zero exit code' do
+      let(:command_stdout) { 'Fail' }
+      let(:command_exit_code) { 1 }
+
+      it 'raises' do
+        expect { instance.run_documentation(options) }.to raise_error(PDK::CLI::ExitWithError)
+      end
+    end
+  end
+
+  describe '#run_dependency_checker' do
+    let(:command) { double(PDK::CLI::Exec::Command, :context= => nil) } # rubocop:disable RSpec/VerifiedDoubles
+    let(:command_stdout) { 'Success' }
+    let(:command_exit_code) { 0 }
+
+    before(:each) do
+      expect(PDK::CLI::Exec::Command).to receive(:new).with('dependency-checker', 'metadata.json').and_return(command)
+      expect(command).to receive(:execute!).and_return(stdout: command_stdout, exit_code: command_exit_code)
+    end
+
+    it 'executes a command in the context of the module' do
+      expect(command).to receive(:context=).with(:module)
+      instance.run_dependency_checker(options)
+    end
+
+    context 'when the command returns a non-zero exit code' do
+      let(:command_stdout) { 'Fail' }
+      let(:command_exit_code) { 1 }
+
+      it 'raises' do
+        expect { instance.run_dependency_checker(options) }.to raise_error(PDK::CLI::ExitWithError)
+      end
+    end
+  end
+
+  describe '#run_build' do
+    it 'calls PDK::Module::Build.invoke' do
+      expect(PDK::Module::Build).to receive(:invoke)
+      instance.run_build(options)
+    end
+  end
+
+  describe '#run_publish' do
+    let(:tarball_path) { '/does/not/exist' }
+    let(:http_response) { Net::HTTPSuccess.new(nil, nil, nil) }
+    # Note that this test setup is quite fragile and indicates that the method
+    # under test really needs to be refactored
+
+    before(:each) do
+      allow(instance).to receive(:forge_token).and_return('abc123')
+      allow(instance).to receive(:forge_upload_url).and_return('https://badapi.puppetlabs.com/v3/releases')
+      allow(PDK::Util::Filesystem).to receive(:file?).with(tarball_path).and_return(true)
+      allow(PDK::Util::Filesystem).to receive(:read_file).with(tarball_path, Hash).and_return('tarball_contents')
+      allow(Net::HTTP).to receive(:start).and_return(http_response)
+    end
+
+    it 'uploads the tarball to the Forge' do
+      instance.run_publish({}, tarball_path)
+    end
+
+    context 'when the tarball does not exist' do
+      before(:each) do
+        expect(PDK::Util::Filesystem).to receive(:file?).with(tarball_path).and_return(false)
+      end
+
+      it 'raises' do
+        expect { instance.run_publish({}, tarball_path) }.to raise_error(PDK::CLI::ExitWithError)
+      end
+    end
+
+    context 'when the Forge returns an error' do
+      let(:http_response) { Net::HTTPUnauthorized.new(nil, nil, nil) }
+
+      it 'raises' do
+        expect { instance.run_publish({}, tarball_path) }.to raise_error(PDK::CLI::ExitWithError)
+      end
+    end
+  end
+
+  describe '#validate_publish_options!' do
+    before(:each) do
+      allow(instance).to receive(:skip_publish?).and_return(false)
+    end
+
+    it 'raises when missing the forge upload url' do
+      allow(instance).to receive(:forge_upload_url).and_return(nil)
+      allow(instance).to receive(:forge_token).and_return('abc123')
+      expect { instance.validate_publish_options! }.to raise_error(PDK::CLI::ExitWithError)
+    end
+
+    it 'raises when missing the forge token' do
+      allow(instance).to receive(:forge_upload_url).and_return('https://localhost')
+      allow(instance).to receive(:forge_token).and_return(nil)
+      expect { instance.validate_publish_options! }.to raise_error(PDK::CLI::ExitWithError)
+    end
+
+    it 'does not raise when publishing is skipped' do
+      allow(instance).to receive(:skip_publish?).and_return(true)
+      allow(instance).to receive(:forge_upload_url).and_return(nil)
+      allow(instance).to receive(:forge_token).and_return(nil)
+      expect { instance.validate_publish_options! }.not_to raise_error
+    end
+  end
+
+  [
+    { method: 'force?',              option_name: :force },
+    { method: 'skip_build?',         option_name: :'skip-build' },
+    { method: 'skip_changelog?',     option_name: :'skip-changelog' },
+    { method: 'skip_dependency?',    option_name: :'skip-dependency' },
+    { method: 'skip_documentation?', option_name: :'skip-documentation' },
+    { method: 'skip_publish?',       option_name: :'skip-publish' },
+    { method: 'skip_validation?',    option_name: :'skip-validation' },
+    { method: 'specified_version',   option_name: :version },
+    { method: 'specified_package',   option_name: :file },
+    { method: 'forge_token',         option_name: :'forge-token' },
+    { method: 'forge_upload_url',    option_name: :'forge-upload-url' },
+  ].each do |testcase|
+    describe "\##{testcase[:method]}" do
+      context "when the #{testcase[:option_name]} options is set" do
+        let(:options) { { testcase[:option_name] => 'a_value' } }
+
+        it 'returns the set value' do
+          expect(instance.send(testcase[:method])).to eq('a_value')
+        end
+      end
+
+      context "when the #{testcase[:option_name]} options is not set" do
+        let(:options) { {} }
+
+        it 'returns nil' do
+          expect(instance.send(testcase[:method])).to be_nil
+        end
+      end
+    end
+  end
+
+  describe '#forge_compatible?' do
+    # This is a convenience method and is tested elsewhere
+    it 'responds to' do
+      expect(instance).to respond_to(:forge_compatible?)
+    end
+  end
+
+  describe '#pdk_compatible?' do
+    # This is a convenience method and is tested elsewhere
+    it 'responds to' do
+      expect(instance).to respond_to(:pdk_compatible?)
+    end
+  end
+end

--- a/spec/unit/pdk/util/changelog_generator_spec.rb
+++ b/spec/unit/pdk/util/changelog_generator_spec.rb
@@ -1,0 +1,198 @@
+require 'spec_helper'
+require 'pdk/util/changelog_generator'
+
+describe PDK::Util::ChangelogGenerator do
+  describe '#generate_changelog' do
+    let(:command) { double(PDK::CLI::Exec::InteractiveCommand, :context= => nil) } # rubocop:disable RSpec/VerifiedDoubles
+    let(:command_stdout) { 'Success' }
+    let(:command_exit_code) { 0 }
+    let(:changelog_content) { 'foo' }
+
+    before(:each) do
+      allow(described_class).to receive(:github_changelog_generator_available!)
+      allow(described_class).to receive(:changelog_content).and_return(changelog_content)
+      expect(PDK::CLI::Exec::InteractiveCommand).to receive(:new).and_return(command)
+      expect(command).to receive(:execute!).and_return(stdout: command_stdout, exit_code: command_exit_code)
+    end
+
+    it 'returns the changelog content' do
+      expect(described_class.generate_changelog).to eq(changelog_content)
+    end
+
+    it 'executes the command in the context of the module' do
+      expect(command).to receive(:context=).with(:module)
+      described_class.generate_changelog
+    end
+
+    context 'when the changelog task retruns a non-zero exit code' do
+      let(:command_exit_code) { 1 }
+
+      it 'raises' do
+        expect { described_class.generate_changelog }.to raise_error(PDK::CLI::ExitWithError, %r{#{command_stdout}})
+      end
+    end
+
+    context 'with uncategorized Pull Requests' do
+      let(:changelog_content) { 'UNCATEGORIZED PRS; GO LABEL THEM' }
+
+      it 'raises' do
+        expect { described_class.generate_changelog }.to raise_error(PDK::CLI::ExitWithError, %r{uncategorized Pull Requests})
+      end
+    end
+  end
+
+  describe '#compute_next_version' do
+    context 'given invalid starting version' do
+      [
+        '1.x',
+        '1',
+        'a.b.c',
+      ].each do |testcase|
+        it "raises for #{testcase}" do
+          expect { described_class.compute_next_version(testcase) }.to raise_error(StandardError)
+        end
+      end
+    end
+
+    context 'given a valid changelog' do
+      let(:changelog_content) { '' }
+      let(:current_version) { '1.2.3' }
+
+      before(:each) do
+        allow(described_class).to receive(:changelog_content).and_return(changelog_content)
+      end
+
+      context 'given a major change' do
+        let(:changelog_content) do
+          <<-EOT
+          # Change log
+
+          All notable changes to this project will be documented in this file.
+
+          ## [v4.0.0](url_4.0)
+
+          [Full Changelog](someting)
+
+          ### Changed
+
+          - something major
+
+          ### Added
+
+          - something minor
+
+          ### Fixed
+
+          - something tiny
+
+          ## [v3.1.0](https://github.com/puppetlabs/puppetlabs-inifile/tree/v3.
+
+          ## [v3.1.0](url_3.1)
+
+          [Full Changelog](someting)
+
+          ### Changed
+
+          - something major
+
+          ### Added
+
+          - something minor
+
+          ### Fixed
+
+          - something tiny
+          EOT
+        end
+
+        it 'returns a new major version' do
+          expect(described_class.compute_next_version(current_version)).to eq('2.0.0')
+        end
+      end
+
+      context 'given a minor change' do
+        let(:changelog_content) do
+          <<-EOT
+          # Change log
+
+          All notable changes to this project will be documented in this file.
+
+          ## [v4.0.0](url_4.0)
+
+          [Full Changelog](someting)
+
+          ### Added
+
+          - something minor
+
+          ### Fixed
+
+          - something tiny
+
+          ## [v3.1.0](https://github.com/puppetlabs/puppetlabs-inifile/tree/v3.
+
+          ## [v3.1.0](url_3.1)
+
+          [Full Changelog](someting)
+
+          ### Changed
+
+          - something major
+
+          ### Added
+
+          - something minor
+
+          ### Fixed
+
+          - something tiny
+          EOT
+        end
+
+        it 'returns a new minor version' do
+          expect(described_class.compute_next_version(current_version)).to eq('1.3.0')
+        end
+      end
+
+      context 'given a patch change' do
+        let(:changelog_content) do
+          <<-EOT
+          # Change log
+
+          All notable changes to this project will be documented in this file.
+
+          ## [v4.0.0](url_4.0)
+
+          [Full Changelog](someting)
+
+          ### Fixed
+
+          - something tiny
+
+          ## [v3.1.0](https://github.com/puppetlabs/puppetlabs-inifile/tree/v3.
+
+          ## [v3.1.0](url_3.1)
+
+          [Full Changelog](someting)
+
+          ### Changed
+
+          - something major
+
+          ### Added
+
+          - something minor
+
+          ### Fixed
+
+          - something tiny
+          EOT
+        end
+
+        it 'returns a new patch version' do
+          expect(described_class.compute_next_version(current_version)).to eq('1.2.4')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
RFC 003 [1] defines the experience and behavior of the new pdk release sub
command.  This commit:

* Adds the root subcommand `release` with all of the available skip options.
  This will allow the later `release build` and so on sub-sub-commands to be
  implemented much easier. Future commits will add these sub-sub commands.

* Adds a PDK::Module::Release class which does all of the release process

* Adds tests for Release process

[1] https://github.com/puppetlabs/pdk-planning/blob/master/RFCs/0003-add-pdk-release.md