### PR TITLE
{WIP} (maint) Only call bundle when needed for validators

### DIFF
--- a/lib/pdk/validate/validator.rb
+++ b/lib/pdk/validate/validator.rb
@@ -94,6 +94,26 @@ module PDK
         prepare_invoke!
         0
       end
+
+      # Returns this validator and recursively any child validator instances
+      #
+      # @return [Array[PDK::Validate::Validator]]
+      # @abstract
+      def resolve_validator_tree(include_self = true)
+        return [self] if child_validators.empty?
+
+        resolved = include_self ? [self] : []
+        child_validators.each { |child| resolved.concat(child.resolve_validator_tree(false)) }
+        resolved
+      end
+
+      # Returns any child validator instances
+      #
+      # @return [Array[PDK::Validate::Validator]]
+      # @abstract
+      def child_validators
+        []
+      end
     end
   end
 end

--- a/lib/pdk/validate/validator_group.rb
+++ b/lib/pdk/validate/validator_group.rb
@@ -44,7 +44,7 @@ module PDK
         @spinner = TTY::Spinner::Multi.new("[:spinner] #{spinner_text}", PDK::CLI::Util.spinner_opts_for_platform)
 
         # Register the child spinners
-        validator_instances.each do |instance|
+        child_validators.each do |instance|
           next if instance.spinner.nil?
           @spinner.register(instance.spinner)
         end
@@ -64,7 +64,7 @@ module PDK
         spinner
 
         # Prepare child validators
-        validator_instances.each { |instance| instance.prepare_invoke! }
+        child_validators.each { |instance| instance.prepare_invoke! }
         nil
       end
 
@@ -82,7 +82,7 @@ module PDK
         prepare_invoke!
         start_spinner
 
-        validator_instances.each do |instance|
+        child_validators.each do |instance|
           exit_code = instance.invoke(report)
           break if exit_code != 0
         end
@@ -92,11 +92,11 @@ module PDK
         exit_code
       end
 
-      # The instanitated PDK::Validator::Validator classes from the `validators` array
+      # The instantiated PDK::Validator::Validator classes from the `validators` array
       # @return Array[PDK::Validator::Validator]
-      # @api private
-      def validator_instances
-        @validator_instances ||= validators.map { |klass| klass.new(options.merge(parent_validator: self)) }
+      # @see PDK::Validate::Validator.child_validators
+      def child_validators
+        @child_validators ||= validators.map { |klass| klass.new(options.merge(parent_validator: self)) }
       end
     end
   end

--- a/spec/unit/pdk/cli/validate_spec.rb
+++ b/spec/unit/pdk/cli/validate_spec.rb
@@ -17,12 +17,18 @@ describe 'Running `pdk validate` in a module' do
     allow(PDK::Util).to receive(:module_root).and_return('/path/to/testmodule')
     allow(PDK::Util).to receive(:module_pdk_version).and_return(PDK::VERSION)
 
-    allow(PDK::Validate).to receive(:invoke_validators_by_name).and_return([0, report])
+    allow(PDK::Validate).to receive(:invoke_validators).and_return([0, report])
+  end
+
+  RSpec::Matchers.define :a_validator_of do |klass|
+    match do |actual|
+      actual.find { |validator| validator.is_a?(klass) }
+    end
   end
 
   context 'when no arguments or options are provided' do
     it 'invokes each validator with no report and no options and exits zero' do
-      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(PDK::Validate.validator_names, false, hash_including(puppet: puppet_version)).and_return([0, report])
+      expect(PDK::Validate).to receive(:invoke_validators).with(Array, false, hash_including(puppet: puppet_version)).and_return([0, report])
 
       expect(logger).to receive(:info).with('Running all available validators...')
 
@@ -41,7 +47,7 @@ describe 'Running `pdk validate` in a module' do
 
     context 'with --parallel' do
       it 'invokes each validator with no report and no options and exits zero' do
-        expect(PDK::Validate).to receive(:invoke_validators_by_name).with(PDK::Validate.validator_names, true, hash_including(puppet: puppet_version)).and_return([0, report])
+        expect(PDK::Validate).to receive(:invoke_validators).with(Array, true, hash_including(puppet: puppet_version)).and_return([0, report])
 
         expect(logger).to receive(:info).with('Running all available validators...')
 
@@ -82,7 +88,12 @@ describe 'Running `pdk validate` in a module' do
 
   context 'when a single validator is provided as an argument' do
     it 'only invokes the given validator and exits zero' do
-      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(['metadata'], false, hash_including(puppet: puppet_version)).and_return([0, report])
+      expect(PDK::Validate).to receive(:instantiate_validators_by_name).with(['metadata'], Hash).and_call_original
+      expect(PDK::Validate).to receive(:invoke_validators).with(
+        a_validator_of(PDK::Validate::Metadata::MetadataValidatorGroup),
+        false,
+        hash_including(puppet: puppet_version),
+      ).and_return([0, report])
 
       expect { PDK::CLI.run(%w[validate metadata]) }.to exit_zero
     end
@@ -102,7 +113,8 @@ describe 'Running `pdk validate` in a module' do
     let(:invoked_validators) { %w[metadata puppet] }
 
     it 'invokes each given validator and exits zero' do
-      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(invoked_validators, false, hash_including(puppet: puppet_version)).and_return([0, report])
+      expect(PDK::Validate).to receive(:instantiate_validators_by_name).with(invoked_validators, Hash).and_call_original
+      expect(PDK::Validate).to receive(:invoke_validators).with(Array, false, hash_including(puppet: puppet_version)).and_return([0, report])
 
       expect { PDK::CLI.run(['validate', 'puppet,metadata']) }.to exit_zero
     end
@@ -123,7 +135,8 @@ describe 'Running `pdk validate` in a module' do
 
     it 'warns about unknown validators, invokes known validators, and exits zero' do
       expect(logger).to receive(:warn).with(%r{Unknown validator 'bad-val'. Available validators: #{pretty_validator_names}}i)
-      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(invoked_validators, false, hash_including(puppet: puppet_version)).and_return([0, report])
+      expect(PDK::Validate).to receive(:instantiate_validators_by_name).with(invoked_validators, Hash).and_call_original
+      expect(PDK::Validate).to receive(:invoke_validators).with(Array, false, hash_including(puppet: puppet_version)).and_return([0, report])
 
       expect { PDK::CLI.run(['validate', 'puppet,bad-val']) }.to exit_zero
     end
@@ -143,7 +156,8 @@ describe 'Running `pdk validate` in a module' do
     let(:invoked_validators) { %w[metadata] }
 
     it 'invokes the specified validator with the target as an option' do
-      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(invoked_validators, false, hash_including(puppet: puppet_version, targets: ['lib/', 'manifests/'])).and_return([0, report])
+      expect(PDK::Validate).to receive(:instantiate_validators_by_name).with(invoked_validators, Hash).and_call_original
+      expect(PDK::Validate).to receive(:invoke_validators).with(Array, false, hash_including(puppet: puppet_version, targets: ['lib/', 'manifests/'])).and_return([0, report])
 
       expect { PDK::CLI.run(['validate', 'metadata', 'lib/', 'manifests/']) }.to exit_zero
     end
@@ -163,7 +177,8 @@ describe 'Running `pdk validate` in a module' do
     let(:invoked_validators) { PDK::Validate.validator_names }
 
     it 'invokes all validators with the target as an option' do
-      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(invoked_validators, false, hash_including(puppet: puppet_version, targets: ['lib/', 'manifests/'])).and_return([0, report])
+      expect(PDK::Validate).to receive(:instantiate_validators_by_name).with(invoked_validators, Hash).and_call_original
+      expect(PDK::Validate).to receive(:invoke_validators).with(Array, false, hash_including(puppet: puppet_version, targets: ['lib/', 'manifests/'])).and_return([0, report])
 
       expect(logger).to receive(:info).with('Running all available validators...')
 

--- a/spec/unit/pdk/validate/validator_group_spec.rb
+++ b/spec/unit/pdk/validate/validator_group_spec.rb
@@ -31,7 +31,7 @@ describe PDK::Validate::ValidatorGroup do
 
         # This is a little convulted. The TTY Multi Spinner is Enumerable, so the first item
         # is the parent spinner, and subsequent items and registered child spinners
-        expect(obj.entries[1]).to eq(validator_group.validator_instances.first.spinner)
+        expect(obj.entries[1]).to eq(validator_group.child_validators.first.spinner)
       end
     end
 
@@ -52,7 +52,7 @@ describe PDK::Validate::ValidatorGroup do
     end
 
     it 'calls prepare_invoke! for each validator in the group' do
-      expect(validator_group.validator_instances).to all(receive(:prepare_invoke!).and_call_original)
+      expect(validator_group.child_validators).to all(receive(:prepare_invoke!).and_call_original)
       validator_group.prepare_invoke!
     end
   end
@@ -80,7 +80,7 @@ describe PDK::Validate::ValidatorGroup do
     end
 
     it 'calls invoke of each validator in the group' do
-      expect(validator_group.validator_instances).to all(receive(:invoke).with(report).and_call_original)
+      expect(validator_group.child_validators).to all(receive(:invoke).with(report).and_call_original)
       validator_group.invoke(report)
     end
 
@@ -105,11 +105,11 @@ describe PDK::Validate::ValidatorGroup do
       end
 
       it 'does not call invoke once a validator has failed' do
-        expect(validator_group.validator_instances[0]).to receive(:invoke).and_call_original
+        expect(validator_group.child_validators[0]).to receive(:invoke).and_call_original
         # The second validator fails
-        expect(validator_group.validator_instances[1]).to receive(:invoke).and_call_original
+        expect(validator_group.child_validators[1]).to receive(:invoke).and_call_original
         # The third validator also fails but should never be called
-        expect(validator_group.validator_instances[2]).not_to receive(:invoke)
+        expect(validator_group.child_validators[2]).not_to receive(:invoke)
 
         validator_group.invoke(report)
       end
@@ -121,22 +121,22 @@ describe PDK::Validate::ValidatorGroup do
     end
   end
 
-  describe '.validator_instances' do
+  describe '.child_validators' do
     before(:each) do
       allow(validator_group).to receive(:validators).and_return([MockSuccessValidator, PDK::Validate::Validator])
     end
 
     it 'returns instances of the classes in validators' do
-      validator_group.validator_instances.each_with_index do |item, index|
+      validator_group.child_validators.each_with_index do |item, index|
         expect(item).to be_a(validator_group.validators[index])
       end
     end
 
     it 'returns the same object in mulitple calls' do
       # Get the object_ids for the first call
-      object_ids = validator_group.validator_instances.map(&:object_id)
+      object_ids = validator_group.child_validators.map(&:object_id)
       # Compare the object_ids on the second call
-      expect(validator_group.validator_instances.map(&:object_id)).to eq(object_ids)
+      expect(validator_group.child_validators.map(&:object_id)).to eq(object_ids)
     end
   end
 end


### PR DESCRIPTION
Previously PDK would call bundle, even if the validator doesn't need it, for
example internal validators like JSON or YAML.  This commit changes the CLI for
`pdk validate` to first check all of the requested validators to see if they
require a valid bundle and then only call bundle if needed.  This significantly
speeds up validation for validators like JSON or YAML syntax.