### PR TITLE
(PDK-1615) Add Ini File configuration support

### DIFF
--- a/lib/pdk/config.rb
+++ b/lib/pdk/config.rb
@@ -2,6 +2,8 @@ require 'pdk'
 
 module PDK
   class Config
+    autoload :IniFile, 'pdk/config/ini_file'
+    autoload :IniFileSetting, 'pdk/config/ini_file_setting'
     autoload :JSON, 'pdk/config/json'
     autoload :JSONSchemaNamespace, 'pdk/config/json_schema_namespace'
     autoload :JSONSchemaSetting, 'pdk/config/json_schema_setting'

--- a/lib/pdk/config/ini_file.rb
+++ b/lib/pdk/config/ini_file.rb
@@ -1,0 +1,183 @@
+require 'pdk'
+
+module PDK
+  class Config
+    # Represents a configuration file using the INI file format
+    class IniFile < Namespace
+      # Ini Files have very strict valdiation rules which are set in the IniFileSetting class
+      # @see PDK::Config::Namespace.default_setting_class
+      def default_setting_class
+        PDK::Config::IniFileSetting
+      end
+
+      # Parses an IniFile document.
+      #
+      # @see PDK::Config::Namespace.parse_file
+      def parse_file(filename)
+        raise unless block_given?
+        data = load_data(filename)
+        return if data.nil? || data.empty?
+
+        ini_file = IniFileImpl.parse(data)
+        ini_file.to_hash.each do |name, value|
+          begin
+            new_setting = PDK::Config::IniFileSetting.new(name, self, value)
+          rescue StandardError
+            # We just ignore invalid initial settings
+            new_setting = PDK::Config::IniFileSetting.new(name, self, nil)
+          end
+
+          yield name, new_setting
+        end
+      end
+
+      # Serializes object data into an INI file string.
+      #
+      # @see PDK::Config::Namespace.serialize_data
+      def serialize_data(data)
+        default_lines = ''
+        lines = ''
+        data.each do |name, value|
+          next if value.nil?
+          if value.is_a?(Hash)
+            # Hashes are an INI section
+            lines += "\n[#{name}]\n"
+            value.each do |child_name, child_value|
+              next if child_value.nil?
+              lines += "#{child_name} = #{munge_serialized_value(child_value)}\n"
+            end
+          else
+            default_lines += "#{name} = #{munge_serialized_value(value)}\n"
+          end
+        end
+
+        default_lines + lines
+      end
+
+      private
+
+      def munge_serialized_value(value)
+        value = value.to_s unless value.is_a?(String)
+        # Add enclosing quotes if there's a space in the value
+        value = '"' + value + '"' if value.include?(' ')
+        value
+      end
+
+      # Adapted from https://raw.githubusercontent.com/puppetlabs/puppet/6c257fc7827989c2af2901f974666f0f23611153/lib/puppet/settings/ini_file.rb
+      # rubocop:disable Style/RegexpLiteral
+      # rubocop:disable Style/PerlBackrefs
+      # rubocop:disable Style/RedundantSelf
+      # rubocop:disable Style/StringLiterals
+      class IniFileImpl
+        DEFAULT_SECTION_NAME = 'default_section_name'.freeze
+
+        def self.parse(config_fh)
+          config = new([DefaultSection.new])
+          config_fh.each_line do |line|
+            case line.chomp
+            when /^(\s*)\[([[:word:]]+)\](\s*)$/
+              config.append(SectionLine.new($1, $2, $3))
+            when /^(\s*)([[:word:]]+)(\s*=\s*)(.*?)(\s*)$/
+              config.append(SettingLine.new($1, $2, $3, $4, $5))
+            else
+              config.append(Line.new(line))
+            end
+          end
+
+          config
+        end
+
+        def initialize(lines = [])
+          @lines = lines
+        end
+
+        def to_hash
+          result = {}
+
+          current_section_name = nil
+          @lines.each do |line|
+            if line.instance_of?(SectionLine)
+              current_section_name = line.name
+              result[current_section_name] = {}
+            elsif line.instance_of?(SettingLine)
+              if current_section_name.nil?
+                result[line.name] = munge_value(line.value)
+              else
+                result[current_section_name][line.name] = munge_value(line.value)
+              end
+            end
+          end
+
+          result
+        end
+
+        def munge_value(value)
+          value = value.to_s unless value.is_a?(String)
+          # Strip enclosing quotes
+          value = value.slice(1...-1) if value.start_with?('"') && value.end_with?('"')
+          value
+        end
+
+        def append(line)
+          line.previous = @lines.last
+          @lines << line
+        end
+
+        module LineNumber
+          attr_accessor :previous
+
+          def line_number
+            line = 0
+            previous_line = previous
+            while previous_line
+              line += 1
+              previous_line = previous_line.previous
+            end
+            line
+          end
+        end
+
+        Line = Struct.new(:text) do
+          include LineNumber
+
+          def to_s
+            text
+          end
+        end
+
+        SettingLine = Struct.new(:prefix, :name, :infix, :value, :suffix) do
+          include LineNumber
+
+          def to_s
+            "#{prefix}#{name}#{infix}#{value}#{suffix}"
+          end
+
+          def ==(other)
+            super(other) && self.line_number == other.line_number
+          end
+        end
+
+        SectionLine = Struct.new(:prefix, :name, :suffix) do
+          include LineNumber
+
+          def to_s
+            "#{prefix}[#{name}]#{suffix}"
+          end
+        end
+
+        class DefaultSection < SectionLine
+          attr_accessor :write_sectionline
+
+          def initialize
+            @write_sectionline = false
+            super("", DEFAULT_SECTION_NAME, "")
+          end
+        end
+      end
+      # rubocop:enable Style/StringLiterals
+      # rubocop:enable Style/RedundantSelf
+      # rubocop:enable Style/PerlBackrefs
+      # rubocop:enable Style/RegexpLiteral
+    end
+  end
+end

--- a/lib/pdk/config/ini_file_setting.rb
+++ b/lib/pdk/config/ini_file_setting.rb
@@ -1,0 +1,39 @@
+require 'pdk'
+
+module PDK
+  class Config
+    class IniFileSetting < PDK::Config::Setting
+      # Initialises the PDK::Config::JSONSchemaSetting object.
+      #
+      # @see PDK::Config::Setting.initialize
+      def initialize(_name, namespace, initial_value = nil)
+        raise 'The IniFileSetting object can only be created within the IniFile Namespace' unless namespace.is_a?(PDK::Config::IniFile)
+        super
+        validate!(initial_value) unless initial_value.nil?
+      end
+
+      # Verifies that the new setting value is valid in an Ini File
+      #
+      # @see PDK::Config::Setting.validate!
+      def validate!(value)
+        # We're very restrictive here. Realistically Ini files only have string types
+        return if value.nil? || value.is_a?(String) || value.is_a?(Integer)
+        # The only other valid-ish type is a Hash
+        unless value.is_a?(Hash)
+          raise ArgumentError, _('The setting %{key} may only be a String or Integer, not %{class}') % {
+            key:  qualified_name,
+            class: value.class,
+          }
+        end
+        # Any hashes can only have a single String/Integer value
+        value.each do |child_name, child_value|
+          next if child_value.nil? || child_value.is_a?(String) || child_value.is_a?(Integer)
+          raise ArgumentError, _('The setting %{key} may only be a String or Integer, not %{class}') % {
+            key:   qualified_name + '.' + child_name,
+            class: child_value.class,
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/pdk/config/namespace.rb
+++ b/lib/pdk/config/namespace.rb
@@ -48,7 +48,7 @@ module PDK
       #
       # @return [nil]
       def setting(key, &block)
-        @settings[key.to_s] ||= PDK::Config::Setting.new(key.to_s, self)
+        @settings[key.to_s] ||= default_setting_class.new(key.to_s, self)
         @settings[key.to_s].instance_eval(&block) if block_given?
       end
 
@@ -207,6 +207,16 @@ module PDK
 
       private
 
+      # Returns the object class to create settings with. Subclasses may override this to use specific setting classes
+      #
+      # @return [Class[PDK::Config::Setting]]
+      #
+      # @abstract
+      # @private
+      def default_setting_class
+        PDK::Config::Setting
+      end
+
       # Determines whether a setting name should be resolved using the filter
       #  Returns true when filter is nil.
       #  Returns true if the filter is exactly the same name as the setting.
@@ -253,7 +263,7 @@ module PDK
         # Need to use `@settings` and `@mounts` here to stop recursive calls
         return unless @mounts[key.to_s].nil?
         return unless @settings[key.to_s].nil?
-        @settings[key.to_s] = PDK::Config::Setting.new(key.to_s, self, initial_value)
+        @settings[key.to_s] = default_setting_class.new(key.to_s, self, initial_value)
       end
 
       # Set the value of the named key.

--- a/spec/unit/pdk/config/ini_file_setting_spec.rb
+++ b/spec/unit/pdk/config/ini_file_setting_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+require 'pdk/config/ini_file_setting'
+
+describe PDK::Config::IniFileSetting do
+  subject(:setting) { described_class.new('spec_setting', namespace, initial_value) }
+
+  let(:initial_value) { nil }
+
+  let(:namespace) { PDK::Config::IniFile.new('spec') }
+
+  context 'when not in an Ini File Namespace' do
+    let(:namespace) { PDK::Config::Namespace.new }
+
+    it 'raises' do
+      expect { setting }.to raise_error(%r{IniFile Namespace})
+    end
+  end
+
+  context 'with invalid initial value' do
+    let(:initial_value) { %w[abc 123] }
+
+    it 'raises' do
+      expect { setting }.to raise_error(ArgumentError, %r{spec_setting})
+    end
+  end
+
+  RSpec.shared_examples 'a setting validator' do |value_type_name, value|
+    it "validates #{value_type_name}" do
+      expect { setting.validate!(value) }.not_to raise_error
+    end
+
+    it "validates #{value_type_name} in a simple hash" do
+      expect { setting.validate!('foo' => value) }.not_to raise_error
+    end
+  end
+
+  RSpec.shared_examples 'an error raising validator' do |value_type_name, value|
+    it "raises for #{value_type_name}" do
+      expect { setting.validate!(value) }.to raise_error(ArgumentError, %r{spec_setting})
+    end
+  end
+
+  describe '#validate!' do
+    context 'with valid values' do
+      include_examples 'a setting validator', 'String', 'value'
+      include_examples 'a setting validator', 'Nil', nil
+      include_examples 'a setting validator', 'Integer', 1
+    end
+
+    context 'with invalid values' do
+      include_examples 'an error raising validator', 'Symbol', :value
+      include_examples 'an error raising validator', 'Array', %w[abc 123]
+      include_examples 'an error raising validator', 'Nested hash', 'foo' => { 'bar' => 'baz' }
+      include_examples 'an error raising validator', 'Float', 1.0
+    end
+  end
+end

--- a/spec/unit/pdk/config/ini_file_spec.rb
+++ b/spec/unit/pdk/config/ini_file_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+require 'tempfile'
+require 'pdk/config/ini_file'
+require 'pdk/config/ini_file_setting'
+
+RSpec.shared_examples 'an ini file based namespace reader' do |content, expected_settings|
+  before(:each) do
+    allow(PDK::Util::Filesystem).to receive(:mkdir_p)
+  end
+
+  describe '#parse_file' do
+    before(:each) do
+      expect(ini_config).to receive(:load_data).and_return(content)
+    end
+
+    it 'returns the parsed data' do
+      settings = {}
+      ini_config.parse_file(ini_config.file) { |k, v| settings[k] = v }
+
+      expect(settings.keys).to eq(expected_settings.keys)
+      expected_settings.each do |expected_key, expected_value|
+        expect(settings[expected_key].value).to eq(expected_value)
+      end
+    end
+  end
+end
+
+RSpec.shared_examples 'an ini file based namespace writer' do |settings, expected_content|
+  describe '#serialize_data' do
+    it 'returns the serialized data' do
+      expect(ini_config.serialize_data(settings)).to eq(expected_content)
+    end
+  end
+end
+
+describe PDK::Config::IniFile do
+  subject(:ini_config) { described_class.new(file: tempfile) }
+
+  let(:tempfile) do
+    file = Tempfile.new('test')
+    file.path
+  end
+
+  it_behaves_like 'a file based namespace', "key = 0\n\n[foo]\nbar = baz\n", 'key' => '0', 'foo' => { 'bar' => 'baz' }
+
+  it_behaves_like 'a file based namespace without a schema'
+
+  context 'when the file contains invalid data' do
+    before(:each) do
+      # Note this isn't the best testing method, however there isn't really a way to craft an ini file to
+      # actually raise an error.
+      allow_any_instance_of(PDK::Config::IniFileSetting).to receive(:validate!).and_call_original # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(PDK::Config::IniFileSetting).to receive(:validate!).with('error').and_raise('Mock Validation Error') # rubocop:disable RSpec/AnyInstance
+    end
+
+    # Invalid values are set to `nil`
+    include_examples 'an ini file based namespace reader', "key = error\n\n[foo]\nbar = baz\n", 'key' => nil, 'foo' => { 'bar' => 'baz' }
+  end
+
+  context 'when the file contains quoted values and settings' do
+    # Quoted keys are ignored, values are not
+    include_examples 'an ini file based namespace reader', "\"key\" = \"0\"\nabc = \"123\"\n[foo]\nbar = \"baz\"\n", 'abc' => '123', 'foo' => { 'bar' => 'baz' }
+  end
+
+  context 'when the settings contains values with spaces' do
+    include_examples 'an ini file based namespace writer',
+                     { 's1' => 'v1', 'abc' => '12 3', 'fo o' => { 'ba r' => '  baz  ' } },
+                     "s1 = v1\nabc = \"12 3\"\n\n[fo o]\nba r = \"  baz  \"\n"
+  end
+
+  context 'when the settings contains values with nil' do
+    # nil values are not written
+    include_examples 'an ini file based namespace writer',
+                     { 's1' => 'v1', 'abc' => nil, 'foo' => { 'bar' => nil } },
+                     "s1 = v1\n\n[foo]\n"
+    it_behaves_like 'a file based namespace', "s1 = v1\n\n[foo]\n", 's1' => 'v1', 'foo' => {}
+  end
+end


### PR DESCRIPTION
This commit adds an Ini File configuration namespace which can read and write to
Ini files. This is needed for reading environment.conf in control repositories.