### PR TITLE
(maint) Pin JSON test dependency to ~> 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ end
 
 group :test do
   gem 'coveralls'
+  gem 'json', '~> 2.2.0'
   gem 'license_finder', '~> 3.0.4'
   if RUBY_VERSION < '2.4'
     # license_finder depends on rubyzip which requires Ruby 2.4 in 2.x


### PR DESCRIPTION
json 2.3.0 was released but there was no json_pure 2.3.0 release that we can update to and the new json gem isn't compatible with our json_pure version so we can't just bump it. json is only pulled in as a test dependency of simplecov so we'll just lock it to 2.2.0 for now.

https://github.com/flori/json/issues/393