### PR TITLE
(PDK-1556) Use the module root when generating objects

### DIFF
--- a/lib/pdk/cli/convert.rb
+++ b/lib/pdk/cli/convert.rb
@@ -48,7 +48,7 @@ module PDK::CLI
         opts[:'full-interview'] = false
       end
 
-      PDK::Module::Convert.invoke(opts)
+      PDK::Module::Convert.invoke(PDK::Util.module_root, opts)
     end
   end
 end

--- a/lib/pdk/cli/new/class.rb
+++ b/lib/pdk/cli/new/class.rb
@@ -13,7 +13,6 @@ module PDK::CLI
       )
 
       class_name = args[0]
-      module_dir = Dir.pwd
 
       if class_name.nil? || class_name.empty?
         puts command.help
@@ -26,7 +25,7 @@ module PDK::CLI
 
       PDK::CLI::Util.analytics_screen_view('new_class', opts)
 
-      PDK::Generate::PuppetClass.new(module_dir, class_name, opts).run
+      PDK::Generate::PuppetClass.new(PDK::Util.module_root, class_name, opts).run
     end
   end
 end

--- a/lib/pdk/cli/new/defined_type.rb
+++ b/lib/pdk/cli/new/defined_type.rb
@@ -11,7 +11,6 @@ module PDK::CLI
       )
 
       defined_type_name = args[0]
-      module_dir = Dir.pwd
 
       if defined_type_name.nil? || defined_type_name.empty?
         puts command.help
@@ -26,7 +25,7 @@ module PDK::CLI
 
       require 'pdk/generate/defined_type'
 
-      PDK::Generate::DefinedType.new(module_dir, defined_type_name, opts).run
+      PDK::Generate::DefinedType.new(PDK::Util.module_root, defined_type_name, opts).run
     end
   end
 end

--- a/lib/pdk/cli/new/provider.rb
+++ b/lib/pdk/cli/new/provider.rb
@@ -8,7 +8,6 @@ module PDK::CLI
       PDK::CLI::Util.ensure_in_module!
 
       provider_name = args[0]
-      module_dir = Dir.pwd
 
       if provider_name.nil? || provider_name.empty?
         puts command.help
@@ -23,7 +22,7 @@ module PDK::CLI
 
       require 'pdk/generate/provider'
 
-      PDK::Generate::Provider.new(module_dir, provider_name, opts).run
+      PDK::Generate::Provider.new(PDK::Util.module_root, provider_name, opts).run
     end
   end
 end

--- a/lib/pdk/cli/new/task.rb
+++ b/lib/pdk/cli/new/task.rb
@@ -15,7 +15,6 @@ module PDK::CLI
       )
 
       task_name = args[0]
-      module_dir = Dir.pwd
 
       if task_name.nil? || task_name.empty?
         puts command.help
@@ -28,7 +27,7 @@ module PDK::CLI
 
       PDK::CLI::Util.analytics_screen_view('new_task', opts)
 
-      PDK::Generate::Task.new(module_dir, task_name, opts).run
+      PDK::Generate::Task.new(PDK::Util.module_root, task_name, opts).run
     end
   end
 end

--- a/lib/pdk/cli/new/test.rb
+++ b/lib/pdk/cli/new/test.rb
@@ -18,7 +18,6 @@ module PDK::CLI
       )
 
       object_name = args[0]
-      module_dir = Dir.pwd
 
       if object_name.nil? || object_name.empty?
         puts command.help
@@ -41,7 +40,7 @@ module PDK::CLI
 
         PDK::CLI::Util.analytics_screen_view('new_test', opts)
 
-        generator.new(module_dir, obj['name'], opts.merge(spec_only: true)).run
+        generator.new(PDK::Util.module_root, obj['name'], opts.merge(spec_only: true)).run
       rescue PDK::Util::PuppetStrings::NoObjectError
         raise PDK::CLI::ExitWithError, _('Unable to find anything called "%{object}" to generate unit tests for.') % { object: object_name }
       rescue PDK::Util::PuppetStrings::NoGeneratorError => e

--- a/lib/pdk/cli/new/transport.rb
+++ b/lib/pdk/cli/new/transport.rb
@@ -8,7 +8,6 @@ module PDK::CLI
       PDK::CLI::Util.ensure_in_module!
 
       transport_name = args[0]
-      module_dir = Dir.pwd
 
       if transport_name.nil? || transport_name.empty?
         puts command.help
@@ -21,7 +20,7 @@ module PDK::CLI
 
       require 'pdk/generate/transport'
 
-      PDK::Generate::Transport.new(module_dir, transport_name, opts).run
+      PDK::Generate::Transport.new(PDK::Util.module_root, transport_name, opts).run
     end
   end
 end

--- a/lib/pdk/cli/update.rb
+++ b/lib/pdk/cli/update.rb
@@ -46,7 +46,7 @@ module PDK::CLI
 
       PDK::CLI::Util.analytics_screen_view('update', opts)
 
-      updater = PDK::Module::Update.new(opts)
+      updater = PDK::Module::Update.new(PDK::Util.module_root, opts)
 
       if updater.pinned_to_puppetlabs_template_tag?
         PDK.logger.info _(

--- a/lib/pdk/generate/puppet_object.rb
+++ b/lib/pdk/generate/puppet_object.rb
@@ -16,7 +16,7 @@ module PDK
       # OBJECT_TYPE constant and implement the {#template_data},
       # {#target_object_path} and {#target_spec_path} methods.
       #
-      # @param module_dir [String] The path to the module directory that the
+      # @param module_dir [String] The path to the root of module that the
       #   will contain the object.
       # @param object_name [String] The name of the object.
       # @param options [Hash{Symbol => Object}]

--- a/lib/pdk/module/update.rb
+++ b/lib/pdk/module/update.rb
@@ -51,7 +51,7 @@ module PDK
       end
 
       def module_metadata
-        @module_metadata ||= PDK::Module::Metadata.from_file('metadata.json')
+        @module_metadata ||= PDK::Module::Metadata.from_file(File.join(module_dir, 'metadata.json'))
       rescue ArgumentError => e
         raise PDK::CLI::ExitWithError, e.message
       end

--- a/spec/acceptance/convert_spec.rb
+++ b/spec/acceptance/convert_spec.rb
@@ -38,7 +38,7 @@ describe 'pdk convert', module_command: true do
     describe command("#{pdk_convert_base} --noop --skip-interview") do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to have_no_output }
-      its(:stdout) { is_expected.to match(%r{-+files to be added-+\nmetadata\.json}mi) }
+      its(:stdout) { is_expected.to match(%r{-+files to be added-+\n.*/metadata\.json}mi) }
     end
 
     describe file('convert_report.txt') do
@@ -67,7 +67,7 @@ describe 'pdk convert', module_command: true do
     describe command("#{pdk_convert_base} --force --skip-interview") do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to have_no_output }
-      its(:stdout) { is_expected.to match(%r{-+files to be added-+\nmetadata\.json}mi) }
+      its(:stdout) { is_expected.to match(%r{-+files to be added-+\n.*/metadata\.json}mi) }
     end
 
     describe file('convert_report.txt') do
@@ -124,7 +124,7 @@ describe 'pdk convert', module_command: true do
     describe command("#{pdk_convert_base} --force --skip-interview") do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to have_no_output }
-      its(:stdout) { is_expected.to match(%r{-+files to be removed-+\n\.travis.yml}mi) }
+      its(:stdout) { is_expected.to match(%r{-+files to be removed-+\n.*/\.travis.yml}mi) }
     end
 
     describe file('.travis.yml') do
@@ -146,7 +146,7 @@ describe 'pdk convert', module_command: true do
     describe command("#{pdk_convert_base} --force --skip-interview") do
       its(:exit_status) { is_expected.to eq(0) }
       its(:stderr) { is_expected.to have_no_output }
-      its(:stdout) { is_expected.to match(%r{-+files to be added-+\nREADME\.md}mi) }
+      its(:stdout) { is_expected.to match(%r{-+files to be added-+\n.*/README\.md}mi) }
       describe file('README.md') do
         it { is_expected.to be_file }
       end

--- a/spec/acceptance/update_spec.rb
+++ b/spec/acceptance/update_spec.rb
@@ -34,8 +34,8 @@ describe 'pdk update', module_command: true do
 
       describe command('pdk update --noop') do
         its(:exit_status) { is_expected.to eq(0) }
-        its(:stdout) { is_expected.to match(%r{-+files to be added-+\n\.travis\.yml}mi) }
-        its(:stdout) { is_expected.to match(%r{-+files to be modified-+\nmetadata\.json}mi) }
+        its(:stdout) { is_expected.to match(%r{-+files to be added-+\n.*/\.travis\.yml}mi) }
+        its(:stdout) { is_expected.to match(%r{-+files to be modified-+\n.*/metadata\.json}mi) }
         its(:stderr) { is_expected.to match(%r{updating \w+?-update using the default template}i) }
 
         describe file('update_report.txt') do
@@ -49,8 +49,8 @@ describe 'pdk update', module_command: true do
 
       describe command('pdk update --force') do
         its(:exit_status) { is_expected.to eq(0) }
-        its(:stdout) { is_expected.to match(%r{-+files to be added-+\n\.travis\.yml}mi) }
-        its(:stdout) { is_expected.to match(%r{-+files to be modified-+\nmetadata\.json}mi) }
+        its(:stdout) { is_expected.to match(%r{-+files to be added-+\n.*/\.travis\.yml}mi) }
+        its(:stdout) { is_expected.to match(%r{-+files to be modified-+\n.*/metadata\.json}mi) }
         its(:stderr) { is_expected.to match(%r{updating \w+?-update using the default template}i) }
 
         describe file('update_report.txt') do

--- a/spec/unit/pdk/cli/convert_spec.rb
+++ b/spec/unit/pdk/cli/convert_spec.rb
@@ -3,6 +3,7 @@ require 'pdk/cli'
 
 describe 'PDK::CLI convert' do
   let(:help_text) { a_string_matching(%r{^USAGE\s+pdk convert}m) }
+  let(:module_root) { '/path/to/test/module' }
 
   context 'when not run from inside a module' do
     include_context 'run outside module'
@@ -22,7 +23,7 @@ describe 'PDK::CLI convert' do
 
   context 'when run from inside a module' do
     before(:each) do
-      allow(PDK::Util).to receive(:module_root).and_return('/path/to/test/module')
+      allow(PDK::Util).to receive(:module_root).and_return(module_root)
       allow(PDK::Module::Convert).to receive(:invoke)
     end
 
@@ -32,7 +33,7 @@ describe 'PDK::CLI convert' do
       end
 
       it 'invokes the converter with no template specified' do
-        expect(PDK::Module::Convert).to receive(:invoke).with(hash_not_including(:'template-url'))
+        expect(PDK::Module::Convert).to receive(:invoke).with(module_root, hash_not_including(:'template-url'))
       end
 
       it 'submits the command to analytics' do
@@ -50,7 +51,7 @@ describe 'PDK::CLI convert' do
       end
 
       it 'invokes the converter with the user supplied template' do
-        expect(PDK::Module::Convert).to receive(:invoke).with(hash_including(:'template-url' => 'https://my/template'))
+        expect(PDK::Module::Convert).to receive(:invoke).with(module_root, hash_including(:'template-url' => 'https://my/template'))
       end
 
       it 'submits the command to analytics' do
@@ -69,7 +70,7 @@ describe 'PDK::CLI convert' do
       end
 
       it 'invokes the converter with the user supplied template' do
-        expect(PDK::Module::Convert).to receive(:invoke).with(hash_including(:'template-url' => 'https://my/template', :'template-ref' => '1.0.0'))
+        expect(PDK::Module::Convert).to receive(:invoke).with(module_root, hash_including(:'template-url' => 'https://my/template', :'template-ref' => '1.0.0'))
       end
 
       it 'submits the command to analytics' do
@@ -88,7 +89,7 @@ describe 'PDK::CLI convert' do
       end
 
       it 'passes the noop option through to the converter' do
-        expect(PDK::Module::Convert).to receive(:invoke).with(hash_including(noop: true))
+        expect(PDK::Module::Convert).to receive(:invoke).with(module_root, hash_including(noop: true))
       end
 
       it 'submits the command to analytics' do
@@ -107,7 +108,7 @@ describe 'PDK::CLI convert' do
       end
 
       it 'passes the force option through to the converter' do
-        expect(PDK::Module::Convert).to receive(:invoke).with(hash_including(force: true))
+        expect(PDK::Module::Convert).to receive(:invoke).with(module_root, hash_including(force: true))
       end
 
       it 'submits the command to analytics' do
@@ -140,7 +141,7 @@ describe 'PDK::CLI convert' do
       end
 
       it 'passes the skip-interview option through to the converter' do
-        expect(PDK::Module::Convert).to receive(:invoke).with(hash_including(:'skip-interview' => true))
+        expect(PDK::Module::Convert).to receive(:invoke).with(module_root, hash_including(:'skip-interview' => true))
       end
 
       it 'submits the command to analytics' do
@@ -159,7 +160,7 @@ describe 'PDK::CLI convert' do
       end
 
       it 'passes the full-interview option through to the converter' do
-        expect(PDK::Module::Convert).to receive(:invoke).with(hash_including(:'full-interview' => true))
+        expect(PDK::Module::Convert).to receive(:invoke).with(module_root, hash_including(:'full-interview' => true))
       end
 
       it 'submits the command to analytics' do
@@ -179,7 +180,7 @@ describe 'PDK::CLI convert' do
 
       it 'ignores full-interview and continues with a log message' do
         expect(logger).to receive(:info).with(a_string_matching(%r{Ignoring --full-interview and continuing with --skip-interview.}i))
-        expect(PDK::Module::Convert).to receive(:invoke).with(hash_including(:'skip-interview' => true, :'full-interview' => false))
+        expect(PDK::Module::Convert).to receive(:invoke).with(module_root, hash_including(:'skip-interview' => true, :'full-interview' => false))
       end
 
       it 'submits the command to analytics' do
@@ -199,7 +200,7 @@ describe 'PDK::CLI convert' do
 
       it 'ignores full-interview and continues with a log message' do
         expect(logger).to receive(:info).with(a_string_matching(%r{Ignoring --full-interview and continuing with --force.}i))
-        expect(PDK::Module::Convert).to receive(:invoke).with(hash_including(:force => true, :'full-interview' => false))
+        expect(PDK::Module::Convert).to receive(:invoke).with(module_root, hash_including(:force => true, :'full-interview' => false))
       end
 
       it 'submits the command to analytics' do
@@ -244,7 +245,7 @@ describe 'PDK::CLI convert' do
           expected_template = PDK::Util::TemplateURI.default_template_addressable_uri.to_s
 
           expect(PDK::Module::Convert).to receive(:invoke)
-            .with(hash_including(:'template-url' => expected_template))
+            .with(module_root, hash_including(:'template-url' => expected_template))
         end
 
         it 'clears the saved template-url answer' do

--- a/spec/unit/pdk/cli/new/class_spec.rb
+++ b/spec/unit/pdk/cli/new/class_spec.rb
@@ -21,8 +21,10 @@ describe 'PDK::CLI new class' do
   end
 
   context 'when run from inside a module' do
+    let(:root_dir) { '/path/to/test/module' }
+
     before(:each) do
-      allow(PDK::Util).to receive(:module_root).and_return('/path/to/test/module')
+      allow(PDK::Util).to receive(:module_root).and_return(root_dir)
     end
 
     context 'and not provided with a class name' do
@@ -71,7 +73,7 @@ describe 'PDK::CLI new class' do
       end
 
       it 'generates the class' do
-        expect(PDK::Generate::PuppetClass).to receive(:new).with(anything, 'test_class', instance_of(Hash)).and_return(generator)
+        expect(PDK::Generate::PuppetClass).to receive(:new).with(root_dir, 'test_class', instance_of(Hash)).and_return(generator)
         expect(generator).to receive(:run)
       end
 

--- a/spec/unit/pdk/cli/new/defined_type_spec.rb
+++ b/spec/unit/pdk/cli/new/defined_type_spec.rb
@@ -69,7 +69,7 @@ describe 'PDK::CLI new defined_type' do
       let(:generator_opts) { instance_of(Hash) }
 
       before(:each) do
-        allow(generator).to receive(:new).with(anything, 'test_define', generator_opts).and_return(generator_double)
+        allow(generator).to receive(:new).with(module_root, 'test_define', generator_opts).and_return(generator_double)
       end
 
       after(:each) do

--- a/spec/unit/pdk/cli/new/task_spec.rb
+++ b/spec/unit/pdk/cli/new/task_spec.rb
@@ -69,7 +69,7 @@ describe 'PDK::CLI new task' do
       let(:generator_opts) { {} }
 
       before(:each) do
-        allow(generator).to receive(:new).with(anything, 'test_task', hash_including(generator_opts)).and_return(generator_double)
+        allow(generator).to receive(:new).with(module_root, 'test_task', hash_including(generator_opts)).and_return(generator_double)
       end
 
       it 'generates the task' do

--- a/spec/unit/pdk/cli/new/test_spec.rb
+++ b/spec/unit/pdk/cli/new/test_spec.rb
@@ -21,8 +21,10 @@ describe 'PDK::CLI new test' do
   end
 
   context 'when run from inside a module' do
+    let(:root_dir) { '/path/to/test/module' }
+
     before(:each) do
-      allow(PDK::Util).to receive(:module_root).and_return('/path/to/test/module')
+      allow(PDK::Util).to receive(:module_root).and_return(root_dir)
       allow(PDK::Util::Bundler).to receive(:ensure_bundle!)
       allow(PDK::Util::RubyVersion).to receive(:use)
       allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env).and_return(ruby_version: '2.4.5', gemset: { puppet: '5.0.0' })
@@ -83,7 +85,7 @@ describe 'PDK::CLI new test' do
         end
 
         it 'generates a unit test for the class' do
-          expect(PDK::Generate::PuppetClass).to receive(:new).with(anything, 'my_module::test_class', include(spec_only: true)).and_return(generator)
+          expect(PDK::Generate::PuppetClass).to receive(:new).with(root_dir, 'my_module::test_class', include(spec_only: true)).and_return(generator)
           expect(generator).to receive(:run)
         end
 
@@ -105,7 +107,7 @@ describe 'PDK::CLI new test' do
         end
 
         it 'generates a unit test for the class' do
-          expect(PDK::Generate::PuppetClass).to receive(:new).with(anything, 'my_module::test_class', include(spec_only: true)).and_return(generator)
+          expect(PDK::Generate::PuppetClass).to receive(:new).with(root_dir, 'my_module::test_class', include(spec_only: true)).and_return(generator)
           expect(generator).to receive(:run)
         end
 

--- a/spec/unit/pdk/cli/update_spec.rb
+++ b/spec/unit/pdk/cli/update_spec.rb
@@ -11,6 +11,7 @@ describe 'PDK::CLI update' do
   let(:module_pdk_version) { PDK::VERSION }
   let(:pinned_to_tag) { false }
   let(:template_uri) { PDK::Util::TemplateURI.new("pdk-default##{current_version}") }
+  let(:module_root) { '/path/to/test/module' }
 
   context 'when not run from inside a module' do
     include_context 'run outside module'
@@ -30,7 +31,7 @@ describe 'PDK::CLI update' do
 
   context 'when run from inside a module' do
     before(:each) do
-      allow(PDK::Util).to receive(:module_root).and_return('/path/to/test/module')
+      allow(PDK::Util).to receive(:module_root).and_return(module_root)
       allow(PDK::Util).to receive(:module_pdk_compatible?).and_return(true)
       allow(PDK::Util).to receive(:module_pdk_version).and_return(module_pdk_version)
     end
@@ -41,7 +42,7 @@ describe 'PDK::CLI update' do
       end
 
       it 'invokes the updater with no options' do
-        expect(PDK::Module::Update).to receive(:new) { |opts|
+        expect(PDK::Module::Update).to receive(:new) { |_, opts|
           expect(opts[:noop]).to be false if opts.key?(:noop)
           expect(opts[:force]).to be false if opts.key?(:false) # rubocop:disable Lint/BooleanSymbol
           expect(opts).not_to include(:'template-ref')
@@ -51,7 +52,7 @@ describe 'PDK::CLI update' do
       end
 
       it 'submits the command to analytics' do
-        allow(PDK::Module::Update).to receive(:new).with(anything).and_return(updater)
+        allow(PDK::Module::Update).to receive(:new).with(module_root, anything).and_return(updater)
 
         expect(analytics).to receive(:screen_view).with(
           'update',
@@ -67,7 +68,7 @@ describe 'PDK::CLI update' do
       end
 
       before(:each) do
-        allow(PDK::Module::Update).to receive(:new).with(any_args).and_return(updater)
+        allow(PDK::Module::Update).to receive(:new).with(module_root, any_args).and_return(updater)
         allow(updater).to receive(:run)
       end
 
@@ -84,12 +85,12 @@ describe 'PDK::CLI update' do
       end
 
       it 'passes the noop option through to the updater' do
-        expect(PDK::Module::Update).to receive(:new).with(hash_including(noop: true)).and_return(updater)
+        expect(PDK::Module::Update).to receive(:new).with(module_root, hash_including(noop: true)).and_return(updater)
         expect(updater).to receive(:run)
       end
 
       it 'submits the command to analytics' do
-        allow(PDK::Module::Update).to receive(:new).with(anything).and_return(updater)
+        allow(PDK::Module::Update).to receive(:new).with(module_root, anything).and_return(updater)
 
         expect(analytics).to receive(:screen_view).with(
           'update',
@@ -106,12 +107,12 @@ describe 'PDK::CLI update' do
       end
 
       it 'passes the force option through to the updater' do
-        expect(PDK::Module::Update).to receive(:new).with(hash_including(force: true)).and_return(updater)
+        expect(PDK::Module::Update).to receive(:new).with(module_root, hash_including(force: true)).and_return(updater)
         expect(updater).to receive(:run)
       end
 
       it 'submits the command to analytics' do
-        allow(PDK::Module::Update).to receive(:new).with(anything).and_return(updater)
+        allow(PDK::Module::Update).to receive(:new).with(module_root, anything).and_return(updater)
 
         expect(analytics).to receive(:screen_view).with(
           'update',
@@ -150,7 +151,7 @@ describe 'PDK::CLI update' do
 
       context 'and the --force flag has been passed' do
         it 'warns the user and then continues' do
-          allow(PDK::Module::Update).to receive(:new).with(hash_including(force: true)).and_return(updater)
+          allow(PDK::Module::Update).to receive(:new).with(module_root, hash_including(force: true)).and_return(updater)
           expect(logger).to receive(:warn).with(a_string_matching(%r{newer than your PDK version}i))
 
           PDK::CLI.run(%w[update --force])
@@ -161,7 +162,7 @@ describe 'PDK::CLI update' do
 
   context 'when run from inside an unconverted module' do
     before(:each) do
-      allow(PDK::Util).to receive(:module_root).and_return('/path/to/test/module')
+      allow(PDK::Util).to receive(:module_root).and_return(module_root)
       allow(PDK::Util).to receive(:module_pdk_compatible?).and_return(false)
     end
 

--- a/spec/unit/pdk/module/update_spec.rb
+++ b/spec/unit/pdk/module/update_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'pdk/module/update'
 
 describe PDK::Module::Update do
+  let(:module_root) { File.join('path', 'to', 'update') }
   let(:options) { {} }
   let(:mock_metadata) do
     instance_double(
@@ -16,9 +17,13 @@ describe PDK::Module::Update do
   let(:template_url) { 'https://github.com/puppetlabs/pdk-templates' }
   let(:template_ref) { nil }
 
+  def module_path(relative_path)
+    File.join(module_root, relative_path)
+  end
+
   shared_context 'with mock metadata' do
     before(:each) do
-      allow(PDK::Module::Metadata).to receive(:from_file).with('metadata.json').and_return(mock_metadata)
+      allow(PDK::Module::Metadata).to receive(:from_file).with(module_path('metadata.json')).and_return(mock_metadata)
     end
   end
 
@@ -48,7 +53,7 @@ describe PDK::Module::Update do
   describe '#pinned_to_puppetlabs_template_tag?' do
     subject { instance.pinned_to_puppetlabs_template_tag? }
 
-    let(:instance) { described_class.new(options) }
+    let(:instance) { described_class.new(module_root, options) }
 
     include_context 'with mock metadata'
 
@@ -154,7 +159,7 @@ describe PDK::Module::Update do
   end
 
   describe '#run' do
-    let(:instance) { described_class.new(options) }
+    let(:instance) { described_class.new(module_root, options) }
     let(:template_ref) { '1.3.2-0-g1234567' }
     let(:changes) { true }
 
@@ -290,7 +295,7 @@ describe PDK::Module::Update do
   end
 
   describe '#module_metadata' do
-    subject(:result) { described_class.new(options).module_metadata }
+    subject(:result) { described_class.new(module_root, options).module_metadata }
 
     context 'when the metadata.json can be read' do
       include_context 'with mock metadata'
@@ -302,7 +307,7 @@ describe PDK::Module::Update do
 
     context 'when the metadata.json can not be read' do
       before(:each) do
-        allow(PDK::Module::Metadata).to receive(:from_file).with('metadata.json').and_raise(ArgumentError, 'some error')
+        allow(PDK::Module::Metadata).to receive(:from_file).with(module_path('metadata.json')).and_raise(ArgumentError, 'some error')
       end
 
       it 'raises an ExitWithError exception' do
@@ -312,7 +317,7 @@ describe PDK::Module::Update do
   end
 
   describe '#template_uri' do
-    subject { described_class.new(options).template_uri.to_s }
+    subject { described_class.new(module_root, options).template_uri.to_s }
 
     include_context 'with mock metadata'
 
@@ -322,7 +327,7 @@ describe PDK::Module::Update do
   end
 
   describe '#current_version' do
-    subject { described_class.new(options).current_version }
+    subject { described_class.new(module_root, options).current_version }
 
     include_context 'with mock metadata'
 
@@ -344,7 +349,7 @@ describe PDK::Module::Update do
   end
 
   describe '#new_version' do
-    subject { described_class.new(options).new_version }
+    subject { described_class.new(module_root, options).new_version }
 
     include_context 'with mock metadata'
 
@@ -376,7 +381,7 @@ describe PDK::Module::Update do
   end
 
   describe '#new_template_version' do
-    subject { described_class.new(options).new_template_version }
+    subject { described_class.new(module_root, options).new_template_version }
 
     include_context 'with mock metadata'
 
@@ -462,7 +467,7 @@ describe PDK::Module::Update do
   end
 
   describe '#convert?' do
-    subject { described_class.new.convert? }
+    subject { described_class.new(module_root).convert? }
 
     it { is_expected.to be_falsey }
   end


### PR DESCRIPTION
Previously the `pdk new` command used the current directory as the module root
which caused errors when users executed `pdk new` when deep inside a module.
This commit changes the CLI to use the actual module root when creating the
generators, and updates the tests for this scenario.