### PR TITLE
(PDK-1590) Remove Gemfile.lock before running bundle update

### DIFF
--- a/package-testing/spec/package/version_selection_spec.rb
+++ b/package-testing/spec/package/version_selection_spec.rb
@@ -26,7 +26,7 @@ describe 'Test puppet & ruby version selection' do
         puppet_versions.map { |r| Regexp.escape(r) }.join('|')
       end
 
-      describe command('pdk bundle update --local') do
+      describe command('rm Gemfile.lock; pdk bundle update --local') do
         its(:exit_status) { is_expected.to eq(0) }
       end
 


### PR DESCRIPTION
As the 2.4 and 2.5 runtimes have updated to use Bundler 2.x but the 2.1
runtime is stuck on Bundler 1.x, we need to remove the Gemfile.lock
manually during the version_selection package tests as Bundler 1.x hard
fails when it encounters a 2.x lockfile. This is not a problem with
other PDK commands as they update the lockfile before shelling out but
we deliberately don't do that for `pdk bundle`.