### PR TITLE
(PDK-1588) Increase granularity of `pdk bundle` analytics

### DIFF
--- a/lib/pdk/cli/bundle.rb
+++ b/lib/pdk/cli/bundle.rb
@@ -20,7 +20,11 @@ EOF
 
       PDK::CLI::Util.validate_puppet_version_opts({})
 
-      PDK::CLI::Util.analytics_screen_view('bundle')
+      screen_view_name = ['bundle']
+      screen_view_name << args[0] if args.size >= 1
+      screen_view_name << args[1] if args.size >= 2 && args[0] == 'exec'
+
+      PDK::CLI::Util.analytics_screen_view(screen_view_name.join('_'))
 
       # Ensure that the correct Ruby is activated before running command.
       puppet_env = PDK::CLI::Util.puppet_from_opts_or_env({})

--- a/spec/unit/pdk/cli/bundle_spec.rb
+++ b/spec/unit/pdk/cli/bundle_spec.rb
@@ -2,7 +2,68 @@ require 'spec_helper'
 require 'pdk/cli'
 
 describe 'Running `pdk bundle`' do
-  subject(:test_cmd) { PDK::CLI.instance_variable_get(:@bundle_cmd) }
+  let(:command_args) { ['bundle'] }
+  let(:command_result) { { exit_code: 0 } }
 
-  it { is_expected.not_to be_nil }
+  context 'when it calls bundler successfully' do
+    after(:each) do
+      expect {
+        PDK::CLI.run(command_args)
+      }.to exit_zero
+    end
+
+    before(:each) do
+      mock_command = instance_double(
+        PDK::CLI::Exec::InteractiveCommand,
+        :context=           => true,
+        :update_environment => true,
+        :execute!           => command_result,
+      )
+      allow(PDK::CLI::Exec::InteractiveCommand).to receive(:new)
+        .with(PDK::CLI::Exec.bundle_bin, *(command_args[1..-1] || []))
+        .and_return(mock_command)
+
+      allow(PDK::Util).to receive(:module_root)
+        .and_return(File.join('path', 'to', 'test', 'module'))
+      allow(PDK::Module::Metadata).to receive(:from_file)
+        .with('metadata.json').and_return({})
+      allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env)
+        .and_return(ruby_version: '2.4.3', gemset: { puppet: '5.4.0' })
+      allow(PDK::Util::RubyVersion).to receive(:use)
+    end
+
+    context 'and called with no arguments' do
+      it 'sends a "bundle" screen view to analytics' do
+        expect(analytics).to receive(:screen_view).with(
+          'bundle',
+          output_format: 'default',
+          ruby_version:  RUBY_VERSION,
+        )
+      end
+    end
+
+    context 'and called with a bundler subcommand that is not "exec"' do
+      let(:command_args) { super() + %w[config something] }
+
+      it 'includes only the subcommand in the screen view name sent to analytics' do
+        expect(analytics).to receive(:screen_view).with(
+          'bundle_config',
+          output_format: 'default',
+          ruby_version:  RUBY_VERSION,
+        )
+      end
+    end
+
+    context 'and called with the "exec" bundler subcommand' do
+      let(:command_args) { super() + ['exec', 'rspec', 'some/path'] }
+
+      it 'includes the name of the command being executed in the screen view sent to analytics' do
+        expect(analytics).to receive(:screen_view).with(
+          'bundle_exec_rspec',
+          output_format: 'default',
+          ruby_version:  RUBY_VERSION,
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Up until now, when a user ran a `pdk bundle` command we would only
report a `bundle` screen view to our analytics. This resulted in us
finding out that a lot of users use `pdk bundle` but provided no insight
into why.

When a user runs `pdk bundle`, we will now capture the bundler
subcommand (but not any of the other arguments). The only exception to
this is if the user runs `pdk bundle exec` in which case we will also
capture the name of the command that is being executed (but again, none
of the arguments).

e.g.

 * `pdk bundle show some_gem` will now be reported as a `bundle_show`
    screen view.
 * `pdk bundle exec rspec path/to/some/ruby_spec.rb` will now be
    reported as a `bundle_exec_rspec` screen view.