### PR TITLE
(PDK-1618)(PDK-1613)(PDK-1616) Add Control Repo support to Validators

### DIFF
--- a/lib/pdk.rb
+++ b/lib/pdk.rb
@@ -47,7 +47,9 @@ module PDK
   end
 
   def self.available_feature_flags
-    @available_feature_flags ||= %w[].freeze
+    @available_feature_flags ||= %w[
+      controlrepo
+    ].freeze
   end
 
   def self.requested_feature_flags

--- a/lib/pdk.rb
+++ b/lib/pdk.rb
@@ -46,6 +46,19 @@ module PDK
     @context ||= PDK::Context.create(Dir.pwd)
   end
 
+  def self.available_feature_flags
+    @available_feature_flags ||= %w[].freeze
+  end
+
+  def self.requested_feature_flags
+    @requested_feature_flags ||= (PDK::Util::Env['PDK_FEATURE_FLAGS'] || '').split(',').map { |flag| flag.strip }
+  end
+
+  def self.feature_flag?(flagname)
+    return false unless available_feature_flags.include?(flagname)
+    requested_feature_flags.include?(flagname)
+  end
+
   def self.analytics
     @analytics ||= PDK::Analytics.build_client(
       logger:        PDK.logger,

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -129,13 +129,14 @@ module PDK
       end
       module_function :check_for_deprecated_puppet
 
-      # @param opts [Hash] - the pdk options ot use, defaults to empty hash
+      # @param opts [Hash] - the pdk options to use, defaults to empty hash
       # @option opts [String] :'puppet-dev' Use the puppet development version, default to PDK_PUPPET_DEV env
       # @option opts [String] :'puppet-version' Puppet version to use, default to PDK_PUPPET_VERSION env
       # @option opts [String] :'pe-version' PE Puppet version to use, default to PDK_PE_VERSION env
       # @param logging_disabled [Boolean] - disable logging of PDK info
+      # @param context [PDK::Context::AbstractContext] - The context the PDK is running in
       # @return [Hash] - return hash of { gemset: <>, ruby_version: 2.x.x }
-      def puppet_from_opts_or_env(opts, logging_disabled = false)
+      def puppet_from_opts_or_env(opts, logging_disabled = false, context = PDK.context)
         opts ||= {}
         use_puppet_dev = opts.fetch(:'puppet-dev', PDK::Util::Env['PDK_PUPPET_DEV'])
         desired_puppet_version = opts.fetch(:'puppet-version', PDK::Util::Env['PDK_PUPPET_VERSION'])
@@ -150,8 +151,10 @@ module PDK
               PDK::Util::PuppetVersion.find_gem_for(desired_puppet_version)
             elsif desired_pe_version
               PDK::Util::PuppetVersion.from_pe_version(desired_pe_version)
-            else
+            elsif context.is_a?(PDK::Context::Module)
               PDK::Util::PuppetVersion.from_module_metadata || PDK::Util::PuppetVersion.latest_available
+            else
+              PDK::Util::PuppetVersion.latest_available
             end
         rescue ArgumentError => e
           raise PDK::CLI::ExitWithError, e.message

--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -36,13 +36,16 @@ module PDK::CLI
       end
 
       PDK::CLI::Util.validate_puppet_version_opts(opts)
+      unless PDK.feature_flag?('controlrepo') || PDK.context.is_a?(PDK::Context::Module)
+        raise PDK::CLI::ExitWithError.new(_('Code validation can only be run from inside a valid module directory'), log_level: :error)
+      end
 
-      PDK::CLI::Util.ensure_in_module!(
-        message:   _('Code validation can only be run from inside a valid module directory'),
-        log_level: :info,
-      )
+      PDK::CLI::Util.module_version_check if PDK.context.is_a?(PDK::Context::Module)
 
-      PDK::CLI::Util.module_version_check
+      # Set the ruby version we're going to use early. Must be set before the validators are created.
+      # Note that this is a bit of code-smell and should be fixed
+      puppet_env = PDK::CLI::Util.puppet_from_opts_or_env(opts)
+      PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
 
       targets = []
       validators_to_run = nil
@@ -94,15 +97,11 @@ module PDK::CLI
 
       options = targets.empty? ? {} : { targets: targets }
       options[:auto_correct] = true if opts[:'auto-correct']
-
-      # Ensure that the bundled gems are up to date and correct Ruby is activated before running any validations.
-      puppet_env = PDK::CLI::Util.puppet_from_opts_or_env(opts)
-      PDK::Util::RubyVersion.use(puppet_env[:ruby_version])
-
       options.merge!(puppet_env[:gemset])
 
+      # Ensure that the bundled gems are up to date and correct Ruby is activated before running any validations.
+      # Note that if no Gemfile exists, then ensure_bundle! will log a debug message and exit gracefully
       require 'pdk/util/bundler'
-
       PDK::Util::Bundler.ensure_bundle!(puppet_env[:gemset])
 
       exit_code, report = PDK::Validate.invoke_validators_by_name(PDK.context, validators_to_run, opts.fetch(:parallel, false), options)

--- a/lib/pdk/cli/validate.rb
+++ b/lib/pdk/cli/validate.rb
@@ -19,6 +19,9 @@ module PDK::CLI
     flag nil, :parallel, _('Run validations in parallel.')
 
     run do |opts, args, _cmd|
+      # Write the context information to the debug log
+      PDK.context.to_debug_log
+
       if args == ['help']
         PDK::CLI.run(['validate', '--help'])
         exit 0
@@ -102,7 +105,7 @@ module PDK::CLI
 
       PDK::Util::Bundler.ensure_bundle!(puppet_env[:gemset])
 
-      exit_code, report = PDK::Validate.invoke_validators_by_name(validators_to_run, opts.fetch(:parallel, false), options)
+      exit_code, report = PDK::Validate.invoke_validators_by_name(PDK.context, validators_to_run, opts.fetch(:parallel, false), options)
 
       report_formats.each do |format|
         report.send(format[:method], format[:target])

--- a/lib/pdk/config.rb
+++ b/lib/pdk/config.rb
@@ -79,6 +79,17 @@ module PDK
             end
           end
         end
+
+        # Display the feature flags
+        mount :pdk_feature_flags, PDK::Config::Namespace.new('pdk_feature_flags') do
+          setting 'available' do
+            default_to { PDK.available_feature_flags }
+          end
+
+          setting 'requested' do
+            default_to { PDK.requested_feature_flags }
+          end
+        end
       end
     end
 

--- a/lib/pdk/context.rb
+++ b/lib/pdk/context.rb
@@ -16,7 +16,7 @@ module PDK
       current = PDK::Util::Filesystem.expand_path(context_path)
       until !PDK::Util::Filesystem.directory?(current) || current == previous
         # Control Repo detection
-        return PDK::Context::ControlRepo.new(current, context_path) if PDK::ControlRepo.control_repo_root?(current)
+        return PDK::Context::ControlRepo.new(current, context_path) if PDK.feature_flag?('controlrepo') && PDK::ControlRepo.control_repo_root?(current)
 
         # Puppet Module detection
         metadata_file = File.join(current, 'metadata.json')

--- a/lib/pdk/control_repo.rb
+++ b/lib/pdk/control_repo.rb
@@ -4,6 +4,16 @@ module PDK
   module ControlRepo
     CONTROL_REPO_FILES = %w[environment.conf Puppetfile].freeze
 
+    DEFAULT_IGNORED = [
+      '/pkg/',
+      '~*',
+      '/coverage',
+      # Strictly speaking this isn't default but if people have tricked older PDK into thinking that a
+      # Control Repo is a module, they may have recursive symlinks in spec/fixtures/modules
+      '/spec/fixtures/modules/',
+      '/vendor/',
+    ].freeze
+
     # Returns path to the root of the Control Repo being worked on.
     #
     # An environment.conf is required for a PDK compatible Control Repo,
@@ -67,5 +77,14 @@ module PDK
       end
     end
     module_function :environment_conf_as_config
+
+    def default_ignored_pathspec(ignore_dotfiles = true)
+      require 'pathspec'
+
+      PathSpec.new(DEFAULT_IGNORED).tap do |ps|
+        ps.add('.*') if ignore_dotfiles
+      end
+    end
+    module_function :default_ignored_pathspec
   end
 end

--- a/lib/pdk/util/bundler.rb
+++ b/lib/pdk/util/bundler.rb
@@ -210,6 +210,7 @@ module PDK
         end
 
         def binstubs!(gems)
+          raise PDK::CLI::FatalError, _('Unable to install requested binstubs as the Gemfile is missing') if gemfile.nil?
           binstub_dir = File.join(File.dirname(gemfile), 'bin')
           return true if gems.all? { |gem| PDK::Util::Filesystem.file?(File.join(binstub_dir, gem)) }
 

--- a/lib/pdk/validate.rb
+++ b/lib/pdk/validate.rb
@@ -57,9 +57,9 @@ module PDK
       ].map { |klass| [klass.new.name, klass] }.to_h.freeze
     end
 
-    def self.invoke_validators_by_name(names, parallel = false, options = {})
+    def self.invoke_validators_by_name(context, names, parallel = false, options = {})
       instances = names.select { |name| validator_names.include?(name) }
-                       .map { |name| validator_hash[name].new(options) }
+                       .map { |name| validator_hash[name].new(context, options) }
                        .each { |instance| instance.prepare_invoke! }
       report = PDK::Report.new
 

--- a/lib/pdk/validate/external_command_validator.rb
+++ b/lib/pdk/validate/external_command_validator.rb
@@ -72,7 +72,7 @@ module PDK
       # @return [String]
       # @api private
       def cmd_path
-        File.join(PDK::Util.module_root, 'bin', cmd)
+        File.join(context.root_path, 'bin', cmd)
       end
 
       # An array of command line arguments to pass to the command for validation

--- a/lib/pdk/validate/external_command_validator.rb
+++ b/lib/pdk/validate/external_command_validator.rb
@@ -67,12 +67,35 @@ module PDK
       # @abstract
       def cmd; end
 
+      # Alternate paths which the command (cmd) may exist in. Typically other ruby gem caches,
+      # or packaged installation bin directories.
+      # @return [Array[String]]
+      # @api private
+      def alternate_bin_paths
+        [
+          PDK::Util::RubyVersion.bin_path,
+          File.join(PDK::Util::RubyVersion.gem_home, 'bin'),
+          PDK::Util::RubyVersion.gem_paths_raw.map { |gem_path_raw| File.join(gem_path_raw, 'bin') },
+          PDK::Util.package_install? ? File.join(PDK::Util.pdk_package_basedir, 'bin') : nil,
+        ].flatten.compact
+      end
+
       # The full path to the command (cmd)
       # Can be overridden in child classes to a non-default path
       # @return [String]
       # @api private
       def cmd_path
-        File.join(context.root_path, 'bin', cmd)
+        return @cmd_path unless @cmd_path.nil?
+        @cmd_path = File.join(context.root_path, 'bin', cmd)
+        # Return the path to the command if it exists on disk, or we have a gemfile (i.e. Bundled install)
+        # The Bundle may be created after the prepare_invoke so if the file doesn't exist, it may not be an error
+        return @cmd_path if PDK::Util::Filesystem.exist?(@cmd_path) || !PDK::Util::Bundler::BundleHelper.new.gemfile.nil?
+        # But if there is no Gemfile AND cmd doesn't exist in the default path, we need to go searching...
+        @cmd_path = alternate_bin_paths.map { |alternate_path| File.join(alternate_path, cmd) }
+                                       .find { |path| PDK::Util::Filesystem.exist?(path) }
+        return @cmd_path unless @cmd_path.nil?
+        # If we can't find it anywhere, just let the OS find it
+        @cmd_path = cmd
       end
 
       # An array of command line arguments to pass to the command for validation
@@ -156,7 +179,8 @@ module PDK
         # Nothing to execute so return success
         return 0 if @commands.empty?
 
-        PDK::Util::Bundler.ensure_binstubs!(cmd)
+        # If there's no Gemfile, then we can't ensure the binstubs are correct
+        PDK::Util::Bundler.ensure_binstubs!(cmd) unless PDK::Util::Bundler::BundleHelper.new.gemfile.nil?
 
         exec_group = PDK::CLI::ExecGroup.create(name, { parallel: false }, options)
 

--- a/lib/pdk/validate/invokable_validator.rb
+++ b/lib/pdk/validate/invokable_validator.rb
@@ -172,6 +172,20 @@ module PDK
         false
       end
 
+      protected
+
+      # Takes the pattern used in a module context and transforms it depending on the
+      # context e.g. A Control Repo will use the module pattern in each module path
+      #
+      # @param [Array, String] The pattern when used in the module root. Does not start with '/'
+      #
+      # @return [Array[String]]
+      def contextual_pattern(module_pattern)
+        module_pattern = [module_pattern] unless module_pattern.is_a?(Array)
+        return module_pattern unless context.is_a?(PDK::Context::ControlRepo)
+        context.actualized_module_paths.map { |mod_path| module_pattern.map { |pat_path| mod_path + '/*/' + pat_path } }.flatten
+      end
+
       private
 
       # Helper method to collate the default ignored paths

--- a/lib/pdk/validate/invokable_validator.rb
+++ b/lib/pdk/validate/invokable_validator.rb
@@ -19,6 +19,13 @@ module PDK
         :once
       end
 
+      # Whether this Validator can be invoked in this context. By default any Validator can work in any Context, except ::None
+      # @return [Boolean]
+      # @abstract
+      def valid_in_context?
+        !context.is_a?(PDK::Context::None)
+      end
+
       # An array, or a string, of glob patterns to use to find targets
       # @return [Array[String], String]
       # @abstract
@@ -57,11 +64,13 @@ module PDK
         # targets. For example, using rubocop with no targets, will allow rubocop to determine the
         # target list using it's .rubocop.yml file
         return [[], [], []] if requested_targets.empty? && allow_empty_targets?
-        # If no targets are specified, then we will run validations from the
-        # base module directory.
-        targets = requested_targets.empty? ? [PDK::Util.module_root] : requested_targets
-
+        # If no targets are specified, then we will run validations from the base context directory.
+        targets = requested_targets.empty? ? [context.root_path] : requested_targets
         targets.map! { |r| r.gsub(File::ALT_SEPARATOR, File::SEPARATOR) } if File::ALT_SEPARATOR
+
+        # If this validator is not valid in this context then skip all of the targets
+        return [[], targets, []] unless valid_in_context?
+
         skipped = []
         invalid = []
         matched = targets.map { |target|
@@ -69,11 +78,11 @@ module PDK
             target
           else
             if PDK::Util::Filesystem.directory?(target) # rubocop:disable Style/IfInsideElse
-              target_root = PDK::Util.module_root
+              target_root = context.root_path
               pattern_glob = Array(pattern).map { |p| PDK::Util::Filesystem.glob(File.join(target_root, p), File::FNM_DOTMATCH) }
               target_list = pattern_glob.flatten
                                         .select { |glob| PDK::Util::Filesystem.fnmatch(File.join(PDK::Util::Filesystem.expand_path(PDK::Util.canonical_path(target)), '*'), glob, File::FNM_DOTMATCH) }
-                                        .map { |glob| Pathname.new(glob).relative_path_from(Pathname.new(PDK::Util.module_root)).to_s }
+                                        .map { |glob| Pathname.new(glob).relative_path_from(Pathname.new(context.root_path)).to_s }
 
               ignore_list = ignore_pathspec
               target_list = target_list.reject { |file| ignore_list.match(file) }
@@ -168,9 +177,17 @@ module PDK
       # Helper method to collate the default ignored paths
       # @return [PathSpec] Paths to ignore
       def ignore_pathspec
-        require 'pdk/module'
-
-        ignore_pathspec = PDK::Module.default_ignored_pathspec(ignore_dotfiles?)
+        ignore_pathspec = if context.is_a?(PDK::Context::Module)
+                            require 'pdk/module'
+                            PDK::Module.default_ignored_pathspec(ignore_dotfiles?)
+                          elsif context.is_a?(PDK::Context::ControlRepo)
+                            require 'pdk/control_repo'
+                            PDK::ControlRepo.default_ignored_pathspec(ignore_dotfiles?)
+                          else
+                            PathSpec.new.tap do |ps|
+                              ps.add('.*') if ignore_dotfiles?
+                            end
+                          end
 
         unless pattern_ignore.nil?
           Array(pattern_ignore).each do |pattern|

--- a/lib/pdk/validate/invokable_validator.rb
+++ b/lib/pdk/validate/invokable_validator.rb
@@ -103,7 +103,7 @@ module PDK
               next
             end
           end
-        }.compact.flatten
+        }.compact.flatten.uniq
         [matched, skipped, invalid]
       end
 

--- a/lib/pdk/validate/metadata/metadata_json_lint_validator.rb
+++ b/lib/pdk/validate/metadata/metadata_json_lint_validator.rb
@@ -25,7 +25,7 @@ module PDK
         end
 
         def pattern
-          'metadata.json'
+          contextual_pattern('metadata.json')
         end
 
         def parse_options(targets)

--- a/lib/pdk/validate/metadata/metadata_syntax_validator.rb
+++ b/lib/pdk/validate/metadata/metadata_syntax_validator.rb
@@ -9,7 +9,7 @@ module PDK
         end
 
         def pattern
-          ['metadata.json', 'tasks/*.json']
+          contextual_pattern(['metadata.json', 'tasks/*.json'])
         end
 
         def spinner_text

--- a/lib/pdk/validate/puppet/puppet_epp_validator.rb
+++ b/lib/pdk/validate/puppet/puppet_epp_validator.rb
@@ -33,15 +33,11 @@ module PDK
         end
 
         def pattern
-          '**/*.epp'
-        end
-
-        def pattern_ignore
-          ''
+          contextual_pattern('**/*.epp')
         end
 
         def spinner_text_for_targets(_targets)
-          _('Checking Puppet EPP syntax (%{pattern}).') % { pattern: pattern }
+          _('Checking Puppet EPP syntax (%{pattern}).') % { pattern: pattern.join(' ') }
         end
 
         def parse_options(targets)

--- a/lib/pdk/validate/puppet/puppet_lint_validator.rb
+++ b/lib/pdk/validate/puppet/puppet_lint_validator.rb
@@ -13,11 +13,11 @@ module PDK
         end
 
         def pattern
-          '**/*.pp'
+          contextual_pattern('**/*.pp')
         end
 
         def spinner_text_for_targets(_targets)
-          _('Checking Puppet manifest style (%{pattern}).') % { pattern: pattern }
+          _('Checking Puppet manifest style (%{pattern}).') % { pattern: pattern.join(' ') }
         end
 
         def parse_options(targets)

--- a/lib/pdk/validate/puppet/puppet_syntax_validator.rb
+++ b/lib/pdk/validate/puppet/puppet_syntax_validator.rb
@@ -33,15 +33,15 @@ module PDK
         end
 
         def pattern
-          '**/*.pp'
+          contextual_pattern('**/*.pp')
         end
 
         def pattern_ignore
-          '/plans/**/*.pp'
+          contextual_pattern('plans/**/*.pp')
         end
 
         def spinner_text_for_targets(_targets)
-          _('Checking Puppet manifest syntax (%{pattern}).') % { pattern: pattern }
+          _('Checking Puppet manifest syntax (%{pattern}).') % { pattern: pattern.join(' ') }
         end
 
         def parse_options(targets)

--- a/lib/pdk/validate/ruby/ruby_rubocop_validator.rb
+++ b/lib/pdk/validate/ruby/ruby_rubocop_validator.rb
@@ -17,7 +17,11 @@ module PDK
         end
 
         def pattern
-          '**/**.rb'
+          if context.is_a?(PDK::Context::ControlRepo)
+            ['Puppetfile', '**/**.rb']
+          else
+            '**/**.rb'
+          end
         end
 
         def spinner_text_for_targets(_targets)

--- a/lib/pdk/validate/tasks/tasks_metadata_lint_validator.rb
+++ b/lib/pdk/validate/tasks/tasks_metadata_lint_validator.rb
@@ -11,12 +11,12 @@ module PDK
         end
 
         def pattern
-          'tasks/*.json'
+          contextual_pattern('tasks/*.json')
         end
 
         def spinner_text
           _('Checking task metadata style (%{pattern}).') % {
-            pattern: pattern,
+            pattern: pattern.join(' '),
           }
         end
 

--- a/lib/pdk/validate/tasks/tasks_name_validator.rb
+++ b/lib/pdk/validate/tasks/tasks_name_validator.rb
@@ -14,12 +14,12 @@ module PDK
         end
 
         def pattern
-          'tasks/**/*'
+          contextual_pattern('tasks/**/*')
         end
 
         def spinner_text
           _('Checking task names (%{pattern}).') % {
-            pattern: pattern,
+            pattern: pattern.join(' '),
           }
         end
 

--- a/lib/pdk/validate/validator.rb
+++ b/lib/pdk/validate/validator.rb
@@ -10,6 +10,10 @@ module PDK
       # @return Hash[Object => Object]
       attr_reader :options
 
+      # The PDK context which the validator will be within.
+      # @return [PDK::Context::AbstractContext] or a subclass PDK::Context::AbstractContext
+      attr_reader :context
+
       # Whether the validator is prepared to be invoked.
       # This should only be used for testing
       #
@@ -20,10 +24,18 @@ module PDK
 
       # Creates a new Validator
       #
+      # @param context [PDK::Context::AbstractContext] Optional context which specifies where the validation will take place.
+      #                Passing nil will use a None context (PDK::Context::None)
       # @param options [Hash] Optional configuration for the Validator
       # @option options :parent_validator [PDK::Validate::Validator] The parent validator for this validator.
       #   Typically used by ValidatorGroup to create trees of Validators for invocation.
-      def initialize(options = {})
+      def initialize(context = nil, options = {})
+        if context.nil?
+          @context = PDK::Context::None.new(nil)
+        else
+          raise ArgumentError, _('Expected PDK::Context::AbstractContext but got \'%{klass}\' for context') % { klass: context.class } unless context.is_a?(PDK::Context::AbstractContext)
+          @context = context
+        end
         @options = options.dup.freeze
         @prepared = false
       end

--- a/lib/pdk/validate/validator_group.rb
+++ b/lib/pdk/validate/validator_group.rb
@@ -96,7 +96,7 @@ module PDK
       # @return Array[PDK::Validator::Validator]
       # @api private
       def validator_instances
-        @validator_instances ||= validators.map { |klass| klass.new(options.merge(parent_validator: self)) }
+        @validator_instances ||= validators.map { |klass| klass.new(context, options.merge(parent_validator: self)) }
       end
     end
   end

--- a/lib/pdk/validate/yaml/yaml_syntax_validator.rb
+++ b/lib/pdk/validate/yaml/yaml_syntax_validator.rb
@@ -17,10 +17,19 @@ module PDK
         def pattern
           [
             '**/*.yaml',
-            '*.yaml',
             '**/*.yml',
-            '*.yml',
-          ]
+          ].tap do |pat|
+            if context.is_a?(PDK::Context::ControlRepo)
+              pat.concat(
+                [
+                  '**/*.eyaml',
+                  '**/*.eyml',
+                ],
+              )
+            else
+              pat
+            end
+          end
         end
 
         def spinner_text

--- a/spec/support/run_outside_module.rb
+++ b/spec/support/run_outside_module.rb
@@ -1,6 +1,9 @@
 RSpec.shared_context 'run outside module' do
+  let(:mock_context) { PDK::Context::None.new(nil) }
+
   before(:each) do
     msg = 'must be run from inside a valid module (no metadata.json found)'
     allow(PDK::CLI::Util).to receive(:ensure_in_module!).with(any_args).and_raise(PDK::CLI::ExitWithError, msg)
+    allow(PDK).to receive(:context).and_return(mock_context)
   end
 end

--- a/spec/unit/pdk/cli/console_spec.rb
+++ b/spec/unit/pdk/cli/console_spec.rb
@@ -3,11 +3,14 @@ require 'pdk/cli'
 
 describe 'pdk console' do
   let(:console_cmd) { PDK::CLI.instance_variable_get(:@console_cmd) }
+  let(:module_path) { '/path/to/testmodule' }
+  let(:context) { PDK::Context::Module.new(module_path, module_path) }
 
   before(:each) do
     allow_any_instance_of(PDK::Util::Bundler::BundleHelper).to receive(:gemfile_lock).and_return(File.join(FIXTURES_DIR, 'module_gemfile_lockfile'))
     allow(Bundler).to receive(:default_lockfile).and_return(File.join(FIXTURES_DIR, 'module_gemfile_lockfile'))
     allow(PDK::CLI::Util).to receive(:module_version_check).and_return(true)
+    allow(PDK).to receive(:context).and_return(context)
   end
 
   shared_context 'with a mocked rubygems response' do

--- a/spec/unit/pdk/cli/validate_spec.rb
+++ b/spec/unit/pdk/cli/validate_spec.rb
@@ -22,7 +22,12 @@ describe 'Running `pdk validate` in a module' do
 
   context 'when no arguments or options are provided' do
     it 'invokes each validator with no report and no options and exits zero' do
-      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(PDK::Validate.validator_names, false, hash_including(puppet: puppet_version)).and_return([0, report])
+      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(
+        PDK::Context::AbstractContext,
+        PDK::Validate.validator_names,
+        false,
+        hash_including(puppet: puppet_version),
+      ).and_return([0, report])
 
       expect(logger).to receive(:info).with('Running all available validators...')
 
@@ -41,7 +46,12 @@ describe 'Running `pdk validate` in a module' do
 
     context 'with --parallel' do
       it 'invokes each validator with no report and no options and exits zero' do
-        expect(PDK::Validate).to receive(:invoke_validators_by_name).with(PDK::Validate.validator_names, true, hash_including(puppet: puppet_version)).and_return([0, report])
+        expect(PDK::Validate).to receive(:invoke_validators_by_name).with(
+          PDK::Context::AbstractContext,
+          PDK::Validate.validator_names,
+          true,
+          hash_including(puppet: puppet_version),
+        ).and_return([0, report])
 
         expect(logger).to receive(:info).with('Running all available validators...')
 
@@ -82,7 +92,12 @@ describe 'Running `pdk validate` in a module' do
 
   context 'when a single validator is provided as an argument' do
     it 'only invokes the given validator and exits zero' do
-      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(['metadata'], false, hash_including(puppet: puppet_version)).and_return([0, report])
+      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(
+        PDK::Context::AbstractContext,
+        ['metadata'],
+        false,
+        hash_including(puppet: puppet_version),
+      ).and_return([0, report])
 
       expect { PDK::CLI.run(%w[validate metadata]) }.to exit_zero
     end
@@ -102,7 +117,10 @@ describe 'Running `pdk validate` in a module' do
     let(:invoked_validators) { %w[metadata puppet] }
 
     it 'invokes each given validator and exits zero' do
-      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(invoked_validators, false, hash_including(puppet: puppet_version)).and_return([0, report])
+      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(
+        PDK::Context::AbstractContext,
+        invoked_validators, false, hash_including(puppet: puppet_version)
+      ).and_return([0, report])
 
       expect { PDK::CLI.run(['validate', 'puppet,metadata']) }.to exit_zero
     end
@@ -123,7 +141,12 @@ describe 'Running `pdk validate` in a module' do
 
     it 'warns about unknown validators, invokes known validators, and exits zero' do
       expect(logger).to receive(:warn).with(%r{Unknown validator 'bad-val'. Available validators: #{pretty_validator_names}}i)
-      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(invoked_validators, false, hash_including(puppet: puppet_version)).and_return([0, report])
+      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(
+        PDK::Context::AbstractContext,
+        invoked_validators,
+        false,
+        hash_including(puppet: puppet_version),
+      ).and_return([0, report])
 
       expect { PDK::CLI.run(['validate', 'puppet,bad-val']) }.to exit_zero
     end
@@ -143,7 +166,12 @@ describe 'Running `pdk validate` in a module' do
     let(:invoked_validators) { %w[metadata] }
 
     it 'invokes the specified validator with the target as an option' do
-      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(invoked_validators, false, hash_including(puppet: puppet_version, targets: ['lib/', 'manifests/'])).and_return([0, report])
+      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(
+        PDK::Context::AbstractContext,
+        invoked_validators,
+        false,
+        hash_including(puppet: puppet_version, targets: ['lib/', 'manifests/']),
+      ).and_return([0, report])
 
       expect { PDK::CLI.run(['validate', 'metadata', 'lib/', 'manifests/']) }.to exit_zero
     end
@@ -163,7 +191,12 @@ describe 'Running `pdk validate` in a module' do
     let(:invoked_validators) { PDK::Validate.validator_names }
 
     it 'invokes all validators with the target as an option' do
-      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(invoked_validators, false, hash_including(puppet: puppet_version, targets: ['lib/', 'manifests/'])).and_return([0, report])
+      expect(PDK::Validate).to receive(:invoke_validators_by_name).with(
+        PDK::Context::AbstractContext,
+        invoked_validators,
+        false,
+        hash_including(puppet: puppet_version, targets: ['lib/', 'manifests/']),
+      ).and_return([0, report])
 
       expect(logger).to receive(:info).with('Running all available validators...')
 

--- a/spec/unit/pdk/cli/validate_spec.rb
+++ b/spec/unit/pdk/cli/validate_spec.rb
@@ -8,13 +8,15 @@ describe 'Running `pdk validate` in a module' do
   let(:report) { instance_double('PDK::Report').as_null_object }
   let(:ruby_version) { '2.4.3' }
   let(:puppet_version) { '5.4.0' }
+  let(:module_path) { '/path/to/testmodule' }
+  let(:context) { PDK::Context::Module.new(module_path, module_path) }
 
   before(:each) do
     allow(PDK::CLI::Util).to receive(:puppet_from_opts_or_env).and_return(ruby_version: ruby_version, gemset: { puppet: puppet_version })
     allow(PDK::Util::RubyVersion).to receive(:use)
     allow(PDK::Util::Bundler).to receive(:ensure_bundle!).with(hash_including(:puppet))
 
-    allow(PDK::Util).to receive(:module_root).and_return('/path/to/testmodule')
+    allow(PDK).to receive(:context).and_return(context)
     allow(PDK::Util).to receive(:module_pdk_version).and_return(PDK::VERSION)
 
     allow(PDK::Validate).to receive(:invoke_validators_by_name).and_return([0, report])

--- a/spec/unit/pdk/cli_spec.rb
+++ b/spec/unit/pdk/cli_spec.rb
@@ -97,7 +97,7 @@ describe PDK::CLI do
       include_context 'run outside module'
 
       it 'informs the user that this is not a module folder' do
-        expect(logger).to receive(:error).with(a_string_matching(%r{no metadata\.json found}i))
+        expect(logger).to receive(:error).with(a_string_matching(%r{(no metadata\.json found|only be run from inside a valid module)}i))
 
         expect { described_class.run(command.split(' ')) }.to exit_nonzero
       end

--- a/spec/unit/pdk/context_spec.rb
+++ b/spec/unit/pdk/context_spec.rb
@@ -36,7 +36,11 @@ describe PDK::Context do
 
     def expect_a_module_context(context, context_path, module_root, has_parent = false)
       expect(context).to be_a(PDK::Context::Module)
-      expect(context.context_path).to eq(context_path)
+      if context_path.nil?
+        expect(context.context_path).not_to be_nil
+      else
+        expect(context.context_path).to eq(context_path) unless context_path.nil?
+      end
       expect(context.root_path).to eq(module_root)
       if has_parent
         expect(context.parent_context).not_to be_a(PDK::Context::None)
@@ -132,25 +136,53 @@ describe PDK::Context do
         context 'in the root of the control repo' do
           let(:context_path) { control_repo_fixture_root }
 
-          it 'returns a Control Repo Context at the root' do
-            expect_a_controlrepo_context(context, context_path, control_repo_fixture_root)
+          it 'returns a None Context' do
+            expect_a_none_context(context, context_path)
           end
         end
 
         context 'in a non-module path of the control repo' do
           let(:context_path) { File.join(control_repo_fixture_root, 'data') }
 
-          it 'returns a Control Repo Context at the root' do
-            expect_a_controlrepo_context(context, context_path, control_repo_fixture_root)
+          it 'returns a None Context' do
+            expect_a_none_context(context, context_path)
           end
         end
 
         context 'in a module path of the control repo' do
           let(:context_path) { File.join(module_dir, 'manifests') }
 
-          it 'returns a Module Context in a Control Repo Context' do
-            expect_a_module_context(context, context_path, module_dir, true)
-            expect_a_controlrepo_context(context.parent_context, nil, control_repo_fixture_root)
+          it 'returns a Module Context ' do
+            expect_a_module_context(context, context_path, module_dir)
+          end
+        end
+
+        context 'and has the controlrepo feature flag' do
+          before(:each) { allow(PDK).to receive(:feature_flag?).with('controlrepo').and_return(true) }
+
+          context 'in the root of the control repo' do
+            let(:context_path) { control_repo_fixture_root }
+
+            it 'returns a Control Repo Context at the root' do
+              expect_a_controlrepo_context(context, context_path, control_repo_fixture_root)
+            end
+          end
+
+          context 'in a non-module path of the control repo' do
+            let(:context_path) { File.join(control_repo_fixture_root, 'data') }
+
+            it 'returns a Control Repo Context at the root' do
+              expect_a_controlrepo_context(context, context_path, control_repo_fixture_root)
+            end
+          end
+
+          context 'in a module path of the control repo' do
+            let(:context_path) { File.join(module_dir, 'manifests') }
+
+            it 'returns a Module Context in a Control Repo Context' do
+              expect_a_module_context(context, context_path, module_dir, true)
+              expect_a_controlrepo_context(context.parent_context, nil, control_repo_fixture_root)
+            end
           end
         end
       end
@@ -176,25 +208,54 @@ describe PDK::Context do
         context 'in the root of the control repo' do
           let(:context_path) { control_repo_fixture_root }
 
-          it 'returns a Control Repo Context at the root' do
-            expect_a_controlrepo_context(context, context_path, control_repo_fixture_root)
+          it 'returns a Module Context ' do
+            expect_a_module_context(context, context_path, control_repo_fixture_root)
           end
         end
 
         context 'in a non-module path of the control repo' do
           let(:context_path) { File.join(control_repo_fixture_root, 'data') }
 
-          it 'returns a Control Repo Context at the root' do
-            expect_a_controlrepo_context(context, context_path, control_repo_fixture_root)
+          it 'returns a Module Context ' do
+            expect_a_module_context(context, context_path, control_repo_fixture_root)
           end
         end
 
         context 'in a module path of the control repo' do
           let(:context_path) { File.join(module_dir, 'manifests') }
 
-          it 'returns a Module Context in a Control Repo Context' do
+          it 'returns a Module Context in a Module Context' do
             expect_a_module_context(context, context_path, module_dir, true)
-            expect_a_controlrepo_context(context.parent_context, nil, control_repo_fixture_root)
+            expect_a_module_context(context.parent_context, nil, control_repo_fixture_root)
+          end
+        end
+
+        context 'and has the controlrepo feature flag' do
+          before(:each) { allow(PDK).to receive(:feature_flag?).with('controlrepo').and_return(true) }
+
+          context 'in the root of the control repo' do
+            let(:context_path) { control_repo_fixture_root }
+
+            it 'returns a Control Repo Context at the root' do
+              expect_a_controlrepo_context(context, context_path, control_repo_fixture_root)
+            end
+          end
+
+          context 'in a non-module path of the control repo' do
+            let(:context_path) { File.join(control_repo_fixture_root, 'data') }
+
+            it 'returns a Control Repo Context at the root' do
+              expect_a_controlrepo_context(context, context_path, control_repo_fixture_root)
+            end
+          end
+
+          context 'in a module path of the control repo' do
+            let(:context_path) { File.join(module_dir, 'manifests') }
+
+            it 'returns a Module Context in a Control Repo Context' do
+              expect_a_module_context(context, context_path, module_dir, true)
+              expect_a_controlrepo_context(context.parent_context, nil, control_repo_fixture_root)
+            end
           end
         end
       end

--- a/spec/unit/pdk/validate/external_command_validator_spec.rb
+++ b/spec/unit/pdk/validate/external_command_validator_spec.rb
@@ -42,6 +42,20 @@ describe PDK::Validate::ExternalCommandValidator do
     it 'returns a String' do
       expect(validator.cmd_path).to be_a(String)
     end
+
+    context 'when the context has no bin path or Gemfile' do
+      before(:each) do
+        allow(PDK::Util::Filesystem).to receive(:exist?).with(%r{#{validator_context.root_path}}).and_return(false)
+        allow_any_instance_of(PDK::Util::Bundler::BundleHelper).to receive(:gemfile).and_return(nil) # rubocop:disable RSpec/AnyInstance BundleHelper needs a refactor
+      end
+
+      it 'uses alternate_bin_paths' do
+        allow(PDK::Util::Filesystem).to receive(:exist?).with(%r{/fakepath/bin}).and_return(true)
+        expect(validator).to receive(:alternate_bin_paths).and_return(['/fakepath/bin'])
+
+        expect(validator.cmd_path).to eq('/fakepath/bin/command')
+      end
+    end
   end
 
   describe '.parse_options' do

--- a/spec/unit/pdk/validate/external_command_validator_spec.rb
+++ b/spec/unit/pdk/validate/external_command_validator_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 require 'pdk/validate/external_command_validator'
 
 describe PDK::Validate::ExternalCommandValidator do
-  let(:validator) { described_class.new(validator_options) }
+  let(:validator) { described_class.new(validator_context, validator_options) }
+  let(:validator_context) { PDK::Context::Module.new(EMPTY_MODULE_ROOT, EMPTY_MODULE_ROOT) }
   let(:validator_options) { {} }
   let(:targets) { [] }
   let(:skipped_targets) { [] }
@@ -35,7 +36,6 @@ describe PDK::Validate::ExternalCommandValidator do
 
   describe '.cmd_path' do
     before(:each) do
-      allow(PDK::Util).to receive(:module_root).and_return('/does/not/exist')
       allow(validator).to receive(:cmd).and_return('command')
     end
 
@@ -59,8 +59,6 @@ describe PDK::Validate::ExternalCommandValidator do
   describe '.prepare_invoke!' do
     before(:each) do
       allow(validator).to receive(:cmd).and_return('mock_cmd')
-      allow(PDK::Util).to receive(:module_root).and_return(EMPTY_MODULE_ROOT)
-      allow(PDK::Util::RubyVersion).to receive(:bin_path).and_return('bin/ruby/path')
     end
 
     it 'calls parse_targets only once' do
@@ -195,7 +193,6 @@ describe PDK::Validate::ExternalCommandValidator do
     let(:invalid_targets) { ['invalid'] }
 
     before(:each) do
-      allow(PDK::Util).to receive(:module_root).and_return('/does/not/exist')
       allow(validator).to receive(:cmd).and_return('command')
     end
 

--- a/spec/unit/pdk/validate/internal_ruby_validator_spec.rb
+++ b/spec/unit/pdk/validate/internal_ruby_validator_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 require 'pdk/validate/internal_ruby_validator'
 
 describe PDK::Validate::InternalRubyValidator do
-  let(:validator) { described_class.new(validator_options) }
+  let(:validator) { described_class.new(validator_context, validator_options) }
+  let(:validator_context) { nil }
   let(:validator_options) { {} }
   let(:targets) { [] }
   let(:skipped_targets) { [] }

--- a/spec/unit/pdk/validate/invokable_validator_spec.rb
+++ b/spec/unit/pdk/validate/invokable_validator_spec.rb
@@ -2,8 +2,10 @@ require 'spec_helper'
 require 'pdk/validate/invokable_validator'
 
 describe PDK::Validate::InvokableValidator do
+  let(:validator) { described_class.new(validator_context, validator_options) }
   let(:validator_options) { {} }
-  let(:validator) { described_class.new(validator_options) }
+  let(:context_root) { File.join('path', 'to', 'test', 'module') }
+  let(:validator_context) { PDK::Context::Module.new(context_root, context_root) }
 
   it 'inherits from PDK::Validate::Validator' do
     expect(validator).to be_a(PDK::Validate::Validator)
@@ -11,6 +13,22 @@ describe PDK::Validate::InvokableValidator do
 
   it 'has an invoke_style of :once' do
     expect(validator.invoke_style).to eq(:once)
+  end
+
+  describe '.valid_in_context?' do
+    context 'given a default context' do
+      let(:validator_context) { nil }
+
+      it 'defaults to false' do
+        expect(validator.valid_in_context?).to eq(false)
+      end
+    end
+
+    context 'when given a context other than ::None' do
+      it 'defaults to true' do
+        expect(validator.valid_in_context?).to eq(true)
+      end
+    end
   end
 
   it 'has a pattern of nil' do
@@ -35,12 +53,26 @@ describe PDK::Validate::InvokableValidator do
     subject(:target_files) { validator.parse_targets }
 
     let(:validator_options) { { targets: targets } }
-    let(:module_root) { File.join('path', 'to', 'test', 'module') }
     let(:pattern) { '**/**.pp' }
+
+    RSpec.shared_examples 'a parsed target list in an invalid context' do |expected_skipped_targets = nil|
+      before(:each) do
+        allow(validator).to receive(:valid_in_context?).and_return(false)
+      end
+
+      it 'returns all targets as skipped' do
+        expect(target_files[0]).to be_empty
+        if expected_skipped_targets.nil?
+          expect(target_files[1]).to eq(targets)
+        else
+          expect(target_files[1]).to eq(expected_skipped_targets)
+        end
+        expect(target_files[2]).to be_empty
+      end
+    end
 
     before(:each) do
       allow(validator).to receive(:pattern).and_return(pattern)
-      allow(PDK::Util).to receive(:module_root).and_return(module_root)
       allow(PDK::Util).to receive(:canonical_path).and_wrap_original do |_m, *args|
         args[0]
       end
@@ -50,18 +82,18 @@ describe PDK::Validate::InvokableValidator do
       let(:targets) { [] }
 
       context 'when empty targets are not allowed' do
-        let(:glob_pattern) { File.join(module_root, validator.pattern) }
+        let(:glob_pattern) { File.join(context_root, validator.pattern) }
         let(:files) { [File.join('manifests', 'init.pp')] }
-        let(:globbed_files) { files.map { |file| File.join(module_root, file) } }
+        let(:globbed_files) { files.map { |file| File.join(context_root, file) } }
 
         before(:each) do
           allow(validator).to receive(:allow_empty_targets?).and_return(false)
           allow(PDK::Util::Filesystem).to receive(:directory?).and_return(true)
           allow(PDK::Util::Filesystem).to receive(:glob).with(glob_pattern, anything).and_return(globbed_files)
-          allow(PDK::Util::Filesystem).to receive(:expand_path).with(module_root).and_return(module_root)
+          allow(PDK::Util::Filesystem).to receive(:expand_path).with(context_root).and_return(context_root)
         end
 
-        it 'returns the module root' do
+        it 'returns the context root' do
           expect(target_files[0]).to eq(files)
         end
       end
@@ -75,17 +107,19 @@ describe PDK::Validate::InvokableValidator do
           expect(target_files[0]).to eq([])
         end
       end
+
+      it_behaves_like 'a parsed target list in an invalid context', ['path/to/test/module']
     end
 
     context 'when the globbed files include files matching the default ignore list' do
       let(:targets) { [] }
-      let(:glob_pattern) { File.join(module_root, validator.pattern) }
+      let(:glob_pattern) { File.join(context_root, validator.pattern) }
       let(:files) { [File.join('manifests', 'init.pp')] }
-      let(:fixture_file) { File.join(module_root, 'spec', 'fixtures', 'modules', 'test', 'manifests', 'init.pp') }
-      let(:pkg_file) { File.join(module_root, 'pkg', 'my-module-0.0.1', 'manifests', 'init.pp') }
+      let(:fixture_file) { File.join(context_root, 'spec', 'fixtures', 'modules', 'test', 'manifests', 'init.pp') }
+      let(:pkg_file) { File.join(context_root, 'pkg', 'my-module-0.0.1', 'manifests', 'init.pp') }
       let(:globbed_files) do
         [
-          File.join(module_root, 'manifests', 'init.pp'),
+          File.join(context_root, 'manifests', 'init.pp'),
           fixture_file,
           pkg_file,
         ]
@@ -94,7 +128,7 @@ describe PDK::Validate::InvokableValidator do
       before(:each) do
         allow(PDK::Util::Filesystem).to receive(:directory?).and_return(true)
         allow(PDK::Util::Filesystem).to receive(:glob).with(glob_pattern, anything).and_return(globbed_files)
-        allow(PDK::Util::Filesystem).to receive(:expand_path).with(module_root).and_return(module_root)
+        allow(PDK::Util::Filesystem).to receive(:expand_path).with(context_root).and_return(context_root)
       end
 
       it 'does not return the files under spec/fixtures/' do
@@ -104,13 +138,15 @@ describe PDK::Validate::InvokableValidator do
       it 'does not return the files under pkg/' do
         expect(target_files[0]).not_to include(a_string_including('pkg/'))
       end
+
+      it_behaves_like 'a parsed target list in an invalid context', ['path/to/test/module']
     end
 
     context 'when given specific targets' do
       let(:targets) { ['target1.pp', 'target2/'] }
-      let(:glob_pattern) { File.join(module_root, validator.pattern) }
+      let(:glob_pattern) { File.join(context_root, validator.pattern) }
       let(:targets2) { [File.join('target2', 'target.pp')] }
-      let(:globbed_target2) { targets2.map { |target| File.join(module_root, target) } }
+      let(:globbed_target2) { targets2.map { |target| File.join(context_root, target) } }
 
       before(:each) do
         allow(PDK::Util::Filesystem).to receive(:glob).with(glob_pattern, anything).and_return(globbed_target2)
@@ -119,11 +155,11 @@ describe PDK::Validate::InvokableValidator do
         allow(PDK::Util::Filesystem).to receive(:file?).with('target1.pp').and_return(true)
 
         targets.map do |t|
-          allow(PDK::Util::Filesystem).to receive(:expand_path).with(t).and_return(File.join(module_root, t))
+          allow(PDK::Util::Filesystem).to receive(:expand_path).with(t).and_return(File.join(context_root, t))
         end
 
         Array[validator.pattern].flatten.map do |p|
-          allow(PDK::Util::Filesystem).to receive(:expand_path).with(p).and_return(File.join(module_root, p))
+          allow(PDK::Util::Filesystem).to receive(:expand_path).with(p).and_return(File.join(context_root, p))
         end
       end
 
@@ -132,6 +168,8 @@ describe PDK::Validate::InvokableValidator do
         expect(target_files[1]).to eq(['target1.pp'])
         expect(target_files[2]).to be_empty
       end
+
+      it_behaves_like 'a parsed target list in an invalid context'
     end
 
     context 'when given specific targets which are not in the glob_pattern' do
@@ -140,19 +178,19 @@ describe PDK::Validate::InvokableValidator do
 
       before(:each) do
         # The glob simulates a module with a metadata.json
-        allow(PDK::Util::Filesystem).to receive(:glob).with(File.join(module_root, 'metadata.json'), anything).and_return([File.join(module_root, 'metadata.json')])
+        allow(PDK::Util::Filesystem).to receive(:glob).with(File.join(context_root, 'metadata.json'), anything).and_return([File.join(context_root, 'metadata.json')])
         # The glob simulates a module without any tasks
-        allow(PDK::Util::Filesystem).to receive(:glob).with(File.join(module_root, 'tasks/*.json'), anything).and_return([])
+        allow(PDK::Util::Filesystem).to receive(:glob).with(File.join(context_root, 'tasks/*.json'), anything).and_return([])
         allow(PDK::Util::Filesystem).to receive(:directory?).with('target1.pp').and_return(false)
         allow(PDK::Util::Filesystem).to receive(:directory?).with('target2/').and_return(true)
         allow(PDK::Util::Filesystem).to receive(:file?).with('target1.pp').and_return(true)
 
         targets.map do |t|
-          allow(PDK::Util::Filesystem).to receive(:expand_path).with(t).and_return(File.join(module_root, t))
+          allow(PDK::Util::Filesystem).to receive(:expand_path).with(t).and_return(File.join(context_root, t))
         end
 
         Array[validator.pattern].flatten.map do |p|
-          allow(PDK::Util::Filesystem).to receive(:expand_path).with(p).and_return(File.join(module_root, p))
+          allow(PDK::Util::Filesystem).to receive(:expand_path).with(p).and_return(File.join(context_root, p))
         end
       end
 
@@ -161,26 +199,28 @@ describe PDK::Validate::InvokableValidator do
         expect(target_files[1]).to eq(targets)
         expect(target_files[2]).to be_empty
       end
+
+      it_behaves_like 'a parsed target list in an invalid context'
     end
 
     context 'when given specific targets which are case insensitive on a case insensitive file system' do
       let(:targets) { ['target2/'] }
-      let(:glob_pattern) { File.join(module_root, validator.pattern) }
+      let(:glob_pattern) { File.join(context_root, validator.pattern) }
       let(:real_targets) { [File.join('target2', 'target.pp')] }
-      let(:globbed_targets) { real_targets.map { |target| File.join(module_root, target) } }
+      let(:globbed_targets) { real_targets.map { |target| File.join(context_root, target) } }
 
       before(:each) do
         allow(PDK::Util::Filesystem).to receive(:glob).with(glob_pattern, anything).and_return(globbed_targets)
         allow(PDK::Util::Filesystem).to receive(:directory?).and_return(true)
         targets.map do |t|
-          allow(PDK::Util::Filesystem).to receive(:expand_path).with(t).and_return(File.join(module_root, t))
+          allow(PDK::Util::Filesystem).to receive(:expand_path).with(t).and_return(File.join(context_root, t))
           # PDK::Util.canonical_path will then convert the case-insensitive paths
           # back to their "real" on-disk names. In this case, lowercase
           expect(PDK::Util).to receive(:canonical_path).with(t.upcase).and_return(t)
         end
 
         Array[validator.pattern].flatten.map do |p|
-          allow(PDK::Util::Filesystem).to receive(:expand_path).with(p).and_return(File.join(module_root, p))
+          allow(PDK::Util::Filesystem).to receive(:expand_path).with(p).and_return(File.join(context_root, p))
         end
       end
 
@@ -202,7 +242,7 @@ describe PDK::Validate::InvokableValidator do
       end
 
       before(:each) do
-        allow(PDK::Util::Filesystem).to receive(:glob).with(File.join(module_root, validator.pattern), anything).and_return(globbed_target2)
+        allow(PDK::Util::Filesystem).to receive(:glob).with(File.join(context_root, validator.pattern), anything).and_return(globbed_target2)
         allow(PDK::Util::Filesystem).to receive(:directory?).with('target3/').and_return(true)
       end
 
@@ -245,11 +285,11 @@ describe PDK::Validate::InvokableValidator do
 
         allow(PDK::Util::Filesystem).to receive(:directory?).and_return(true)
         allow(PDK::Util::Filesystem).to receive(:glob).with(glob_pattern, anything).and_return(globbed_files)
-        allow(PDK::Util::Filesystem).to receive(:expand_path).with(module_root).and_return(module_root)
+        allow(PDK::Util::Filesystem).to receive(:expand_path).with(context_root).and_return(context_root)
       end
 
       let(:targets) { [] }
-      let(:glob_pattern) { File.join(module_root, validator.pattern) }
+      let(:glob_pattern) { File.join(context_root, validator.pattern) }
       let(:files) do
         [
           File.join('manifests', 'init.pp'),
@@ -257,7 +297,7 @@ describe PDK::Validate::InvokableValidator do
           File.join('plans', 'nested', 'thing.pp'),
         ]
       end
-      let(:globbed_files) { files.map { |file| File.join(module_root, file) } }
+      let(:globbed_files) { files.map { |file| File.join(context_root, file) } }
 
       it 'does not match the ignored files' do
         expect(target_files[0].count).to eq(1)

--- a/spec/unit/pdk/validate/metadata/metadata_json_lint_validator_spec.rb
+++ b/spec/unit/pdk/validate/metadata/metadata_json_lint_validator_spec.rb
@@ -43,8 +43,9 @@ describe PDK::Validate::Metadata::MetadataJSONLintValidator do
   end
 
   describe '.pattern' do
-    it 'only matches metadata.json files' do
-      expect(validator.pattern).to eq('metadata.json')
+    it 'only contextually matches metadata.json files' do
+      expect(validator).to receive(:contextual_pattern).with('metadata.json') # rubocop:disable RSpec/SubjectStub This is fine
+      validator.pattern
     end
   end
 

--- a/spec/unit/pdk/validate/metadata/metadata_syntax_validator_spec.rb
+++ b/spec/unit/pdk/validate/metadata/metadata_syntax_validator_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 require 'pdk/validate/metadata/metadata_syntax_validator'
 
 describe PDK::Validate::Metadata::MetadataSyntaxValidator do
-  subject(:validator) { described_class.new(targets: targets.map { |r| r[:name] }) }
+  subject(:validator) { described_class.new(validator_context, targets: targets.map { |r| r[:name] }) }
 
+  let(:validator_context) { PDK::Context::Module.new(EMPTY_MODULE_ROOT, EMPTY_MODULE_ROOT) }
   let(:targets) { [] }
 
   describe '.pattern' do

--- a/spec/unit/pdk/validate/metadata/metadata_syntax_validator_spec.rb
+++ b/spec/unit/pdk/validate/metadata/metadata_syntax_validator_spec.rb
@@ -8,8 +8,9 @@ describe PDK::Validate::Metadata::MetadataSyntaxValidator do
   let(:targets) { [] }
 
   describe '.pattern' do
-    it 'only matches metadata JSON files' do
-      expect(validator.pattern).to eq(['metadata.json', 'tasks/*.json'])
+    it 'only contextually matches metadata JSON files' do
+      expect(validator).to receive(:contextual_pattern).with(['metadata.json', 'tasks/*.json']) # rubocop:disable RSpec/SubjectStub This is fine
+      validator.pattern
     end
   end
 

--- a/spec/unit/pdk/validate/puppet/puppet_epp_validator_spec.rb
+++ b/spec/unit/pdk/validate/puppet/puppet_epp_validator_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 require 'pdk/validate/puppet/puppet_epp_validator'
 
 describe PDK::Validate::Puppet::PuppetEPPValidator do
-  subject(:validator) { described_class.new(options) }
+  subject(:validator) { described_class.new(validator_context, options) }
 
+  let(:validator_context) { nil }
   let(:options) { {} }
   let(:tmpdir) { File.join('/', 'tmp', 'puppet-epp-validate') }
 

--- a/spec/unit/pdk/validate/puppet/puppet_epp_validator_spec.rb
+++ b/spec/unit/pdk/validate/puppet/puppet_epp_validator_spec.rb
@@ -22,8 +22,9 @@ describe PDK::Validate::Puppet::PuppetEPPValidator do
   end
 
   describe '.pattern' do
-    it 'only matches embedded puppet templates' do
-      expect(validator.pattern).to eq('**/*.epp')
+    it 'only contextually matches embedded puppet templates' do
+      expect(validator).to receive(:contextual_pattern).with('**/*.epp') # rubocop:disable RSpec/SubjectStub This is fine
+      validator.pattern
     end
   end
 

--- a/spec/unit/pdk/validate/puppet/puppet_lint_validator_spec.rb
+++ b/spec/unit/pdk/validate/puppet/puppet_lint_validator_spec.rb
@@ -16,8 +16,9 @@ shared_examples_for 'it sets the common puppet-lint options' do
 end
 
 describe PDK::Validate::Puppet::PuppetLintValidator do
-  subject(:validator) { described_class.new(options) }
+  subject(:validator) { described_class.new(validator_context, options) }
 
+  let(:validator_context) { nil }
   let(:options) { {} }
 
   it 'defines the base validator attributes' do

--- a/spec/unit/pdk/validate/puppet/puppet_lint_validator_spec.rb
+++ b/spec/unit/pdk/validate/puppet/puppet_lint_validator_spec.rb
@@ -30,8 +30,9 @@ describe PDK::Validate::Puppet::PuppetLintValidator do
   end
 
   describe '.pattern' do
-    it 'only matches puppet manifests' do
-      expect(validator.pattern).to eq('**/*.pp')
+    it 'only contextually matches puppet manifests' do
+      expect(validator).to receive(:contextual_pattern).with('**/*.pp') # rubocop:disable RSpec/SubjectStub This is fine
+      validator.pattern
     end
   end
 

--- a/spec/unit/pdk/validate/puppet/puppet_syntax_validator_spec.rb
+++ b/spec/unit/pdk/validate/puppet/puppet_syntax_validator_spec.rb
@@ -22,14 +22,16 @@ describe PDK::Validate::Puppet::PuppetSyntaxValidator do
   end
 
   describe '.pattern' do
-    it 'only matches puppet manifests' do
-      expect(validator.pattern).to eq('**/*.pp')
+    it 'only contextually matches puppet manifests' do
+      expect(validator).to receive(:contextual_pattern).with('**/*.pp') # rubocop:disable RSpec/SubjectStub This is fine
+      validator.pattern
     end
   end
 
   describe '.pattern_ignore' do
-    it 'does not match plan files' do
-      expect(validator.pattern_ignore).to eq('/plans/**/*.pp')
+    it 'does not contextually matches plan files' do
+      expect(validator).to receive(:contextual_pattern).with('plans/**/*.pp') # rubocop:disable RSpec/SubjectStub This is fine
+      validator.pattern_ignore
     end
   end
 

--- a/spec/unit/pdk/validate/puppet/puppet_syntax_validator_spec.rb
+++ b/spec/unit/pdk/validate/puppet/puppet_syntax_validator_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 require 'pdk/validate/puppet/puppet_syntax_validator'
 
 describe PDK::Validate::Puppet::PuppetSyntaxValidator do
-  subject(:validator) { described_class.new(options) }
+  subject(:validator) { described_class.new(validator_context, options) }
 
+  let(:validator_context) { nil }
   let(:options) { {} }
   let(:tmpdir) { File.join('/', 'tmp', 'puppet-parser-validate') }
 

--- a/spec/unit/pdk/validate/ruby/ruby_rubocop_validator_spec.rb
+++ b/spec/unit/pdk/validate/ruby/ruby_rubocop_validator_spec.rb
@@ -18,8 +18,9 @@ shared_examples_for 'it sets the common rubocop options' do
 end
 
 describe PDK::Validate::Ruby::RubyRubocopValidator do
-  subject(:validator) { described_class.new(options) }
+  subject(:validator) { described_class.new(validator_context, options) }
 
+  let(:validator_context) { nil }
   let(:options) { {} }
 
   it 'defines the ExternalCommandValidator attributes' do

--- a/spec/unit/pdk/validate/ruby/ruby_rubocop_validator_spec.rb
+++ b/spec/unit/pdk/validate/ruby/ruby_rubocop_validator_spec.rb
@@ -32,8 +32,19 @@ describe PDK::Validate::Ruby::RubyRubocopValidator do
   end
 
   describe '.pattern' do
-    it 'only matches ruby files' do
-      expect(validator.pattern).to eq('**/**.rb')
+    context 'in a Puppet Module' do
+      it 'only matches ruby files' do
+        expect(validator.pattern).to eq('**/**.rb')
+      end
+    end
+
+    context 'in a Control Repo' do
+      let(:context_root) { File.join(FIXTURES_DIR, 'control_repo') }
+      let(:validator_context) { PDK::Context::ControlRepo.new(context_root, context_root) }
+
+      it 'only matches ruby files and Pupeptfile' do
+        expect(validator.pattern).to eq(['Puppetfile', '**/**.rb'])
+      end
     end
   end
 

--- a/spec/unit/pdk/validate/validator_group_spec.rb
+++ b/spec/unit/pdk/validate/validator_group_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 require 'pdk/validate/validator_group'
 
 describe PDK::Validate::ValidatorGroup do
-  let(:validator_group) { described_class.new(validator_options) }
+  let(:validator_group) { described_class.new(validator_context, validator_options) }
+  let(:validator_context) { nil }
   let(:validator_options) { {} }
 
   describe '.spinner_text' do
@@ -129,6 +130,12 @@ describe PDK::Validate::ValidatorGroup do
     it 'returns instances of the classes in validators' do
       validator_group.validator_instances.each_with_index do |item, index|
         expect(item).to be_a(validator_group.validators[index])
+      end
+    end
+
+    it 'passes through the context' do
+      validator_group.validator_instances.each_with_index do |item, _|
+        expect(item.context).to be(validator_group.context)
       end
     end
 

--- a/spec/unit/pdk/validate/validator_spec.rb
+++ b/spec/unit/pdk/validate/validator_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 require 'pdk/validate/validator'
 
 describe PDK::Validate::Validator do
-  subject(:validator) { described_class.new(validator_options) }
+  subject(:validator) { described_class.new(validator_context, validator_options) }
 
+  let(:validator_context) { nil }
   let(:validator_options) { {} }
   let(:mock_spinner) do
     require 'pdk/cli/util/spinner'
@@ -20,7 +21,19 @@ describe PDK::Validate::Validator do
     let(:validator_options) { { 'abc' => :foo } }
 
     it 'remembers the options' do
+      expect(validator.context).to be_a(PDK::Context::None)
+    end
+
+    it 'defaults to None context' do
       expect(validator.options).to eq(validator_options)
+    end
+
+    context 'with a real context' do
+      let(:validator_context) { PDK::Context::Module.new(nil, nil) }
+
+      it 'remembers the context' do
+        expect(validator.context).to be(validator_context)
+      end
     end
   end
 

--- a/spec/unit/pdk/validate_spec.rb
+++ b/spec/unit/pdk/validate_spec.rb
@@ -47,8 +47,9 @@ describe PDK::Validate do
   end
 
   describe '#invoke_validators_by_name' do
-    subject(:invokation_result) { described_class.invoke_validators_by_name(validators_to_run, parallel, validation_options) }
+    subject(:invokation_result) { described_class.invoke_validators_by_name(pdk_context, validators_to_run, parallel, validation_options) }
 
+    let(:pdk_context) { PDK::Context::None.new(nil) }
     let(:parallel) { false }
     let(:validation_options) { {} }
     let(:mock_hash) do

--- a/spec/unit/pdk_spec.rb
+++ b/spec/unit/pdk_spec.rb
@@ -31,4 +31,80 @@ describe PDK do
       expect(object2).to be(object1)
     end
   end
+
+  describe '.feature_flag?' do
+    around(:each) do |example|
+      old_flags = ENV['PDK_FEATURE_FLAGS']
+      ENV['PDK_FEATURE_FLAGS'] = flag_env_var
+      example.run
+      ENV['PDK_FEATURE_FLAGS'] = old_flags
+    end
+
+    before(:each) do
+      allow(described_class).to receive(:available_feature_flags).and_return(%w[setflag unsetflag])
+      # Reset memoized variables
+      described_class.instance_variable_set(:@requested_feature_flags, nil)
+    end
+
+    shared_examples 'an unset flag' do
+      it 'does not have the flag set' do
+        expect(described_class.feature_flag?('setflag')).to eq(false)
+      end
+    end
+
+    shared_examples 'a set flag' do
+      it 'has the flag set' do
+        expect(described_class.feature_flag?('setflag')).to eq(true)
+      end
+    end
+
+    shared_examples 'an unavailable flag' do
+      it 'does not have the flag set' do
+        # Even if the flag is set, if it's not available then it is always false
+        expect(described_class.feature_flag?('unavailable')).to eq(false)
+      end
+    end
+
+    context 'with missing environment variable' do
+      let(:flag_env_var) { nil }
+
+      include_examples 'an unset flag'
+    end
+
+    context 'with empty environment variable' do
+      let(:flag_env_var) { '' }
+
+      include_examples 'an unset flag'
+    end
+
+    context 'with mismatched flagname' do
+      let(:flag_env_var) { 'otherflag' }
+
+      include_examples 'an unset flag'
+    end
+
+    context 'in a list of flags with the wrong delimeter' do
+      let(:flag_env_var) { 'abc:  setflag  : 123' }
+
+      include_examples 'an unset flag'
+    end
+
+    context 'as the only flag' do
+      let(:flag_env_var) { 'setflag' }
+
+      include_examples 'a set flag'
+    end
+
+    context 'as an unavailable flage' do
+      let(:flag_env_var) { 'unavailable' }
+
+      include_examples 'an unavailable flag'
+    end
+
+    context 'in a list of flags' do
+      let(:flag_env_var) { 'abc,  setflag  , 123' }
+
+      include_examples 'a set flag'
+    end
+  end
 end


### PR DESCRIPTION
~~Builds on #857~~ Merged

---

Now that Validators have a context to know whether they are operating in a
Module or Control Repo, the valdiator concrete classes need to be updated to
change their behaviour depending on the context.

* When in a Control Repo, previously module level patterns now need to be
  changed to each modulepath in the Control Repo.  The helper method
  `contextual_pattern` on the InvokableValidator class provides an easy way to
  do this
* Update the concrete validators to handle patterns which are Arrays. Previously
  many just assumed a String
* Update bundler helper to check for a Gemfile before processing binstubs.
  Previously this threw an obtuse error.  Now that Control Repos are supported
  it is common that they do not have a Gemfile.
* Updated `pdk validate` to support the controlrepo feature flag
* Updated `pdk validate` to support NOT having a Gemfile, which is common in
  control repos.
* Updated the ExternalCommandValidator to support being used in a non-Gemfile
  environment.  This meant searching for the external command not only as a
  binstub, but also in packaged or default bin directories


(PDK-1618) Add Feature Flags

(PDK-1618) Add controlrepo feature flag

(PDK-1613) Pass context into the Validators

(PDK-1616) Extend validators for a control-repo

(maint) Validators should use unique target list

---

TODO

- [x] Working on a real control-repo, with no Gemfile
- [x] Behind a featureflag
- [x] Acceptance tests green?
- [ ] Adhoc package testing
- [x] Fix duplicate target issue.