### PR TITLE
(maint) Use case insensitive environment variable names on Windows

### DIFF
--- a/lib/pdk/util/env.rb
+++ b/lib/pdk/util/env.rb
@@ -4,25 +4,42 @@ require 'forwardable'
 module PDK
   module Util
     class Env
+      class WindowsEnv
+        extend Forwardable
+
+        # Note, these delegators may not have case insensitive keys
+        def_delegators :env_hash, :fetch, :select, :reject
+
+        def []=(key, value)
+          PDK::Util::Windows::Process.set_environment_variable(key, value)
+        end
+
+        def key?(key)
+          !env_hash.keys.find { |item| key.casecmp(item).zero? }.nil?
+        end
+
+        def [](key)
+          env_hash.each do |item, value|
+            next unless key.casecmp(item).zero?
+            return value
+          end
+          nil
+        end
+
+        private
+
+        def env_hash
+          PDK::Util::Windows::Process.environment_hash
+        end
+      end
+
       class << self
         extend Forwardable
 
-        def_delegators :env_hash, :[], :key?, :fetch, :select, :reject
+        def_delegators :implementation, :key?, :[], :[]=, :fetch, :select, :reject
 
-        def []=(key, value)
-          if Gem.win_platform?
-            PDK::Util::Windows::Process.set_environment_variable(key, value)
-          else
-            ENV[key] = value
-          end
-        end
-
-        def env_hash
-          if Gem.win_platform?
-            PDK::Util::Windows::Process.environment_hash
-          else
-            ENV
-          end
+        def implementation
+          @implementation ||= Gem.win_platform? ? WindowsEnv.new : ENV
         end
       end
     end

--- a/spec/unit/pdk/util/env_spec.rb
+++ b/spec/unit/pdk/util/env_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+require 'pdk/util/env'
+require 'securerandom'
+
+def on_windows
+  Gem.win_platform?
+end
+
+describe PDK::Util::Env do
+  before(:each) do
+    ENV[env_name] = env_val
+  end
+
+  after(:each) do
+    ENV.delete(env_name)
+  end
+
+  let(:env_name) { SecureRandom.hex(10) + 'ABCabc' }
+  let(:env_val) { 'PDK::Util::Env test value' }
+  let(:upcase_name) { env_name.upcase }
+  let(:downcase_name) { env_name.upcase }
+
+  describe '[]' do
+    it 'is case insensitive on Windows platform', if: on_windows do
+      expect(described_class[env_name]).to eq(env_val)
+      expect(described_class[downcase_name]).to eq(env_val)
+      expect(described_class[upcase_name]).to eq(env_val)
+    end
+
+    it 'is case sensitive on non-Windows platform', unless: on_windows do
+      expect(described_class[env_name]).to eq(env_val)
+      expect(described_class[downcase_name]).to be_nil
+      expect(described_class[upcase_name]).to be_nil
+    end
+  end
+
+  describe '[]=' do
+    let(:new_val) { 'New PDK::Util::Env test value' }
+
+    before(:each) do
+      # Order is important here.
+      ENV.delete(upcase_name)
+      ENV[env_name] = env_val
+      expect(described_class[env_name]).to eq(env_val)
+    end
+
+    after(:each) do
+      ENV.delete(upcase_name)
+    end
+
+    it 'is case insensitive on Windows platform', if: on_windows do
+      described_class[upcase_name] = new_val
+      expect(described_class[env_name]).to eq(new_val)
+      expect(described_class[upcase_name]).to eq(new_val)
+    end
+
+    it 'is case sensitive on non-Windows platform', unless: on_windows do
+      described_class[upcase_name] = new_val
+      expect(described_class[env_name]).to eq(env_val)
+      expect(described_class[upcase_name]).to eq(new_val)
+    end
+  end
+
+  describe '.key?' do
+    let(:new_val) { 'New PDK::Util::Env test value' }
+
+    it 'is case insensitive on Windows platform', if: on_windows do
+      expect(described_class.key?(env_name)).to be true
+      expect(described_class.key?(downcase_name)).to be true
+      expect(described_class.key?(upcase_name)).to be true
+    end
+
+    it 'is case sensitive on non-Windows platform', unless: on_windows do
+      expect(described_class.key?(env_name)).to be true
+      expect(described_class.key?(downcase_name)).to be false
+      expect(described_class.key?(upcase_name)).to be false
+    end
+  end
+end


### PR DESCRIPTION
Previously the PDK Env class had case sensitive keys which meant 'PATH' could
be nil but 'Path' would have the correct value.  This commit updates the
PDK::Util::Env class to be case insensitive on Windows, by having it's own
Hash implementation. And delegates to ENV on non-windows platforms.  This
commit also adds tests for these scenarios.