### PR TITLE
(PDK-1487) Add --default-template flag to pdk convert

### DIFF
--- a/lib/pdk/cli/convert.rb
+++ b/lib/pdk/cli/convert.rb
@@ -11,6 +11,7 @@ module PDK::CLI
     flag nil, :noop, _('Do not convert the module, just output what would be done.')
     flag nil, :force, _('Convert the module automatically, with no prompts.')
     flag nil, :'add-tests', _('Add any missing tests while converting the module.')
+    flag nil, :'default-template', _('Convert the module to use the default PDK template.')
 
     run do |opts, _args, _cmd|
       require 'pdk/module/convert'
@@ -22,11 +23,18 @@ module PDK::CLI
         log_level:           :info,
       )
 
-      PDK::CLI::Util.validate_template_opts(opts)
-
       if opts[:noop] && opts[:force]
         raise PDK::CLI::ExitWithError, _('You can not specify --noop and --force when converting a module')
       end
+
+      if opts[:'default-template']
+        raise PDK::CLI::ExitWithError, _('You can not specify --template-url and --default-template.') if opts[:'template-url']
+
+        opts[:'template-url'] = PDK::Util::TemplateURI.default_template_addressable_uri.to_s
+        PDK.answers.update!('template-url' => nil)
+      end
+
+      PDK::CLI::Util.validate_template_opts(opts)
 
       PDK::CLI::Util.analytics_screen_view('convert', opts)
 

--- a/spec/acceptance/convert_spec.rb
+++ b/spec/acceptance/convert_spec.rb
@@ -153,6 +153,24 @@ describe 'pdk convert', module_command: true do
     end
   end
 
+  context 'when converting to the default template' do
+    include_context 'in a new module', 'non_default_template'
+
+    answer_file = File.join('..', 'non_default_template_answers.json')
+
+    describe command("pdk convert --default-template --force --answer-file #{answer_file}") do
+      its(:exit_status) { is_expected.to eq(0) }
+
+      describe file('metadata.json') do
+        its(:content_as_json) { is_expected.to include('template-url' => "#{template_repo}#master") }
+      end
+
+      describe file(answer_file) do
+        its(:content_as_json) { is_expected.to include('template-url' => nil) }
+      end
+    end
+  end
+
   context 'when adding missing tests' do
     # A real bare bones modules here. Testing to ensure that the functionality
     # works even when the module didn't have puppet-strings installed before


### PR DESCRIPTION
Adds a simple flag for users to convert their module to the default
template.

```
pdk convert --default-template
```

is functionally equivalent to

```
pdk convert --template-url https://github.com/puppetlabs/pdk-templates
```

Additionally, it clears the saved `template-url` value so that future
operations will use the default template by default.