### PR TITLE
(maint) Update for Ruby 2.3 and JSON Schema tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -149,6 +149,10 @@ Style/SymbolArray:
 Layout/EndOfLine:
   EnforcedStyle: lf
 
+# The duplicate gem detection in Gemfile is broken for if-else statements
+Bundler/DuplicatedGem:
+  Enabled: false
+
 PDK/FileFilePredicate:
   Exclude:
     - lib/pdk/util/filesystem.rb

--- a/Gemfile
+++ b/Gemfile
@@ -8,20 +8,29 @@ if RUBY_VERSION < '2.3.0'
   gem 'cri', '>= 2.10.1', '< 2.11.0'
   gem 'nokogiri', '1.7.2'
 else
-  gem 'nokogiri', '~> 1.10.4' # rubocop:disable Bundler/DuplicatedGem
+  gem 'nokogiri', '~> 1.10.4'
 end
 
 group :development do
   gem 'activesupport', '4.2.9'
   gem 'github_changelog_generator', '~> 1.14'
-  gem 'pry-byebug', '~> 3.4'
-  if RUBY_VERSION < '2.2.2'
+  if RUBY_VERSION < '2.2.0'
+    # pry-byebug >= 3.5.0 requires ruby 2.2.0 or newer
+    gem 'pry-byebug', '~> 3.4.0'
     # byebug >= 9.1.0 requires ruby 2.2.0 or newer
     gem 'byebug', '~> 9.0.6'
     # required for github_changelog_generator
     gem 'rack', '~> 1.0'
+  elsif RUBY_VERSION < '2.4.0'
+    # pry-byebug >= 3.8.0 requires ruby 2.4.0 or newer
+    gem 'pry-byebug', '~> 3.7.0'
+    # byebug >= 11.1.0 requires ruby 2.4.0 or newer
+    gem 'byebug', '~> 11.0.1'
+  else
+    gem 'pry-byebug', '~> 3.4'
   end
-  gem 'ruby-prof'
+  # ruby-prof >= 1.0 requires Ruby 2.4.0 or newer
+  gem 'ruby-prof' if RUBY_VERSION >= '2.4.0'
   gem 'yard'
 end
 

--- a/spec/unit/pdk/config/json_schema_setting_spec.rb
+++ b/spec/unit/pdk/config/json_schema_setting_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 require 'pdk/config/json_schema_setting'
 
-describe PDK::Config::JSONSchemaSetting do
+# Note that the JSON Schema Gem is too unreliable for testing right now.
+# For the moment, all tests are skipped here.
+describe PDK::Config::JSONSchemaSetting, skip: true do
   subject(:setting) { described_class.new('spec_setting', namespace, initial_value) }
 
   let(:initial_value) { nil }


### PR DESCRIPTION
This commit updates the development group dependences for Ruby 2.3.

---

Previously in commit 419dc51 many of the JSON Schema tests were disabled,
however one test file was missed.  This commit also skips
pdk\config\json_schema_setting_spec.rb.