### PR TITLE
(maint) Fix license_finder failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
       env: CHECK=spec:coverage
     - rvm: 2.4.3
       env: CHECK=license_finder
-      bundler_args: "" # license_finder requires all gems installed
+      bundler_args: "--with development" # license_finder requires all gems installed. Also can't use an empty string so just include any bundler group
     - rvm: 2.5
       env: CHECK=spec
     - rvm: 2.3

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ end
 group :test do
   gem 'coveralls'
   gem 'json', '~> 2.2.0'
-  gem 'license_finder', '~> 3.0.4'
+  gem 'license_finder', '~> 5.4.1'
   if RUBY_VERSION < '2.4'
     # license_finder depends on rubyzip which requires Ruby 2.4 in 2.x
     gem 'rubyzip', '< 2.0.0'


### PR DESCRIPTION
Previously the Travis tests for license_finder were breaking in master due to
Travis configuration. Also the gem was pinned to a very old version.  This
commit updates the Travis configuration so that it correctly sets the bundler
args (can't use an empty string anymore) and updates the license_finder gem
to the latest that's compatible with Ruby 2.1.9.