### PR TITLE
(PDK-1590) Use short path names when calling Bundler ruby bin

### DIFF
--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -116,20 +116,7 @@ module PDK
       raise PDK::CLI::FatalError, _('Package basedir requested for non-package install.') unless package_install?
       require 'pdk/util/version'
 
-      dir = File.dirname(PDK::Util::Version.version_file)
-      return dir unless Gem.win_platform?
-
-      begin
-        # Note that the short path detection is not fool-proof.  For example if 8.3 filename creation is disabled
-        # there is no shortname to find. In that case it just returns the long name
-        short_path = PDK::Util::Windows::File.get_short_pathname(dir)
-      rescue RuntimeError => ex
-        # If there are any failures detecting the short path then log a warning and return the, possibly, long path
-        PDK.logger.warn(_("Failed to resolve the shortname of the PDK package directory '%{path}': %{message}") %
-          { path: dir, message: ex.message })
-        return dir
-      end
-      short_path
+      File.dirname(PDK::Util::Version.version_file)
     end
     module_function :pdk_package_basedir
 

--- a/lib/pdk/util/ruby_version.rb
+++ b/lib/pdk/util/ruby_version.rb
@@ -94,7 +94,10 @@ module PDK
         require 'pdk/util'
 
         if PDK::Util.package_install?
-          File.join(PDK::Util.pdk_package_basedir, 'private', 'ruby', ruby_version, 'bin')
+          # Bundler is very sensitive to spaces in path names so on Windows use the ShortPath API
+          # to get a path that will probably not have spaces.
+          pkg_base_dir = PDK::Util.on_windows? ? PDK::Util::Windows::File.safe_get_short_pathname(PDK::Util.pdk_package_basedir) : PDK::Util.pdk_package_basedir
+          File.join(pkg_base_dir, 'private', 'ruby', ruby_version, 'bin')
         else
           RbConfig::CONFIG['bindir']
         end

--- a/lib/pdk/util/windows.rb
+++ b/lib/pdk/util/windows.rb
@@ -1,15 +1,28 @@
 module PDK
   module Util
+    #:nocov:
+    def on_windows?
+      # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
+      # requiring features to be initialized and without side effect.
+      #
+      # This should _NOT_ be mocked in tests. Code using this detection cannot
+      # be mocked (e.g. Windows API calls) and if mocked, will most likely cause
+      # false test failures on non-Windows platforms
+      !!File::ALT_SEPARATOR # rubocop:disable Style/DoubleNegation This is fine. Cannot use Gem.win_platform? as that is commonly mocked
+    end
+    module_function :on_windows?
+
     module Windows
       WIN32_FALSE = 0
       module File; end
 
-      if Gem.win_platform?
+      if PDK::Util.on_windows?
         require 'pdk/util/windows/api_types'
         require 'pdk/util/windows/string'
         require 'pdk/util/windows/file'
         require 'pdk/util/windows/process'
       end
     end
+    #:nocov:
   end
 end

--- a/lib/pdk/util/windows/file.rb
+++ b/lib/pdk/util/windows/file.rb
@@ -44,6 +44,23 @@ module PDK::Util::Windows::File
   end
   module_function :get_short_pathname
 
+  # Wraps the call to get the short path name in Windows and swallows any errors.
+  #
+  # @api private
+  def safe_get_short_pathname(path)
+    # Note that the short path detection is not fool-proof.  For example if 8.3 filename creation is disabled
+    # there is no shortname to find. In that case it just returns the long name.
+    #
+    # Testing this is also not needed as it's just wrapping core Windows APIs
+    PDK::Util::Windows::File.get_short_pathname(path)
+  rescue RuntimeError => ex
+    # If there are any failures detecting the short path then log a warning and return the, possibly, long path
+    PDK.logger.warn(_("Failed to resolve the shortname of the path '%{path}': %{message}") %
+      { path: path, message: ex.message })
+    path
+  end
+  module_function :safe_get_short_pathname
+
   ffi_convention :stdcall
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa364980(v=vs.85).aspx

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -225,12 +225,6 @@ describe PDK::Util do
     end
 
     context 'when the PDK was installed from a native package', version_file: true do
-      # Note that on Windows, this is not testing the ShortPath conversion as the
-      # path is mocked and the ShortPath API call requires a real on-disk file.  This test
-      # succeeds because if there is an error in the ShortPath detection, it just uses the
-      # long path instead.
-      #
-      # This functionality is exercised properly in the package-testing (acceptance tests)
       it 'returns the directory where the version file is located' do
         is_expected.to eq(File.dirname(version_file))
       end


### PR DESCRIPTION
Previously the full path was used to call the Bundler bin. Unforunately as in
commit 10736a4 Bundler is sensitive to spaces in path names.  This commit
modifies the bundler bin path generation to use short path name.

Note that this does not have unit tests as it can't really be tested. But it is
tested as part of the packaging tests.

Note that an additional Windows detection method (PDK::Util.on_windows?) is
introduced.  This method is designed specifically to _NOT_ be mocked and any
code using this method will probably raise errors on non-Windows platforms e.g.
calling Windows API via FFI.  Gem.win_platform? is commonly used in the PDK
codebase and is also commonly mocked.