### PR TITLE
(PDK-1614) Add project.environment settings

### DIFF
--- a/lib/pdk/context/control_repo.rb
+++ b/lib/pdk/context/control_repo.rb
@@ -10,12 +10,35 @@ module PDK
       def initialize(repo_root, context_path)
         super(context_path)
         @root_path = repo_root
+        @environment_conf = nil
       end
 
+      # @see PDK::Context::AbstractContext.pdk_compatible?
       def pdk_compatible?
         # Currently there is nothing to determine compatibility with the PDK for a
         # Control Repo. For now assume everything is compatible
         true
+      end
+
+      # The modulepath setting for this control repository as an array of strings. These paths are relative
+      # and may contain interpolation strings (e.g. $basemodulepath)
+      # @see https://puppet.com/docs/puppet/latest/config_file_environment.html#allowed-settings
+      # @return [Array[String]] The modulepath setting for this control repository
+      def module_paths
+        return @module_paths unless @module_paths.nil?
+        value = environment_conf['modulepath'] || ''
+        # We have to use a hardcoded value here because File::PATH_SEPARATOR is ';' on Windows.
+        # As the environment.conf is only used on Puppet Server, it's always ':'
+        # Based on - https://github.com/puppetlabs/puppet/blob/f3e6d7e6d87f46408943a8e2176afb82ff6ea096/lib/puppet/settings/environment_conf.rb#L98-L106
+        @module_paths = value.split(':')
+      end
+
+      # The relative module_paths that exist on disk.
+      # @see https://puppet.com/docs/puppet/latest/config_file_environment.html#allowed-settings
+      # @return [Array[String]] The relative module paths on disk
+      def actualized_module_paths
+        @actualized_module_paths ||= module_paths.reject { |path| path.start_with?('$') }
+                                                 .select { |path| PDK::Util::Filesystem.directory?(PDK::Util::Filesystem.expand_path(File.join(root_path, path))) }
       end
 
       #:nocov:
@@ -24,6 +47,14 @@ module PDK
         _('a Control Repository context')
       end
       #:nocov:
+
+      private
+
+      # Memoization helper to read the environment.conf file.
+      # @return [PDK::Config::IniFile]
+      def environment_conf
+        @environment_conf ||= PDK::ControlRepo.environment_conf_as_config(File.join(root_path, 'environment.conf'))
+      end
     end
   end
 end

--- a/lib/pdk/control_repo.rb
+++ b/lib/pdk/control_repo.rb
@@ -46,5 +46,26 @@ module PDK
       CONTROL_REPO_FILES.any? { |file| PDK::Util::Filesystem.file?(File.join(path, file)) }
     end
     module_function :control_repo_root?
+
+    # Returns a PDK::Config::Namespace for the specified environment.conf file.
+    # Note there is no validation of the path.
+    #
+    # @param path [String] The path to the environment.conf file
+    #
+    # @return [PDK::Config::IniFile] The configuration file
+    def environment_conf_as_config(path)
+      PDK::Config::IniFile.new('environment', file: path) do
+        setting :modulepath do
+          # As per https://puppet.com/docs/puppet/latest/config_file_environment.html#allowed-settings
+          default_to { 'modules:$basemodulepath' }
+        end
+
+        setting :manifest do
+          # As per https://puppet.com/docs/puppet/latest/config_file_environment.html#allowed-settings
+          default_to { 'manifests/' }
+        end
+      end
+    end
+    module_function :environment_conf_as_config
   end
 end

--- a/spec/support/mock_configuration.rb
+++ b/spec/support/mock_configuration.rb
@@ -10,6 +10,7 @@ RSpec.shared_context 'mock configuration' do
     PDK::Config.new.tap do |item|
       item.user_config.read_only!
       item.system_config.read_only!
+      item.project_config.read_only!
     end
   end
 
@@ -18,6 +19,7 @@ RSpec.shared_context 'mock configuration' do
     allow(PDK).to receive(:config).and_return(new_config)
 
     # Mock any configuration file read/writes
+    # Note - That we don't yet know what the project config filename/path will be so it's not mockable.
     [
       { file: PDK::AnswerFile.default_answer_file_path, content: default_answer_file_content },
       { file: PDK::Config.system_answers_path, content: system_answers_content },

--- a/spec/unit/pdk/config_spec.rb
+++ b/spec/unit/pdk/config_spec.rb
@@ -39,6 +39,30 @@ describe PDK::Config do
     end
   end
 
+  describe '.project_config' do
+    it 'returns a PDK::Config::Namespace' do
+      expect(config.project_config).to be_a(PDK::Config::Namespace)
+    end
+
+    context 'Given a Control Repo context' do
+      subject(:config) { described_class.new('context' => repo_context) }
+
+      let(:repo_path) { File.join(FIXTURES_DIR, 'control_repo') }
+      let(:repo_context) { PDK::Context::ControlRepo.new(repo_path, repo_path) }
+
+      before(:each) do
+        # Allow anything in the fixtures dir to actually be read
+        allow(PDK::Util::Filesystem).to receive(:file?).with(%r{#{FIXTURES_DIR}}).and_call_original
+        allow(PDK::Util::Filesystem).to receive(:read_file).with(%r{#{FIXTURES_DIR}}).and_call_original
+      end
+
+      it 'has environment settings' do
+        # The modulepath has a default setting so it will always exist
+        expect(config.get('project.environment.modulepath')).not_to be_nil
+      end
+    end
+  end
+
   describe '.resolve' do
     subject(:resolve) { config.resolve(filter) }
 

--- a/spec/unit/pdk/context/control_repo_spec.rb
+++ b/spec/unit/pdk/context/control_repo_spec.rb
@@ -5,6 +5,8 @@ describe PDK::Context::ControlRepo do
   subject(:context) { described_class.new(repo_root, nil) }
 
   let(:repo_root) { File.join(FIXTURES_DIR, 'control_repo') }
+  let(:expected_module_paths) { ['modules', 'site', '$basemodulepath'] }
+  let(:module_paths_in_fixture) { ['site'] }
 
   it 'subclasses PDK::Context::AbstractContext' do
     expect(context).is_a?(PDK::Context::AbstractContext)
@@ -16,5 +18,33 @@ describe PDK::Context::ControlRepo do
 
   it 'is PDK compatible' do
     expect(context.pdk_compatible?).to eq(true)
+  end
+
+  describe '.module_paths' do
+    it 'returns an array of paths' do
+      expect(context.module_paths).to eq(expected_module_paths)
+    end
+
+    it 'is memoized' do
+      expect(context).to receive(:environment_conf).and_call_original # rubocop:disable RSpec/SubjectStub We are still calling the original so this is fine
+
+      context.module_paths
+      context.module_paths
+      context.module_paths
+    end
+  end
+
+  describe '.actualized_module_paths' do
+    it 'returns absolute paths that exist on disk' do
+      expect(context.actualized_module_paths).to eq(module_paths_in_fixture)
+    end
+
+    it 'is memoized' do
+      expect(context).to receive(:module_paths).and_call_original # rubocop:disable RSpec/SubjectStub We are still calling the original so this is fine
+
+      context.actualized_module_paths
+      context.actualized_module_paths
+      context.actualized_module_paths
+    end
   end
 end

--- a/spec/unit/pdk/control_repo_spec.rb
+++ b/spec/unit/pdk/control_repo_spec.rb
@@ -117,4 +117,26 @@ describe PDK::ControlRepo do
       described_class.control_repo_root?
     end
   end
+
+  describe 'environment_conf_as_config' do
+    subject(:config) { described_class.environment_conf_as_config(path) }
+
+    let(:path) { File.join(FIXTURES_DIR, 'control_repo') }
+
+    it 'returns a PDK::Config::IniFile object' do
+      expect(config).to be_a(PDK::Config::IniFile)
+    end
+
+    context 'with a nil path' do
+      let(:path) { File.join(FIXTURES_DIR, 'control_repo') }
+
+      it 'has a modulepath default setting' do
+        expect(config['modulepath']).not_to be_nil
+      end
+
+      it 'has a manifest default setting' do
+        expect(config['manifest']).not_to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Now that the PDK can read the environment.conf file, it can be updated to
display that the user, and be consumed by the Control Repo context. This commit:

* Adds a helper method to PDK::ControlRepo to create an an object to read/edit
  an arbitrary environment.conf file.  The helper method also adds the default
  settings as per Puppet documentation
* Updates the PDK::Config class to take in a PDK Context. The configuration
  settings then are mutated depending on the Context, for example, the
  'puppet.environment.*' settings now exist if the user is in a Control Repo,
  and won't if they're in a Module.

Note that because PDK::Config now depends on a PDK::Context object being
passed in (or default via PDK.context), any method calls to configuration
information (ala PDK.config) are not allowed and can cause circular
references and stack overflows. Thus there is a helper class to create the
environment.conf IniFile object.

Note that right now there is no project-level PDK configuration file therefore
the mock configuration RSpec context does not mock this and that the
PDK::Config.project_config method has no filename associated with it.  Future
commits may add this feature.