### PR TITLE
(GH-808) Implement pdk release prep and publish subcommands

### DIFF
--- a/lib/pdk/cli/release/prep.rb
+++ b/lib/pdk/cli/release/prep.rb
@@ -1,0 +1,39 @@
+require 'pdk/cli/release'
+
+module PDK::CLI
+  @release_prep_cmd = @release_cmd.define_command do
+    name 'prep'
+    usage _('prep [options]')
+    summary _('(Experimental) Performs all the pre-release checks to ensure module is ready to be released')
+
+    flag nil, :force,                _('Prepare the module automatically, with no prompts.')
+    flag nil, :'skip-validation',    _('Skips the module validation check.')
+    flag nil, :'skip-changelog',     _('Skips the automatic changelog generation.')
+    flag nil, :'skip-dependency',    _('Skips the module dependency check.')
+    flag nil, :'skip-documentation', _('Skips the documentation update.')
+
+    option nil, :version, _('Update the module to the specified version prior to release. When not specified, the new version will be computed from the Changelog where possible.'),
+           argument: :required
+
+    run do |opts, _args, cmd|
+      # Make sure build is being run in a valid module directory with a metadata.json
+      PDK::CLI::Util.ensure_in_module!(
+        message:   _("`pdk release #{cmd.name}` can only be run from inside a valid module with a metadata.json."),
+        log_level: :info,
+      )
+
+      opts[:'skip-build'] = true
+      opts[:'skip-publish'] = true
+
+      Release.prepare_interview(opts) unless opts[:force]
+
+      Release.send_analytics("release #{cmd.name}", opts)
+
+      release = PDK::Module::Release.new(nil, opts)
+
+      Release.module_compatibility_checks!(release, opts)
+
+      release.run
+    end
+  end
+end

--- a/lib/pdk/cli/release/publish.rb
+++ b/lib/pdk/cli/release/publish.rb
@@ -1,0 +1,40 @@
+require 'pdk/cli/release'
+
+module PDK::CLI
+  @release_publish_cmd = @release_cmd.define_command do
+    name 'publish'
+    usage _('publish [options] <tarball>')
+    summary _('(Experimental) Publishes the module <tarball> to the Forge.')
+
+    flag nil, :force,                _('Publish the module automatically, with no prompts.')
+
+    option nil, :'forge-upload-url', _('Set forge upload url path.'),
+           argument: :required, default: 'https://forgeapi.puppetlabs.com/v3/releases'
+
+    option nil, :'forge-token', _('Set Forge API token.'), argument: :required, default: nil
+
+    run do |opts, _args, cmd|
+      # Make sure build is being run in a valid module directory with a metadata.json
+      PDK::CLI::Util.ensure_in_module!(
+        message:   _("`pdk release #{cmd.name}` can only be run from inside a valid module with a metadata.json."),
+        log_level: :info,
+      )
+
+      opts[:'skip-validation'] = true
+      opts[:'skip-changelog'] = true
+      opts[:'skip-dependency'] = true
+      opts[:'skip-documentation'] = true
+      opts[:'skip-build'] = true
+      opts[:'skip-versionset'] = true
+      opts[:force] = true unless PDK::CLI::Util.interactive?
+
+      Release.prepare_publish_interview(TTY::Prompt.new(help_color: :cyan), opts) unless opts[:force]
+
+      Release.send_analytics("release #{cmd.name}", opts)
+
+      release = PDK::Module::Release.new(nil, opts)
+
+      release.run
+    end
+  end
+end

--- a/spec/unit/pdk/cli/release/prep_spec.rb
+++ b/spec/unit/pdk/cli/release/prep_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+require 'pdk/cli'
+
+describe 'PDK::CLI release prep' do
+  let(:help_text) { a_string_matching(%r{^USAGE\s+pdk release prep}m) }
+  let(:cli_args) { %w[release prep] }
+
+  context 'when not run from inside a module' do
+    include_context 'run outside module'
+
+    it 'exits with an error' do
+      expect(logger).to receive(:error).with(a_string_matching(%r{must be run from inside a valid module}))
+
+      expect { PDK::CLI.run(cli_args) }.to exit_nonzero
+    end
+
+    it 'does not submit the command to analytics' do
+      expect(analytics).not_to receive(:screen_view)
+
+      expect { PDK::CLI.run(cli_args) }.to exit_nonzero
+    end
+  end
+
+  context 'when run from inside a module' do
+    let(:release_object) do
+      instance_double(
+        PDK::Module::Release,
+        pdk_compatible?: true,
+        module_metadata: mock_metadata_obj,
+        run: nil,
+      )
+    end
+
+    let(:mock_metadata_obj) do
+      instance_double(
+        PDK::Module::Metadata,
+        forge_ready?: true,
+      )
+    end
+
+    before(:each) do
+      allow(PDK::CLI::Util).to receive(:ensure_in_module!).and_return(nil)
+      allow(PDK::Module::Release).to receive(:new).and_return(release_object)
+      allow(PDK::Util).to receive(:exit_process).and_raise('exit_process mock should not be called')
+    end
+
+    it 'calls PDK::Module::Release.run' do
+      expect(release_object).to receive(:run)
+
+      expect { PDK::CLI.run(cli_args.concat(%w[--force])) }.not_to raise_error
+    end
+
+    it 'skips building and publishing' do
+      expect(PDK::Module::Release).to receive(:new).with(Object, hash_including(:'skip-build' => true, :'skip-publish' => true))
+
+      expect { PDK::CLI.run(cli_args.concat(%w[--force])) }.not_to raise_error
+    end
+
+    it 'does not start an interview when --force is used' do
+      expect(PDK::CLI::Util::Interview).to receive(:new).never
+
+      PDK::CLI.run(cli_args.concat(%w[--force]))
+    end
+
+    it 'calls PDK::CLI::Release.module_compatibility_checks!' do
+      expect(PDK::CLI::Release).to receive(:module_compatibility_checks!).and_return(nil)
+
+      expect { PDK::CLI.run(cli_args.concat(%w[--force])) }.not_to raise_error
+    end
+  end
+end

--- a/spec/unit/pdk/cli/release/prep_spec.rb
+++ b/spec/unit/pdk/cli/release/prep_spec.rb
@@ -57,7 +57,7 @@ describe 'PDK::CLI release prep' do
     end
 
     it 'does not start an interview when --force is used' do
-      expect(PDK::CLI::Util::Interview).to receive(:new).never
+      expect(PDK::CLI::Util::Interview).not_to receive(:new)
 
       PDK::CLI.run(cli_args.concat(%w[--force]))
     end

--- a/spec/unit/pdk/cli/release/publish_spec.rb
+++ b/spec/unit/pdk/cli/release/publish_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+require 'pdk/cli'
+
+describe 'PDK::CLI release publish' do
+  let(:help_text) { a_string_matching(%r{^USAGE\s+pdk release publish}m) }
+  let(:cli_args) { %w[release publish] }
+
+  context 'when not run from inside a module' do
+    include_context 'run outside module'
+
+    it 'exits with an error' do
+      expect(logger).to receive(:error).with(a_string_matching(%r{must be run from inside a valid module}))
+
+      expect { PDK::CLI.run(cli_args) }.to exit_nonzero
+    end
+
+    it 'does not submit the command to analytics' do
+      expect(analytics).not_to receive(:screen_view)
+
+      expect { PDK::CLI.run(cli_args) }.to exit_nonzero
+    end
+  end
+
+  context 'when run from inside a module' do
+    let(:release_object) do
+      instance_double(
+        PDK::Module::Release,
+        pdk_compatible?: true,
+        module_metadata: mock_metadata_obj,
+        run: nil,
+      )
+    end
+
+    let(:mock_metadata_obj) do
+      instance_double(
+        PDK::Module::Metadata,
+        forge_ready?: true,
+      )
+    end
+
+    before(:each) do
+      allow(PDK::CLI::Util).to receive(:ensure_in_module!).and_return(nil)
+      allow(PDK::Module::Release).to receive(:new).and_return(release_object)
+      allow(PDK::Util).to receive(:exit_process).and_raise('exit_process mock should not be called')
+    end
+
+    it 'calls PDK::Module::Release.run' do
+      expect(release_object).to receive(:run)
+
+      expect { PDK::CLI.run(cli_args.concat(%w[--force])) }.not_to raise_error
+    end
+
+    it 'skips all but publishing' do
+      expect(PDK::Module::Release).to receive(:new).with(
+        Object,
+        hash_including(
+          :'skip-validation'    => true,
+          :'skip-changelog'     => true,
+          :'skip-dependency'    => true,
+          :'skip-documentation' => true,
+          :'skip-build'         => true,
+        ),
+      )
+
+      expect { PDK::CLI.run(cli_args.concat(%w[--force])) }.not_to raise_error
+    end
+
+    it 'does not start an interview when --force is used' do
+      expect(PDK::CLI::Util::Interview).to receive(:new).never
+
+      PDK::CLI.run(cli_args.concat(%w[--force]))
+    end
+
+    it 'implicitly uses --force in non-interactive environments' do
+      allow(PDK::CLI::Util).to receive(:interactive?).and_return(false)
+      expect(PDK::Module::Release).to receive(:new).with(Object, hash_including(force: true))
+
+      expect { PDK::CLI.run(cli_args) }.not_to raise_error
+    end
+  end
+end

--- a/spec/unit/pdk/cli/release/publish_spec.rb
+++ b/spec/unit/pdk/cli/release/publish_spec.rb
@@ -66,7 +66,7 @@ describe 'PDK::CLI release publish' do
     end
 
     it 'does not start an interview when --force is used' do
-      expect(PDK::CLI::Util::Interview).to receive(:new).never
+      expect(PDK::CLI::Util::Interview).not_to receive(:new)
 
       PDK::CLI.run(cli_args.concat(%w[--force]))
     end

--- a/spec/unit/pdk/cli/release_spec.rb
+++ b/spec/unit/pdk/cli/release_spec.rb
@@ -41,7 +41,7 @@ describe 'PDK::CLI release' do
     end
 
     it 'does not start an interview when --force is used' do
-      expect(PDK::CLI::Util::Interview).to receive(:new).never
+      expect(PDK::CLI::Util::Interview).not_to receive(:new)
 
       PDK::CLI.run(%w[release --force])
     end

--- a/spec/unit/pdk/config/namespace_spec.rb
+++ b/spec/unit/pdk/config/namespace_spec.rb
@@ -58,7 +58,7 @@ describe PDK::Config::Namespace do
     end
 
     it 'does not save values when reading defaults' do
-      expect(config).to receive(:save_data).never # rubocop:disable RSpec/SubjectStub This is an expectation, not a stub
+      expect(config).not_to receive(:save_data)
       expect(config[:missing]).to be_nil
     end
 
@@ -89,7 +89,7 @@ describe PDK::Config::Namespace do
       end
 
       it 'does not save default values to disk' do
-        expect(config).to receive(:save_data).never # rubocop:disable RSpec/SubjectStub This is an expectation, not a stub
+        expect(config).not_to receive(:save_data)
         expect(config[:spec_test]).to eq('spec_default')
       end
     end
@@ -141,7 +141,7 @@ describe PDK::Config::Namespace do
     end
 
     it 'does not save values when using the default' do
-      expect(config).to receive(:save_data).never # rubocop:disable RSpec/SubjectStub This is an expectation, not a stub
+      expect(config).not_to receive(:save_data)
       config.fetch(:missing, 'default')
     end
   end
@@ -157,7 +157,7 @@ describe PDK::Config::Namespace do
         default_to { 'spec_default' }
       end
       # The resolver should not trigger any saves unless persistent_defaults is set to true
-      expect(PDK::Util::Filesystem).to receive(:write_file).never
+      expect(PDK::Util::Filesystem).not_to receive(:write_file)
     end
 
     context 'with an empty filter' do

--- a/spec/unit/pdk/module/release_spec.rb
+++ b/spec/unit/pdk/module/release_spec.rb
@@ -72,12 +72,12 @@ describe PDK::Module::Release do
       end
 
       it 'does not do anything' do
-        expect(instance).to receive(:run_validations).never
-        expect(instance).to receive(:run_documentation).never
-        expect(instance).to receive(:run_dependency_checker).never
-        expect(instance).to receive(:run_build).never
-        expect(instance).to receive(:run_publish).never
-        expect(PDK::Util::ChangelogGenerator).to receive(:generate_changelog).never
+        expect(instance).not_to receive(:run_validations)
+        expect(instance).not_to receive(:run_documentation)
+        expect(instance).not_to receive(:run_dependency_checker)
+        expect(instance).not_to receive(:run_build)
+        expect(instance).not_to receive(:run_publish)
+        expect(PDK::Util::ChangelogGenerator).not_to receive(:generate_changelog)
 
         instance.run
       end
@@ -159,7 +159,7 @@ describe PDK::Module::Release do
 
       it 'does not save the version if it has not changed' do
         expect(PDK::Util::ChangelogGenerator).to receive(:compute_next_version).with('1.0.0').and_return('1.0.0')
-        expect(mock_metadata_object).to receive(:write!).never
+        expect(mock_metadata_object).not_to receive(:write!)
 
         instance.run
 

--- a/spec/unit/pdk/util/version_spec.rb
+++ b/spec/unit/pdk/util/version_spec.rb
@@ -36,7 +36,7 @@ describe PDK::Util::Version do
       allow(PDK::Util::Filesystem).to receive(:exist?).with('/tmp/package/PDK_VERSION').and_return(true)
       allow(PDK::Util::Filesystem).to receive(:read_file).with('/tmp/package/PDK_VERSION').and_return('0.1.2.3.4.pkg_hash')
       allow(PDK::Util::Filesystem).to receive(:directory?).with(%r{.git\Z}).and_return(false)
-      allow(PDK::CLI::Exec).to receive(:git).never
+      expect(PDK::CLI::Exec).not_to receive(:git)
     end
 
     describe '#git_ref' do


### PR DESCRIPTION
Previously the pdk release command was added.  This commit adds the prep and
publish subcommands as per PDK RFC 003.

This commit also adds tests for new subcommands.

The `pdk release build` sub command needs more work, specifically around the tagging component.