### PR TITLE
(maint) Update methods for Bundler 2.x deprecations 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,15 @@ sudo: false
 language: ruby
 bundler_args: "--without development"
 script:
+  - bundle --version
+  - gem --version
   - cat Gemfile.lock
   - bundle list
   - bundle exec rake $CHECK
 before_install:
   - if [ $BUNDLER_VERSION ]; then
-      gem install -v $BUNDLER_VERSION bundler --no-document;
+      rvm @global do gem uninstall bundler --executables --force;
+      rvm @global do gem install bundler -v $BUNDLER_VERSION;
     else
       gem install bundler --no-document;
     fi
@@ -16,6 +19,9 @@ matrix:
   include:
     - rvm: 2.4.3
       env: CHECK=rubocop
+    # Make sure that the we still work with an older Bundler version
+    - rvm: 2.4.3
+      env: CHECK=acceptance:smoke BUNDLER_VERSION=2.0.2
     - rvm: 2.4.3
       env: CHECK=acceptance:local_parallel
     - rvm: 2.4.3

--- a/Rakefile
+++ b/Rakefile
@@ -64,6 +64,13 @@ namespace :acceptance do
     specs = Rake::FileList['spec/acceptance/**/*_spec.rb'].to_a
     ParallelTests::CLI.new.run(['-t', 'rspec'] + specs)
   end
+
+  desc 'Run acceptance smoke tests against current code'
+  RSpec::Core::RakeTask.new(:smoke) do |t|
+    t.rspec_opts = '--tag ~package' # Exclude package specific examples
+    # We only need to run a subset of the acceptance suite.
+    t.pattern = 'spec/acceptance/bundle_spec.rb'
+  end
 end
 
 RuboCop::RakeTask.new(:rubocop) do |task|

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,6 +53,7 @@ install:
       }
       $ENV:SSL_CERT_FILE = $CACertFile
   - echo %PATH%
+  - gem update bundler
   - bundle install --retry 2 --without development
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,13 @@ environment:
     #   BUNDLE_JOBS: 4
     - RUBY_VERSION: 24-x64
       USE_MSYS: true
+      SUITES: "acceptance:smoke"
+      BUNDLE_JOBS: 4
+    - RUBY_VERSION: 24-x64
+      USE_MSYS: true
       SUITES: "acceptance:local_parallel"
       BUNDLE_JOBS: 4
+      UPDATE_BUNDLER: true
     - RUBY_VERSION: 24-x64
       USE_MSYS: true
       SUITES: "spec"
@@ -53,7 +58,11 @@ install:
       }
       $ENV:SSL_CERT_FILE = $CACertFile
   - echo %PATH%
-  - gem update bundler
+  # TODO: We can't use the same BUNDLER_VERSION technique that is in Travis CI for some reason. For the moment, we can at least just update the bundler gem
+  - ps: |
+      if ($ENV:UPDATE_BUNDLER) {
+        & gem update bundler
+      }
   - bundle install --retry 2 --without development
 
 build: off
@@ -63,8 +72,10 @@ branches:
     - master
 
 before_test:
-  - bundle env
+  - bundle --version
+  - gem --version
   - type Gemfile.lock
+  - bundle list
 
 test_script:
   - bundle exec rake %SUITES%

--- a/lib/pdk/util/ruby_version.rb
+++ b/lib/pdk/util/ruby_version.rb
@@ -115,9 +115,7 @@ module PDK
         else
           # This allows the subprocess to find the 'bundler' gem, which isn't
           # in GEM_HOME for gem installs.
-          # TODO: There must be a better way to do this than shelling out to
-          # gem... Perhaps can be replaced with "Gem.path"?
-          [File.absolute_path(File.join(`gem which bundler`, '..', '..', '..', '..'))]
+          [File.absolute_path(File.join(bundler_basedir, '..', '..', '..'))]
         end
       end
 
@@ -166,6 +164,10 @@ module PDK
 
       def versions
         self.class.versions
+      end
+
+      def bundler_basedir
+        Gem::Specification.latest_specs.find { |spec| spec.name.eql?('bundler') }.base_dir
       end
     end
   end

--- a/lib/pdk/util/ruby_version.rb
+++ b/lib/pdk/util/ruby_version.rb
@@ -126,6 +126,7 @@ module PDK
       def gem_home
         require 'pdk/util'
 
+        # TODO: bundle install --path is deprecated
         # `bundle install --path` ignores all "system" installed gems and
         # causes unnecessary package installs. `bundle install` (without
         # --path) installs into GEM_HOME, which by default is non-user

--- a/spec/acceptance/bundle_spec.rb
+++ b/spec/acceptance/bundle_spec.rb
@@ -84,7 +84,7 @@ describe 'pdk bundle' do
 
       describe command('pdk bundle env') do
         its(:exit_status) { is_expected.not_to eq(0) }
-        its(:stdout) { is_expected.to match(%r{error parsing `gemfile`}i) }
+        its(:stderr) { is_expected.to match(%r{error parsing `gemfile`}i) }
       end
     end
   end

--- a/spec/acceptance/bundle_spec.rb
+++ b/spec/acceptance/bundle_spec.rb
@@ -84,7 +84,13 @@ describe 'pdk bundle' do
 
       describe command('pdk bundle env') do
         its(:exit_status) { is_expected.not_to eq(0) }
-        its(:stderr) { is_expected.to match(%r{error parsing `gemfile`}i) }
+        if ENV['APPVEYOR']
+          # TODO: This is very strange that Appveyor emits the error on STDOUT instead of STDERR
+          # For moment switch the expectation based on the APPVEYOR environment variable
+          its(:stdout) { is_expected.to match(%r{error parsing `gemfile`}i) }
+        else
+          its(:stderr) { is_expected.to match(%r{error parsing `gemfile`}i) }
+        end
       end
     end
   end

--- a/spec/acceptance/bundle_spec.rb
+++ b/spec/acceptance/bundle_spec.rb
@@ -84,7 +84,7 @@ describe 'pdk bundle' do
 
       describe command('pdk bundle env') do
         its(:exit_status) { is_expected.not_to eq(0) }
-        its(:stderr) { is_expected.to match(%r{error parsing `gemfile`}i) }
+        its(:stdout) { is_expected.to match(%r{error parsing `gemfile`}i) }
       end
     end
   end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -45,9 +45,12 @@ end
 tempdir = nil
 analytics_config = nil
 
-# bundler won't install bundler into the --path, so in order to access ::Bundler.with_clean_env
+# TODO: --path is deprecated
+# bundler won't install bundler into the --path, so in order to access ::Bundler.with_unbundled_env
 # from within pdk during spec tests, we have to manually re-add the global gem path :(
-ENV['GEM_PATH'] = [ENV['GEM_PATH'], File.absolute_path(File.join(`bundle show bundler`, '..', '..')).to_s].compact.join(File::PATH_SEPARATOR)
+bundler_spec = Gem::Specification.find_by_name('bundler')
+bundler_path = bundler_spec.gem_dir
+ENV['GEM_PATH'] = [ENV['GEM_PATH'], File.absolute_path(File.join(bundler_path, '..', '..')).to_s].compact.join(File::PATH_SEPARATOR)
 
 # Save bundle environment from being purged by specinfra. This needs to be repeated for every example, as specinfra does not correctly reset the environment after a `describe command()` block
 # presumably https://github.com/mizzy/specinfra/blob/79b62b37909545b67b7492574a97c300fb1dc91e/lib/specinfra/backend/exec.rb#L143-L165

--- a/spec/unit/pdk/cli/exec/interactive_command_spec.rb
+++ b/spec/unit/pdk/cli/exec/interactive_command_spec.rb
@@ -80,7 +80,7 @@ describe PDK::CLI::Exec::InteractiveCommand do
       end
 
       it "executes in parent process' bundler env" do
-        expect(::Bundler).not_to receive(:with_clean_env)
+        expect(::Bundler).not_to receive(:with_unbundled_env)
 
         command.execute!
       end
@@ -119,7 +119,7 @@ describe PDK::CLI::Exec::InteractiveCommand do
       end
 
       it "executes in module's bundler env" do
-        expect(::Bundler).to receive(:with_clean_env).and_call_original
+        expect(command).to receive(:run_process_in_clean_env!).and_call_original # rubocop:disable RSpec/SubjectStub This is fine
 
         command.execute!
       end
@@ -156,7 +156,7 @@ describe PDK::CLI::Exec::InteractiveCommand do
       end
 
       it "executes in module's bundler env" do
-        expect(::Bundler).to receive(:with_clean_env).and_call_original
+        expect(command).to receive(:run_process_in_clean_env!).and_call_original # rubocop:disable RSpec/SubjectStub This is fine
 
         command.execute!
       end

--- a/spec/unit/pdk/util/ruby_version_spec.rb
+++ b/spec/unit/pdk/util/ruby_version_spec.rb
@@ -31,8 +31,8 @@ describe PDK::Util::RubyVersion do
   shared_context 'is not a package install' do
     before(:each) do
       allow(PDK::Util).to receive(:package_install?).and_return(false)
-      bundler_path = File.join('/', 'usr', 'lib', 'ruby', 'gems', '2.1.0', 'gems', 'bundler-1.16.1', 'lib', 'bundler.rb')
-      allow(instance).to receive(:`).with('gem which bundler').and_return(bundler_path)
+      bundler_basedir = File.join('/', 'usr', 'lib', 'ruby', 'gems', '2.1.0', 'gems', 'bundler-1.16.1', 'lib')
+      allow(instance).to receive(:bundler_basedir).and_return(bundler_basedir)
     end
   end
 


### PR DESCRIPTION
Refactor how gem_path to bundler is calculated

---

Bundler 2.1.0 now warns for many deprecations and has deprecated some methods.
The PDK needs to be modified to use the correct methods based on the version of
Bundler used.  This commit:

* Changes the command.rb to flip which Bundler method to use; preferring the new
  method `.with_unbundled_env` over the deprecated `.with_clean_env`
* Updates Travis CI and Appveyor CI to run acceptance smoke tests (reduced set
  of tests) on older Bundler versions to ensure that we don't break old
  configuration.
* Modify Travis CI to update bundler correctly.  Previously it was not working
  with the newer Bundler 2.1.0 and Travis CI worker
* Adds some TODOs for deprecated Bundler options e.g. `--path` and `--without`
* Updates the spec_helper_acceptance to find bundler using the Bunlder API
  instead of the bundler command line, which has changed the text that is
  output as of Bundler 2.1.0

---

Replaces #745 