### PR TITLE
(#821) Allow for unbalanced JSON fragments in RSpec output

### DIFF
--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -225,7 +225,7 @@ module PDK
 
       json_result = break_on_first ? nil : []
 
-      text.scan(%r{\{(?:[^{}]|(?:\g<0>))*\}?}x) do |str|
+      text.split("\n").select { |r| r.start_with?('{') && r.end_with?('}') }.each do |str|
         begin
           if break_on_first
             json_result = JSON.parse(str)

--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -225,7 +225,7 @@ module PDK
 
       json_result = break_on_first ? nil : []
 
-      text.scan(%r{\{(?:[^{}]|(?:\g<0>))*\}}x) do |str|
+      text.scan(%r{\{(?:[^{}]|(?:\g<0>))*\}?}x) do |str|
         begin
           if break_on_first
             json_result = JSON.parse(str)

--- a/lib/pdk/util/json_finder.rb
+++ b/lib/pdk/util/json_finder.rb
@@ -1,0 +1,84 @@
+module PDK
+  module Util
+    # Processes a given string, looking for JSON objects and parsing them.
+    #
+    # @example A string with a JSON object and some junk characters
+    #   PDK::Util::JSONFinder.new('foo{"bar":1}').objects
+    #   => [{ 'bar' => 1 }]
+    #
+    # @example A string with mulitple JSON objects
+    #   PDK::Util::JSONFinder.new('foo{"bar":1}baz{"gronk":2}').objects
+    #   => [{ 'bar' => 1 }, { 'gronk' => 2 }]
+    class JSONFinder
+      # Creates a new instance of PDK::Util::JSONFinder.
+      #
+      # @param string [String] the string to find JSON objects inside of.
+      #
+      # @return [PDK::Util::JSONFinder] a new PDK::Util::JSONFinder object.
+      def initialize(string)
+        require 'strscan'
+
+        @scanner = StringScanner.new(string)
+      end
+
+      # Returns the parsed JSON objects from the string.
+      #
+      # @return [Array[Hash]] the parsed JSON objects present in the string.
+      def objects
+        return @objects unless @objects.nil?
+
+        require 'json'
+
+        until @scanner.eos?
+          @scanner.getch until @scanner.peek(1) == '{' || @scanner.eos?
+
+          (@objects ||= []) << begin
+                                 JSON.parse(read_object(true) || '')
+                               rescue JSON::ParserError
+                                 nil
+                               end
+        end
+
+        @objects = @objects.compact
+      end
+
+      private
+
+      # Recursively process the string to extract a complete JSON object.
+      #
+      # @param new_object [Boolean] Set to true if processing a new object to
+      #   capture the opening brace. Set to false if being called recursively
+      #   where the opening brace has already been captured.
+      #
+      # @return [String] The matched substring containing a JSON object.
+      def read_object(new_object = false)
+        matched_text = new_object ? @scanner.getch : ''
+
+        until @scanner.eos?
+          text = @scanner.scan_until(%r{(?:(?<!\\)"|\{|\})})
+          unless text
+            @scanner.terminate
+            return nil
+          end
+          matched_text += text
+
+          case @scanner.matched
+          when '}'
+            break
+          when '"'
+            text = @scanner.scan_until(%r{(?<!\\)"})
+            unless text
+              @scanner.terminate
+              return nil
+            end
+            matched_text += text
+          else
+            matched_text += read_object
+          end
+        end
+
+        matched_text
+      end
+    end
+  end
+end

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -486,6 +486,12 @@ describe PDK::Util do
       expect(described_class.find_first_json_in(text)).to be_nil
     end
 
+    it 'returns nil for an unbalanced invalid JSON object' do
+      text = 'foo{{bar}'
+
+      expect(described_class.find_first_json_in(text)).to be_nil
+    end
+
     it 'returns nil for no JSON in a string' do
       text = 'foosomethingbar'
 

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -498,6 +498,24 @@ describe PDK::Util do
 
       expect(described_class.find_first_json_in(text)).to eq(expected)
     end
+
+    context 'with balanced nested JSON fragment' do
+      it 'returns largest valid JSON document' do
+        text = '{"version": "3.6.0", "content": "{\"nested\": \"fragment\"}"}'
+        expected = { 'version' => '3.6.0', 'content' => '{"nested": "fragment"}' }
+
+        expect(described_class.find_first_json_in(text)).to eq(expected)
+      end
+    end
+
+    context 'with unbalanced nested JSON fragment' do
+      it 'returns largest valid JSON document' do
+        text = '{"version": "3.6.0", "content": "{{\"nested\": \"fragment\"}"}'
+        expected = { 'version' => '3.6.0', 'content' => '{{"nested": "fragment"}' }
+
+        expect(described_class.find_first_json_in(text)).to eq(expected)
+      end
+    end
   end
 
   describe '.find_all_json_in' do


### PR DESCRIPTION
This is an initial attempt at making the PDK::Util.find_valid_json_in
method tolerate unbalanced JSON fragments nested as values inside of
a larger, valid JSON document.

The simple change of making the closing brace optional allows the regex to more greedily match the largest valid document, but I would like to see this tested against more complex samples before declaring this a sufficient fix.

Resolves #821