### PR TITLE
(PDK-1545) Include template-ref in module generation output

### DIFF
--- a/lib/pdk/util/template_uri.rb
+++ b/lib/pdk/util/template_uri.rb
@@ -94,6 +94,10 @@ module PDK
         bare_uri == PDK::Util::TemplateURI.bare_uri(PDK::Util::TemplateURI.default_template_addressable_uri)
       end
 
+      def default_ref?
+        uri_fragment == self.class.default_template_ref(self)
+      end
+
       def puppetlabs_template?
         self.class.packaged_template?(bare_uri) || bare_uri == PDK_TEMPLATE_URL
       end

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -220,9 +220,11 @@ describe PDK::Generate::Module do
       end
 
       context 'when a template-url is supplied on the command line' do
+        let(:default_template_url) { 'https://github.com/puppetlabs/pdk-templates' }
+
         before(:each) do
           allow(PDK::Util::Filesystem).to receive(:mv).with(temp_target_dir, target_dir).and_return(0)
-          allow(PDK::Util).to receive(:default_template_uri).and_return(Addressable::URI.parse('https://github.com/puppetlabs/pdk-templates'))
+          allow(PDK::Util).to receive(:default_template_uri).and_return(Addressable::URI.parse(default_template_url))
         end
 
         it 'uses that template to generate the module' do
@@ -245,10 +247,16 @@ describe PDK::Generate::Module do
           described_class.invoke(invoke_opts.merge(:'template-url' => 'cli-template'))
         end
 
+        it 'saves the template-url and template-ref to the answer file if it is not the default ref' do
+          expect(PDK.answers).to receive(:update!).with('template-url' => "#{default_template_url}#1.2.3")
+
+          described_class.invoke(invoke_opts.merge(:'template-url' => default_template_url, :'template-ref' => '1.2.3'))
+        end
+
         it 'clears the saved template-url answer if it is the default template' do
           expect(PDK.answers).to receive(:update!).with('template-url' => nil).and_call_original
 
-          described_class.invoke(invoke_opts.merge(:'template-url' => 'https://github.com/puppetlabs/pdk-templates'))
+          described_class.invoke(invoke_opts.merge(:'template-url' => default_template_url))
           expect(PDK.answers['template-url']).to eq(nil)
         end
       end


### PR DESCRIPTION
Using the default template (no saved answer, no cli override):
```
pdk (INFO): Creating new module: foo
pdk (INFO): Using the default template-uri and template-ref.
[✔] Resolving default Gemfile dependencies.
pdk (INFO): Module 'foo' generated at path '/home/tsharpe/code/puppetlabs/pdk/foo'.
pdk (INFO): In your module directory, add classes with the 'pdk new class' command.
```

Specifying the template-ref or template-url in the cli:
```
pdk (INFO): Creating new module: foo
pdk (INFO): Using the specified template-url and template-ref 'https://github.com/puppetlabs/pdk-templates#1.10.0'.
[✔] Resolving default Gemfile dependencies.
pdk (INFO): Module 'foo' generated at path '/home/tsharpe/code/puppetlabs/pdk/foo'.
pdk (INFO): In your module directory, add classes with the 'pdk new class' command.
```

Using the value saved in the answers:
```
pdk (INFO): Creating new module: foo
pdk (INFO): Using the saved template-url and template-ref 'https://github.com/puppetlabs/pdk-templates#1.10.0'.
[✔] Resolving default Gemfile dependencies.
pdk (INFO): Module 'foo' generated at path '/home/tsharpe/code/puppetlabs/pdk/foo'.
pdk (INFO): In your module directory, add classes with the 'pdk new class' command.
```