### PR TITLE
(PDK-1108) Add pdk set config command

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -158,6 +158,7 @@ module PDK::CLI
   require 'pdk/cli/convert'
   require 'pdk/cli/get'
   require 'pdk/cli/new'
+  require 'pdk/cli/set'
   require 'pdk/cli/test'
   require 'pdk/cli/update'
   require 'pdk/cli/validate'

--- a/lib/pdk/cli/convert.rb
+++ b/lib/pdk/cli/convert.rb
@@ -31,7 +31,7 @@ module PDK::CLI
         raise PDK::CLI::ExitWithError, _('You can not specify --template-url and --default-template.') if opts[:'template-url']
 
         opts[:'template-url'] = PDK::Util::TemplateURI.default_template_addressable_uri.to_s
-        PDK.config.user['module_defaults']['template-url'] = nil
+        PDK.config.set(%w[user module_defaults template-url], nil)
       end
 
       PDK::CLI::Util.validate_template_opts(opts)

--- a/lib/pdk/cli/set.rb
+++ b/lib/pdk/cli/set.rb
@@ -1,0 +1,20 @@
+module PDK::CLI
+  @set_cmd = @base_cmd.define_command do
+    name 'set'
+    usage _('set [subcommand] [options]')
+    summary _('Set or update information about the PDK or current project.')
+    default_subcommand 'help'
+
+    run do |_opts, args, _cmd|
+      if args == ['help']
+        PDK::CLI.run(%w[set --help])
+        exit 0
+      end
+
+      PDK::CLI.run(%w[set help]) if args.empty?
+    end
+  end
+  @set_cmd.add_command Cri::Command.new_basic_help
+end
+
+require 'pdk/cli/set/config'

--- a/lib/pdk/cli/set/config.rb
+++ b/lib/pdk/cli/set/config.rb
@@ -1,0 +1,119 @@
+module PDK::CLI
+  module Set
+    module Config
+      ALLOWED_TYPE_NAMES = %w[array boolean number string].freeze
+
+      # :nocov:
+      def self.pretty_allowed_names
+        ALLOWED_TYPE_NAMES.map { |name| "'#{name}'" }.join(', ')
+      end
+      # :nocov:
+
+      def self.transform_value(type_name, value)
+        normalized_name = type_name.downcase.strip
+        unless ALLOWED_TYPE_NAMES.include?(normalized_name)
+          raise PDK::CLI::ExitWithError, _('Unknown type %{type_name}. Expected one of %{allowed}') % { type_name: type_name, allowed: pretty_allowed_names }
+        end
+
+        # Short circuit string conversions as it's trivial
+        if normalized_name == 'string'
+          raise PDK::CLI::ExitWithError, _('An error occured converting \'%{value}\' into a %{type_name}') % { value: value.nil? ? 'nil' : value, type_name: type_name } unless value.is_a?(String)
+          return value
+        end
+
+        begin
+          case normalized_name
+          when 'array'
+            convert_to_array(value)
+          when 'boolean'
+            convert_to_boolean(value)
+          when 'number'
+            convert_to_number(value)
+          else
+            value
+          end
+        rescue ArgumentError, TypeError
+          raise PDK::CLI::ExitWithError, _('An error occured converting \'%{value}\' into a %{type_name}') % { value: value.nil? ? 'nil' : value, type_name: type_name }
+        end
+      end
+
+      def self.convert_to_array(value)
+        return [] if value.nil?
+        value.is_a?(Array) ? value : [value]
+      end
+      private_class_method :convert_to_array
+
+      def self.convert_to_boolean(value)
+        string_val = value.to_s.strip.downcase
+
+        return true  if %w[yes true -1 1].include?(string_val)
+        return false if %w[no false 0].include?(string_val)
+
+        raise ArgumentError
+      end
+      private_class_method :convert_to_boolean
+
+      def self.convert_to_number(value)
+        float_val = Float(value)
+        # Return an Integer if this is actually and Integer, otherwise return the float
+        (float_val.truncate == float_val) ? float_val.truncate : float_val
+      end
+      private_class_method :convert_to_number
+
+      def self.run(opts, args)
+        item_name = (args.count > 0) ? args[0] : nil
+        item_value = (args.count > 1) ? args[1] : nil
+
+        opts[:type] = opts[:as] if opts[:type].nil? && !opts[:as].nil?
+        force = opts[:force] || false
+
+        # Transform the value if we need to
+        item_value = PDK::CLI::Set::Config.transform_value(opts[:type], item_value) unless opts[:type].nil?
+
+        raise PDK::CLI::ExitWithError, _('Configuration name is required') if item_name.nil?
+        raise PDK::CLI::ExitWithError, _('Configuration value is required. If you wish to remove a value use \'pdk remove config\'') if item_value.nil?
+
+        current_value = PDK.config.get(item_name)
+        raise PDK::CLI::ExitWithError, _("The configuration item '%{name}' can not have a value set.") % { name: item_name } if current_value.is_a?(PDK::Config::Namespace)
+
+        # If we're forcing the value, don't do any munging
+        unless force
+          # Check if the setting already exists
+          if current_value.is_a?(Array) && current_value.include?(item_value)
+            PDK.logger.info(_("No changes made to '%{name}' as it already contains value '%{to}'") % { name: item_name, to: item_value })
+            return 0
+          end
+        end
+
+        new_value = PDK.config.set(item_name, item_value, force: opts[:force])
+        if current_value.nil? || force
+          PDK.logger.info(_("Set initial value of '%{name}' to '%{to}'") % { name: item_name, to: new_value })
+        elsif current_value.is_a?(Array)
+          # Arrays have a special output format
+          PDK.logger.info(_("Added new value '%{to}' to '%{name}'") % { name: item_name, to: item_value })
+        else
+          PDK.logger.info(_("Changed existing value of '%{name}' from '%{from}' to '%{to}'") % { name: item_name, from: current_value, to: new_value })
+        end
+
+        # Same output as `get config`
+        $stdout.puts _('%{name}=%{value}') % { name: item_name, value: PDK.config.get(item_name) }
+        0
+      end
+    end
+  end
+
+  @set_config_cmd = @set_cmd.define_command do
+    name 'config'
+    usage _('config [name] [value]')
+    summary _('Set or update the configuration for <name>')
+
+    option :f, :force, _('Force the configuration setting to be overwitten.'), argument: :forbidden
+
+    option :t, :type, _('The type of value to set. Acceptable values: %{values}') % { values: PDK::CLI::Set::Config.pretty_allowed_names }, argument: :required
+    option nil, :as, _('Alias of --type'), argument: :required
+
+    run do |opts, args, _cmd|
+      exit PDK::CLI::Set::Config.run(opts, args)
+    end
+  end
+end

--- a/lib/pdk/config.rb
+++ b/lib/pdk/config.rb
@@ -33,14 +33,6 @@ module PDK
       }.merge(options)
     end
 
-    # The user configuration settings.
-    # @deprecated This method is only provided as a courtesy until the `pdk set config` CLI and associated changes in this class, are completed.
-    #             Any read-only operations should be using `.get` or `.get_within_scopes`
-    # @return [PDK::Config::Namespace]
-    def user
-      user_config
-    end
-
     # The system level configuration settings.
     # @return [PDK::Config::Namespace]
     # @api private
@@ -269,9 +261,9 @@ module PDK
 
       if answers.nil?
         PDK.logger.info _('No answer given, opting out of analytics collection.')
-        PDK.config.user['analytics']['disabled'] = true
+        PDK.config.set(%w[user analytics disabled], true)
       else
-        PDK.config.user['analytics']['disabled'] = !answers['enabled']
+        PDK.config.set(%w[user analytics disabled], !answers['enabled'])
       end
 
       PDK.logger.info(text: post_message, wrap: true)

--- a/lib/pdk/generate/module.rb
+++ b/lib/pdk/generate/module.rb
@@ -82,11 +82,11 @@ module PDK
           # If the user specifies our default template url via the command
           # line, remove the saved template-url answer so that the template_uri
           # resolution can find new default URLs in the future.
-          PDK.config.user['module_defaults']['template-url'] = nil if opts.key?(:'template-url')
+          PDK.config.set(%w[user module_defaults template-url], nil) if opts.key?(:'template-url')
         else
           # Save the template-url answers if the module was generated using a
           # template/reference other than ours.
-          PDK.config.user['module_defaults']['template-url'] = template_uri.metadata_format
+          PDK.config.set(%w[user module_defaults template-url], template_uri.metadata_format)
         end
 
         begin
@@ -342,9 +342,9 @@ module PDK
         end
 
         require 'pdk/answer_file'
-        PDK.config.user['module_defaults']['forge_username'] = opts[:username] unless opts[:username].nil?
-        PDK.config.user['module_defaults']['author'] = answers['author'] unless answers['author'].nil?
-        PDK.config.user['module_defaults']['license'] = answers['license'] unless answers['license'].nil?
+        PDK.config.set(%w[user module_defaults forge_username], opts[:username]) unless opts[:username].nil?
+        PDK.config.set(%w[user module_defaults author], answers['author']) unless answers['author'].nil?
+        PDK.config.set(%w[user module_defaults license], answers['license']) unless answers['license'].nil?
       end
     end
   end

--- a/package-testing/spec/package/pdk_configuration_spec.rb
+++ b/package-testing/spec/package/pdk_configuration_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper_package'
+
+describe 'Using the PDK configuration commands' do
+  def env_var(host, var_name)
+    value = host.get_env_var(var_name)
+    value.empty? ? nil : value[var_name.length + 1, value.length - var_name.length - 1]
+  end
+
+  def host_system_configdir(host)
+    # This emulates the PDK::Util.system_configdir method
+    # Ugh ... The double backslash escaping makes me sad :_(
+    (host.platform =~ %r{windows}) ? 'C:\\\\ProgramData\\\\PuppetLabs\\\\PDK' : '/opt/puppetlabs/pdk/config'
+  end
+
+  def windows_path(path)
+    # Why Beaker?!?! WHY!
+    path.gsub('\\', '\\\\\\')
+  end
+
+  def host_user_configdir(host)
+    # This emulates the PDK::Util.configdir method
+    if host.platform =~ %r{windows}
+      # Ugh... The double backslash escaping makes me REALLY sad :_(
+      windows_path(env_var(host, 'LOCALAPPDATA')) + '\\\\PDK'
+    else
+      dir = env_var(host, 'XDG_CONFIG_HOME')
+      dir.nil? ? env_var(host, 'HOME') + '/.config/pdk' : dir + '/.config/pdk'
+    end
+  end
+
+  def host_system_config_file(host)
+    # This emulates the PDK::Config.system_config_path method
+    system_dir = host_system_configdir(host)
+    (host.platform =~ %r{windows}) ? system_dir + '\\\\system_config.json' : system_dir + '/system_config.json'
+  end
+
+  def host_user_config_file(host)
+    # This emulates the PDK::Config.user_config_path method
+    user_dir = host_user_configdir(host)
+    (host.platform =~ %r{windows}) ? user_dir + '\\\\user_config.json' : user_dir + '/user_config.json'
+  end
+
+  before(:all) do
+    hosts.each do |host|
+      # Create the sytem configuration directory
+      system_dir = host_system_configdir(host)
+      host.mkdir_p(system_dir) unless directory_exists_on(host, system_dir)
+
+      # Create the user configuration directory
+      # Note that this assumes the user's home directory is already setup with the correct directory permissions
+      user_dir = host_user_configdir(host)
+      host.mkdir_p(user_dir) unless directory_exists_on(host, user_dir)
+
+      # Setup the system and user test settings
+      create_remote_file(host, host_system_config_file(host), "{\n  \"testsetting1\": \"system\"\n}\n")
+      create_remote_file(host, host_user_config_file(host), "{\n  \"testsetting1\": \"user\"\n}\n")
+    end
+  end
+
+  context 'retrieving the configuration' do
+    describe command('pdk get config') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stdout) { is_expected.to contain('system.testsetting1=system') }
+      its(:stdout) { is_expected.to contain('user.testsetting1=user') }
+    end
+  end
+
+  context 'setting the configuration' do
+    describe command('pdk set config system.testsetting2 system2') do
+      its(:exit_status) { is_expected.to eq(0) }
+
+      context 'and then retrieving the configuration' do
+        # Note this requires the above command to be run first.
+        describe command('pdk get config') do
+          its(:stdout) { is_expected.to contain('system.testsetting2=system2') }
+        end
+      end
+    end
+
+    describe command('pdk set config user.testsetting2 user2') do
+      its(:exit_status) { is_expected.to eq(0) }
+
+      context 'and then retrieving the configuration' do
+        # Note this requires the above command to be run first.
+        describe command('pdk get config') do
+          its(:stdout) { is_expected.to contain('user.testsetting2=user2') }
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/set_config_spec.rb
+++ b/spec/acceptance/set_config_spec.rb
@@ -1,0 +1,142 @@
+require 'spec_helper_acceptance'
+require 'tempfile'
+
+describe 'pdk set config' do
+  include_context 'with a fake TTY'
+
+  shared_examples 'a saved configuration file' do |new_content|
+    it 'saves the setting' do
+      # Force the command to run if not already
+      subject.exit_status # rubocop:disable RSpec/NamedSubject We don't actually know the name here
+      expect(File).to exist(ENV['PDK_ANSWER_FILE'])
+
+      actual_content = File.open(ENV['PDK_ANSWER_FILE'], 'rb:utf-8') { |f| f.read }
+      expect(actual_content).to eq(new_content)
+    end
+  end
+
+  shared_examples 'a saved JSON configuration file' do |new_json_content|
+    it 'saves the setting' do
+      # Force the command to run if not already
+      subject.exit_status # rubocop:disable RSpec/NamedSubject We don't actually know the name here
+      expect(File).to exist(ENV['PDK_ANSWER_FILE'])
+
+      actual_content_raw = File.open(ENV['PDK_ANSWER_FILE'], 'rb:utf-8') { |f| f.read }
+      actual_json_content = ::JSON.parse(actual_content_raw)
+      expect(actual_json_content).to eq(new_json_content)
+    end
+  end
+
+  RSpec.shared_context 'with a fake answer file' do |initial_content = nil|
+    before(:all) do
+      fake_answer_file = Tempfile.new('mock_answers.json')
+      unless initial_content.nil?
+        require 'json'
+        fake_answer_file.binmode
+        fake_answer_file.write(::JSON.pretty_generate(initial_content))
+      end
+      fake_answer_file.close
+      ENV['PDK_ANSWER_FILE'] = fake_answer_file.path
+    end
+
+    after(:all) do
+      File.delete(ENV['PDK_ANSWER_FILE']) if File.exist?(ENV['PDK_ANSWER_FILE']) # rubocop:disable PDK/FileDelete,PDK/FileExistPredicate Need actual file calls here
+      ENV.delete('PDK_ANSWER_FILE')
+    end
+  end
+
+  context 'when run outside of a module' do
+    describe command('pdk set config') do
+      its(:exit_status) { is_expected.not_to eq 0 }
+      its(:stdout) { is_expected.to have_no_output }
+      its(:stderr) { is_expected.to match(%r{Configuration name is required}) }
+    end
+
+    context 'with a setting that does not exist' do
+      describe command('pdk set config user.module_defaults.mock value') do
+        include_context 'with a fake answer file'
+
+        its(:exit_status) { is_expected.to eq 0 }
+        its(:stdout) { is_expected.to match(%r{user.module_defaults.mock=value}) }
+        its(:stderr) { is_expected.to match(%r{Set initial value of 'user.module_defaults.mock' to 'value'}) }
+
+        it_behaves_like 'a saved JSON configuration file', 'mock' => 'value'
+
+        # We test the literal output here to make sure it outputs pretty JSON instead of minified JSON
+        it_behaves_like 'a saved configuration file', "{\n  \"mock\": \"value\"\n}\n"
+      end
+    end
+
+    context 'with an existing array setting, not forced' do
+      describe command('pdk set config user.module_defaults.mock value') do
+        include_context 'with a fake answer file', 'mock' => []
+
+        its(:exit_status) { is_expected.to eq 0 }
+        its(:stdout) { is_expected.to match(%r{user.module_defaults.mock=\["value"\]}) }
+        its(:stderr) { is_expected.to match(%r{Added new value 'value' to 'user.module_defaults.mock'}) }
+
+        it_behaves_like 'a saved JSON configuration file', 'mock' => ['value']
+      end
+    end
+
+    context 'with an existing non-array setting, not forced' do
+      describe command('pdk set config user.module_defaults.mock value') do
+        include_context 'with a fake answer file', 'mock' => 1
+
+        its(:exit_status) { is_expected.to eq 0 }
+        its(:stdout) { is_expected.to match(%r{user.module_defaults.mock=value}) }
+        its(:stderr) { is_expected.to match(%r{Changed existing value of 'user.module_defaults.mock' from '1' to 'value'}) }
+
+        it_behaves_like 'a saved JSON configuration file', 'mock' => 'value'
+      end
+    end
+
+    context 'with an existing setting, forced' do
+      describe command('pdk set config --force user.module_defaults.mock value') do
+        include_context 'with a fake answer file', 'mock' => []
+
+        its(:exit_status) { is_expected.to eq 0 }
+        its(:stdout) { is_expected.to match(%r{user.module_defaults.mock=value}) }
+        its(:stderr) { is_expected.to match(%r{Set initial value of 'user.module_defaults.mock' to 'value'}) }
+
+        it_behaves_like 'a saved JSON configuration file', 'mock' => 'value'
+      end
+    end
+
+    context 'with an existing setting, forced and an explicit type' do
+      describe command('pdk set config --force --type number user.module_defaults.mock 1') do
+        include_context 'with a fake answer file', 'mock' => []
+
+        its(:exit_status) { is_expected.to eq 0 }
+        its(:stdout) { is_expected.to match(%r{user.module_defaults.mock=1}) }
+        its(:stderr) { is_expected.to match(%r{Set initial value of 'user.module_defaults.mock' to '1'}) }
+
+        it_behaves_like 'a saved JSON configuration file', 'mock' => 1
+      end
+    end
+
+    context 'with an existing setting, forced and an explicit type (--as)' do
+      describe command('pdk set config --force --as number user.module_defaults.mock 1') do
+        include_context 'with a fake answer file', 'mock' => []
+
+        its(:exit_status) { is_expected.to eq 0 }
+        its(:stdout) { is_expected.to match(%r{user.module_defaults.mock=1}) }
+        its(:stderr) { is_expected.to match(%r{Set initial value of 'user.module_defaults.mock' to '1'}) }
+
+        it_behaves_like 'a saved JSON configuration file', 'mock' => 1
+      end
+    end
+
+    context 'with an invalid type' do
+      describe command('pdk set config --type invalid_type_name user.module_defaults.mock value') do
+        include_context 'with a fake answer file', 'mock' => 'old_value'
+
+        its(:exit_status) { is_expected.not_to eq 0 }
+        its(:stdout) { is_expected.to have_no_output }
+        its(:stderr) { is_expected.to match(%r{Unknown type invalid_type_name}) }
+
+        it_behaves_like 'a saved JSON configuration file', 'mock' => 'old_value'
+      end
+    end
+  end
+end

--- a/spec/acceptance/set_spec.rb
+++ b/spec/acceptance/set_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper_acceptance'
+require 'fileutils'
+
+describe 'pdk set' do
+  include_context 'with a fake TTY'
+
+  context 'when run outside of a module' do
+    describe command('pdk set') do
+      its(:exit_status) { is_expected.to eq 0 }
+      # Should show the command help
+      its(:stdout) { is_expected.to match(%r{pdk set \[subcommand\] \[options\]}) }
+      its(:stderr) { is_expected.to have_no_output }
+    end
+  end
+end

--- a/spec/unit/pdk/cli/convert_spec.rb
+++ b/spec/unit/pdk/cli/convert_spec.rb
@@ -252,7 +252,7 @@ describe 'PDK::CLI convert' do
 
         it 'clears the saved template-url answer' do
           run
-          expect(PDK.config.user['module_defaults']['template-url']).to be_nil
+          expect(PDK.config.get(%w[user module_defaults template-url])).to be_nil
         end
 
         it 'submits the command to analytics' do

--- a/spec/unit/pdk/cli/set/config_spec.rb
+++ b/spec/unit/pdk/cli/set/config_spec.rb
@@ -67,7 +67,7 @@ describe 'PDK::CLI::Set::Config' do
 
     RSpec.shared_examples 'a saved setting' do |setting_name, expected_value, force = nil|
       it 'saves the setting' do
-        expect(pdk_config).to receive(:set).with(setting_name, Object, force: force).and_call_original
+        expect(pdk_config).to receive(:set).with(setting_name, anything, force: force).and_call_original
         expect(run).to eq(0)
         expect(pdk_config.get(setting_name)).to eq(expected_value)
       end

--- a/spec/unit/pdk/cli/set/config_spec.rb
+++ b/spec/unit/pdk/cli/set/config_spec.rb
@@ -1,0 +1,283 @@
+require 'spec_helper'
+require 'pdk/cli'
+
+describe 'PDK::CLI::Set::Config' do
+  describe '#run' do
+    subject(:run) { PDK::CLI::Set::Config.run(cli_opts, cli_args) }
+
+    let(:type_opt) { nil }
+    let(:as_opt) { nil }
+    let(:force_opt) { nil }
+    let(:cli_opts) do
+      {
+        type: type_opt,
+        as: as_opt,
+        force: force_opt,
+      }
+    end
+    let(:setting_name) { nil }
+    let(:setting_value) { nil }
+    let(:cli_args) { [setting_name, setting_value].compact }
+
+    let(:pdk_config) { MockEmptyConfig.new }
+
+    # Note, this class name needs to be unqiue in the ENTIRE rspec suite!
+    class MockEmptyConfig < PDK::Config
+      def user_config
+        @user_config ||= PDK::Config::Namespace.new('user') { ; }
+      end
+
+      def system_config
+        @system_config ||= PDK::Config::Namespace.new('system') { ; }
+      end
+
+      def project_config
+        @project_config ||= PDK::Config::Namespace.new('project') { ; }
+      end
+    end
+
+    before(:each) do
+      allow(PDK).to receive(:config).and_return(pdk_config)
+      allow($stdout).to receive(:puts)
+    end
+
+    RSpec.shared_examples 'a missing name error' do
+      it 'raises with missing name' do
+        expect { run }.to raise_error(PDK::CLI::ExitWithError, %r{name is required})
+      end
+    end
+
+    RSpec.shared_examples 'a missing value error' do
+      it 'raises with missing value' do
+        expect { run }.to raise_error(PDK::CLI::ExitWithError, %r{value is required})
+      end
+    end
+
+    RSpec.shared_examples 'a failed conversion error' do
+      it 'raises with failed conversion' do
+        expect { run }.to raise_error(PDK::CLI::ExitWithError, %r{error occured converting .* into a .*})
+      end
+    end
+
+    RSpec.shared_examples 'a un-settable setting error' do
+      it 'raises with failed conversion' do
+        expect { run }.to raise_error(PDK::CLI::ExitWithError, %r{can not have a value set})
+      end
+    end
+
+    RSpec.shared_examples 'a saved setting' do |setting_name, expected_value, force = nil|
+      it 'saves the setting' do
+        expect(pdk_config).to receive(:set).with(setting_name, Object, force: force).and_call_original
+        expect(run).to eq(0)
+        expect(pdk_config.get(setting_name)).to eq(expected_value)
+      end
+    end
+
+    context 'with no arguments or flags' do
+      it_behaves_like 'a missing name error'
+    end
+
+    context 'with a missing value and no type information' do
+      let(:setting_name) { 'user' }
+
+      it_behaves_like 'a missing value error'
+    end
+
+    context 'with a missing value and non-array type information' do
+      let(:setting_name) { 'user' }
+
+      PDK::CLI::Set::Config::ALLOWED_TYPE_NAMES.reject { |i| i == 'array' }.each do |type_name|
+        context "with type #{type_name}" do
+          let(:type_opt) { type_name }
+
+          it_behaves_like 'a failed conversion error'
+        end
+      end
+    end
+
+    context 'with bad a type conversion' do
+      let(:setting_name) { 'user.foo' }
+      let(:setting_value) { 'i_am_not_a_number' }
+      let(:type_opt) { 'number' }
+
+      it_behaves_like 'a failed conversion error'
+    end
+
+    context 'with a setting name that is a root namespace' do
+      let(:setting_name) { 'user' }
+      let(:setting_value) { 'foo' }
+
+      it_behaves_like 'a un-settable setting error'
+    end
+
+    context 'using --as instead of --type' do
+      let(:setting_name) { 'user.foo' }
+      let(:as_opt) { 'number' }
+      let(:setting_value) { 1 }
+
+      it_behaves_like 'a saved setting', 'user.foo', 1, nil
+    end
+
+    context 'with a missing value and array type information' do
+      let(:setting_name) { 'user.foo' }
+      let(:type_opt) { 'array' }
+
+      it_behaves_like 'a saved setting', 'user.foo', []
+    end
+
+    context 'when appending a value to an existing array' do
+      let(:setting_name) { 'user.foo' }
+
+      before(:each) do
+        pdk_config.user_config['foo'] = []
+      end
+
+      context 'and the value is an array' do
+        let(:type_opt) { 'array' }
+        let(:setting_value) { 'nested' }
+
+        it_behaves_like 'a saved setting', 'user.foo', [['nested']]
+      end
+
+      context 'and the value is a boolan' do
+        let(:type_opt) { 'boolean' }
+        let(:setting_value) { 'Yes' }
+
+        it_behaves_like 'a saved setting', 'user.foo', [true]
+      end
+
+      context 'and the value is a number' do
+        let(:type_opt) { 'number' }
+        let(:setting_value) { '1.0' }
+
+        it_behaves_like 'a saved setting', 'user.foo', [1.0]
+      end
+
+      context 'and the value is a string' do
+        let(:type_opt) { 'string' }
+        let(:setting_value) { 'new_value' }
+
+        it_behaves_like 'a saved setting', 'user.foo', ['new_value']
+      end
+    end
+
+    context 'when appending a value that already exists to an existing array' do
+      let(:setting_name) { 'user.foo' }
+      let(:setting_value) { 'abc' }
+
+      before(:each) do
+        pdk_config.user_config['foo'] = ['abc', 123]
+      end
+
+      it 'does not save the setting' do
+        expect(pdk_config).not_to receive(:set)
+        expect(run).to eq(0)
+        expect(pdk_config.get(setting_name)).to eq(['abc', 123])
+      end
+
+      it 'logs an information message' do
+        expect(PDK.logger).to receive(:info).with(%r{No changes made .+ already contains value}im)
+        run
+      end
+
+      context 'and force is set' do
+        let(:force_opt) { true }
+
+        it_behaves_like 'a saved setting', 'user.foo', 'abc', true
+      end
+    end
+
+    context 'when creating a deep hash' do
+      let(:setting_name) { 'user.foo.a.b.c' }
+      let(:setting_value) { 'abc' }
+
+      before(:each) do
+        pdk_config.user_config['foo'] = { 'bar' => 'whizz' }
+      end
+
+      it_behaves_like 'a saved setting', 'user.foo.a.b.c', 'abc'
+
+      it 'merges the value into the hash' do
+        expect(run).to eq(0)
+        expect(pdk_config.get('user.foo')).to eq('a' => { 'b' => { 'c' => 'abc' } }, 'bar' => 'whizz')
+      end
+    end
+  end
+
+  describe '#transform_value' do
+    let(:type_name) { nil }
+    let(:value) { nil }
+
+    RSpec.shared_examples 'a value transformer' do |value, expected|
+      it "converts valid value '#{value}' to a #{expected.class.name}" do
+        result = PDK::CLI::Set::Config.transform_value(type_name, value)
+        expect(result.class.name).to eq(expected.class.name)
+        expect(result).to eq(expected)
+      end
+    end
+
+    RSpec.shared_examples 'a value transformer error' do |value|
+      it "raises with invalid value '#{value}'" do
+        expect { PDK::CLI::Set::Config.transform_value(type_name, value) }.to raise_error(PDK::CLI::ExitWithError)
+      end
+    end
+
+    context 'given a type of array' do
+      let(:type_name) { 'array' }
+
+      it_behaves_like 'a value transformer', 'abc', ['abc']
+      it_behaves_like 'a value transformer', nil, []
+      it_behaves_like 'a value transformer', [123], [123]
+      it_behaves_like 'a value transformer', { 'abc' => 123 }, [{ 'abc' => 123 }]
+      it_behaves_like 'a value transformer', 1, [1]
+    end
+
+    context 'given a type of boolean' do
+      let(:type_name) { 'boolean' }
+
+      it_behaves_like 'a value transformer error', 'abc'
+      it_behaves_like 'a value transformer error', '1.0a'
+      it_behaves_like 'a value transformer error', nil
+      it_behaves_like 'a value transformer error', [123]
+      it_behaves_like 'a value transformer error', 'abc' => 123
+
+      it_behaves_like 'a value transformer', 'YES', true
+      it_behaves_like 'a value transformer', 'yEs', true
+      it_behaves_like 'a value transformer', '-1', true
+      it_behaves_like 'a value transformer', 'true', true
+      it_behaves_like 'a value transformer', 'True', true
+      it_behaves_like 'a value transformer', 'NO', false
+      it_behaves_like 'a value transformer', 'nO', false
+      it_behaves_like 'a value transformer', '0', false
+      it_behaves_like 'a value transformer', 'false', false
+      it_behaves_like 'a value transformer', 'FALSE', false
+    end
+
+    context 'given a type of number' do
+      let(:type_name) { 'number' }
+
+      it_behaves_like 'a value transformer error', 'abc'
+      it_behaves_like 'a value transformer error', '1.0a'
+      it_behaves_like 'a value transformer error', nil
+      it_behaves_like 'a value transformer error', [123]
+      it_behaves_like 'a value transformer error', 'abc' => 123
+
+      it_behaves_like 'a value transformer', '1', Integer('1')
+      it_behaves_like 'a value transformer', '1.0', Integer('1')
+      it_behaves_like 'a value transformer', '1.1', Float('1.1')
+      it_behaves_like 'a value transformer', '-1.1', Float('-1.1')
+    end
+
+    context 'given a type of string' do
+      let(:type_name) { 'string' }
+
+      it_behaves_like 'a value transformer error', nil
+      it_behaves_like 'a value transformer error', [123]
+      it_behaves_like 'a value transformer error', 'abc' => 123
+
+      it_behaves_like 'a value transformer', '1', '1'
+      it_behaves_like 'a value transformer', '1.0', '1.0'
+      it_behaves_like 'a value transformer', 'abc123', 'abc123'
+    end
+  end
+end

--- a/spec/unit/pdk/config_spec.rb
+++ b/spec/unit/pdk/config_spec.rb
@@ -27,12 +27,6 @@ describe PDK::Config do
     end
   end
 
-  describe '.user' do
-    it 'is an alias for user_config' do
-      expect(config.user).to be(config.user_config)
-    end
-  end
-
   describe '.user_config' do
     it 'returns a PDK::Config::Namespace' do
       expect(config.user_config).to be_a(PDK::Config::Namespace)
@@ -359,12 +353,12 @@ describe PDK::Config do
 
     it 'takes a String for the setting name' do
       config.set('user.foo.whizz', value)
-      expect(config.user['foo']['whizz']).to eq(value)
+      expect(config.get('user.foo.whizz')).to eq(value)
     end
 
     it 'takes an Array for the setting name' do
       config.set(%w[user foo whizz], value)
-      expect(config.user['foo']['whizz']).to eq(value)
+      expect(config.get(%w[user foo whizz])).to eq(value)
     end
 
     context 'given a root name that does not exist' do
@@ -400,7 +394,7 @@ describe PDK::Config do
       it 'can be accessed via a normal hash syntax' do
         config.set(setting, value)
 
-        expect(config.user['bar']['baz']['setting']).to eq(value)
+        expect(config.get(%w[user bar baz setting])).to eq(value)
       end
 
       it 'saves to the root file' do
@@ -423,8 +417,8 @@ describe PDK::Config do
       it 'can be accessed via a normal hash syntax' do
         config.set(setting, value)
 
-        expect(config.user['foo']['bar']).to eq('baz' => { 'setting' => value })
-        expect(config.user['foo']['bar']['baz']['setting']).to eq(value)
+        expect(config.get(%w[user foo bar])).to eq('baz' => { 'setting' => value })
+        expect(config.get(%w[user foo bar baz setting])).to eq(value)
       end
 
       it_behaves_like 'a new setting file', "{\n  \"bar\": {\n    \"baz\": {\n      \"setting\": \"mock_value\"\n    }\n  }\n}"
@@ -436,14 +430,14 @@ describe PDK::Config do
 
       it 'can be accessed via a normal hash syntax' do
         # The old setting should exist
-        expect(config.user['foo']['bar']).to eq('existing_setting' => 'exists')
+        expect(config.get(%w[user foo bar])).to eq('existing_setting' => 'exists')
 
         config.set(setting, value)
 
         # Should still contain the old setting
-        expect(config.user['foo']['bar']).to eq('baz' => { 'setting' => 'mock_value' }, 'existing_setting' => 'exists')
+        expect(config.get(%w[user foo bar])).to eq('baz' => { 'setting' => 'mock_value' }, 'existing_setting' => 'exists')
         # Should contain the new setting
-        expect(config.user['foo']['bar']['baz']['setting']).to eq(value)
+        expect(config.get(%w[user foo bar baz setting])).to eq(value)
       end
 
       it_behaves_like 'a new setting file', "{\n  \"bar\": {\n    \"existing_setting\": \"exists\",\n    \"baz\": {\n      \"setting\": \"mock_value\"\n    }\n  }\n}"
@@ -456,7 +450,7 @@ describe PDK::Config do
       context 'without forcing the change' do
         it 'raises an error' do
           # The old setting should exist
-          expect(config.user['foo']['bar']).to eq([])
+          expect(config.get(%w[user foo bar])).to eq([])
 
           expect { config.set(setting, value) }.to raise_error(ArgumentError)
         end
@@ -467,12 +461,12 @@ describe PDK::Config do
 
         it 'uses the new setting' do
           # The old setting should exist
-          expect(config.user['foo']['bar']).to eq([])
+          expect(config.get(%w[user foo bar])).to eq([])
 
           config.set(setting, value, set_options)
 
           # Should contain only new setting
-          expect(config.user['foo']['bar']['baz']['setting']).to eq(value)
+          expect(config.get(%w[user foo bar baz setting])).to eq(value)
         end
 
         it_behaves_like 'a new setting file', "{\n  \"bar\": {\n    \"baz\": {\n      \"setting\": \"mock_value\"\n    }\n  }\n}"
@@ -486,7 +480,7 @@ describe PDK::Config do
       context 'without forcing the change' do
         it 'appends the new value' do
           config.set(setting, value, set_options)
-          expect(config.user['foo']['bar']).to eq(['abc', 'def', value])
+          expect(config.get(%w[user foo bar])).to eq(['abc', 'def', value])
         end
 
         it_behaves_like 'a new setting file', "{\n  \"bar\": [\n    \"abc\",\n    \"def\",\n    \"mock_value\"\n  ]\n}"
@@ -497,7 +491,7 @@ describe PDK::Config do
 
         it 'uses the new value' do
           config.set(setting, value, set_options)
-          expect(config.user['foo']['bar']).to eq(value)
+          expect(config.get(%w[user foo bar])).to eq(value)
         end
 
         it_behaves_like 'a new setting file', "{\n  \"bar\": \"mock_value\"\n}"
@@ -512,7 +506,7 @@ describe PDK::Config do
         it 'does not append the new value' do
           expect(PDK::Util::Filesystem).not_to receive(:write_file).with(PDK::Util::Filesystem.expand_path(foo_file), anything)
           config.set(setting, value, set_options)
-          expect(config.user['foo']['bar']).to eq(['abc', value])
+          expect(config.get(%w[user foo bar])).to eq(['abc', value])
         end
       end
 
@@ -521,7 +515,7 @@ describe PDK::Config do
 
         it 'uses the new value' do
           config.set(setting, value, set_options)
-          expect(config.user['foo']['bar']).to eq(value)
+          expect(config.get(%w[user foo bar])).to eq(value)
         end
 
         it_behaves_like 'a new setting file', "{\n  \"bar\": \"mock_value\"\n}"
@@ -679,7 +673,7 @@ describe PDK::Config do
 
       it 'sets user.analytics.disabled to false' do
         described_class.analytics_config_interview!
-        expect(PDK.config.user_config['analytics']['disabled']).to be_falsey
+        expect(PDK.config.get(%w[user analytics disabled])).to be_falsey
       end
     end
 
@@ -688,7 +682,7 @@ describe PDK::Config do
 
       it 'sets user.analytics.disabled to true' do
         described_class.analytics_config_interview!
-        expect(PDK.config.user_config['analytics']['disabled']).to be_truthy
+        expect(PDK.config.get(%w[user analytics disabled])).to be_truthy
       end
     end
 
@@ -697,7 +691,7 @@ describe PDK::Config do
 
       it 'sets user.analytics.disabled to false' do
         described_class.analytics_config_interview!
-        expect(PDK.config.user_config['analytics']['disabled']).to be_falsey
+        expect(PDK.config.get(%w[user analytics disabled])).to be_falsey
       end
     end
 
@@ -706,7 +700,7 @@ describe PDK::Config do
 
       it 'sets user.analytics.disabled to true' do
         described_class.analytics_config_interview!
-        expect(PDK.config.user_config['analytics']['disabled']).to be_truthy
+        expect(PDK.config.get(%w[user analytics disabled])).to be_truthy
       end
     end
   end

--- a/spec/unit/pdk/config_spec.rb
+++ b/spec/unit/pdk/config_spec.rb
@@ -119,6 +119,10 @@ describe PDK::Config do
       end
     end
 
+    it 'traverses root names' do
+      expect(config.get('user')).to be_a(PDK::Config::Namespace)
+    end
+
     it 'traverses namespaces' do
       # The analytics is a child namespace of user
       expect(config.get('user', 'analytics', 'disabled')).to eq(true)
@@ -287,6 +291,241 @@ describe PDK::Config do
 
     it 'raises if no block is passed' do
       expect { config.with_scoped_value(setting_name, scopes) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '.set' do
+    # Note, this class name needs to be unqiue in the ENTIRE rspec suite!
+    class MockUserOnlyConfig < PDK::Config
+      def user_config
+        @user_config ||= PDK::Config::JSON.new('user', file: 'path/does/not/exist/root.json') do
+          mount :foo, PDK::Config::JSON.new(file: 'path/does/not/exist/foo.json') do
+          end
+        end
+      end
+
+      def system_config
+        @system_config ||= PDK::Config::Namespace.new('system') { ; }
+      end
+
+      def project_config
+        @system_config ||= PDK::Config::Namespace.new('project') { ; }
+      end
+    end
+
+    subject(:config) { MockUserOnlyConfig.new }
+
+    let(:value) { 'mock_value' }
+    let(:root_file) { 'path/does/not/exist/root.json' }
+    let(:root_file_content) { '{}' }
+    let(:foo_file) { 'path/does/not/exist/foo.json' }
+    let(:foo_file_content) { '{}' }
+    let(:set_options) { {} }
+
+    before(:each) do
+      mock_file(root_file, root_file_content)
+      mock_file(foo_file, foo_file_content)
+      allow(PDK::Util::Filesystem).to receive(:mkdir_p).with(anything)
+    end
+
+    shared_examples 'a round-tripped setting' do
+      it 'round-trips the setting value' do
+        # First make sure the setting doesn't exist
+        expect(config.get(*setting)).to eq(nil)
+        # Set the setting
+        expect(config.set(setting, value)).to eq(value)
+        # Get the new value
+        expect(config.get(*setting)).to eq(value)
+      end
+    end
+
+    shared_examples 'a new setting file' do |new_content|
+      it 'does not save to the root file' do
+        expect(PDK::Util::Filesystem).not_to receive(:write_file).with(PDK::Util::Filesystem.expand_path(root_file), anything)
+        config.set(setting, value, set_options)
+      end
+
+      it 'saves to the nested file' do
+        expect(PDK::Util::Filesystem).to receive(:write_file).with(PDK::Util::Filesystem.expand_path(foo_file), new_content)
+        config.set(setting, value, set_options)
+      end
+    end
+
+    it 'raises an error for invalid names' do
+      [nil, { 'a' => 'Hash' }, []].each do |testcase|
+        expect { config.set(testcase, value) }.to raise_error(ArgumentError)
+      end
+    end
+
+    it 'takes a String for the setting name' do
+      config.set('user.foo.whizz', value)
+      expect(config.user['foo']['whizz']).to eq(value)
+    end
+
+    it 'takes an Array for the setting name' do
+      config.set(%w[user foo whizz], value)
+      expect(config.user['foo']['whizz']).to eq(value)
+    end
+
+    context 'given a root name that does not exist' do
+      let(:names) { %w[missing analytics disabled] }
+
+      it 'raises an error' do
+        expect { config.set(names, value) }.to raise_error(ArgumentError)
+      end
+    end
+
+    it 'raises an error when setting a value to a namespace mount' do
+      expect { config.set(%w[user foo], value) }.to raise_error(ArgumentError)
+    end
+
+    context 'given a plain root setting' do
+      let(:setting) { %w[user setting] }
+
+      it_behaves_like 'a round-tripped setting'
+    end
+
+    context 'given a plain nested setting' do
+      let(:setting) { %w[user foo setting] }
+
+      it_behaves_like 'a round-tripped setting'
+    end
+
+    context 'given a hash root setting that doesn\'t already exist' do
+      let(:setting) { %w[user bar baz setting] }
+      let(:new_file_content) { "{\n  \"bar\": {\n    \"baz\": {\n      \"setting\": \"mock_value\"\n    }\n  }\n}" }
+
+      it_behaves_like 'a round-tripped setting'
+
+      it 'can be accessed via a normal hash syntax' do
+        config.set(setting, value)
+
+        expect(config.user['bar']['baz']['setting']).to eq(value)
+      end
+
+      it 'saves to the root file' do
+        expect(PDK::Util::Filesystem).to receive(:write_file).with(PDK::Util::Filesystem.expand_path(root_file), new_file_content)
+        config.set(setting, value)
+      end
+
+      it 'does not save to the nested file' do
+        expect(PDK::Util::Filesystem).not_to receive(:write_file).with(PDK::Util::Filesystem.expand_path(foo_file), anything)
+        config.set(setting, value)
+      end
+    end
+
+    context 'given a hash nested setting that doesn\'t already exist' do
+      let(:setting) { %w[user foo bar baz setting] }
+      let(:new_file_content) { "{\n  \"bar\": {\n    \"baz\": {\n      \"setting\": \"mock_value\"\n    }\n  }\n}" }
+
+      it_behaves_like 'a round-tripped setting'
+
+      it 'can be accessed via a normal hash syntax' do
+        config.set(setting, value)
+
+        expect(config.user['foo']['bar']).to eq('baz' => { 'setting' => value })
+        expect(config.user['foo']['bar']['baz']['setting']).to eq(value)
+      end
+
+      it_behaves_like 'a new setting file', "{\n  \"bar\": {\n    \"baz\": {\n      \"setting\": \"mock_value\"\n    }\n  }\n}"
+    end
+
+    context 'given a hash nested setting that already partially exists' do
+      let(:setting) { %w[user foo bar baz setting] }
+      let(:foo_file_content) { '{ "bar": { "existing_setting": "exists" }}' }
+
+      it 'can be accessed via a normal hash syntax' do
+        # The old setting should exist
+        expect(config.user['foo']['bar']).to eq('existing_setting' => 'exists')
+
+        config.set(setting, value)
+
+        # Should still contain the old setting
+        expect(config.user['foo']['bar']).to eq('baz' => { 'setting' => 'mock_value' }, 'existing_setting' => 'exists')
+        # Should contain the new setting
+        expect(config.user['foo']['bar']['baz']['setting']).to eq(value)
+      end
+
+      it_behaves_like 'a new setting file', "{\n  \"bar\": {\n    \"existing_setting\": \"exists\",\n    \"baz\": {\n      \"setting\": \"mock_value\"\n    }\n  }\n}"
+    end
+
+    context 'given a hash nested setting that already exists as an Array' do
+      let(:setting) { %w[user foo bar baz setting] }
+      let(:foo_file_content) { '{ "bar": [] }' }
+
+      context 'without forcing the change' do
+        it 'raises an error' do
+          # The old setting should exist
+          expect(config.user['foo']['bar']).to eq([])
+
+          expect { config.set(setting, value) }.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'when forcing the change' do
+        let(:set_options) { { force: true } }
+
+        it 'uses the new setting' do
+          # The old setting should exist
+          expect(config.user['foo']['bar']).to eq([])
+
+          config.set(setting, value, set_options)
+
+          # Should contain only new setting
+          expect(config.user['foo']['bar']['baz']['setting']).to eq(value)
+        end
+
+        it_behaves_like 'a new setting file', "{\n  \"bar\": {\n    \"baz\": {\n      \"setting\": \"mock_value\"\n    }\n  }\n}"
+      end
+    end
+
+    context 'given a setting that already exists as an non-empty Array' do
+      let(:setting) { %w[user foo bar] }
+      let(:foo_file_content) { '{ "bar": ["abc", "def"] }' }
+
+      context 'without forcing the change' do
+        it 'appends the new value' do
+          config.set(setting, value, set_options)
+          expect(config.user['foo']['bar']).to eq(['abc', 'def', value])
+        end
+
+        it_behaves_like 'a new setting file', "{\n  \"bar\": [\n    \"abc\",\n    \"def\",\n    \"mock_value\"\n  ]\n}"
+      end
+
+      context 'forcing the change' do
+        let(:set_options) { { force: true } }
+
+        it 'uses the new value' do
+          config.set(setting, value, set_options)
+          expect(config.user['foo']['bar']).to eq(value)
+        end
+
+        it_behaves_like 'a new setting file', "{\n  \"bar\": \"mock_value\"\n}"
+      end
+    end
+
+    context 'given a setting that already has the value in the Array' do
+      let(:setting) { %w[user foo bar] }
+      let(:foo_file_content) { "{ \"bar\": [\"abc\", \"#{value}\"] }" }
+
+      context 'without forcing the change' do
+        it 'does not append the new value' do
+          expect(PDK::Util::Filesystem).not_to receive(:write_file).with(PDK::Util::Filesystem.expand_path(foo_file), anything)
+          config.set(setting, value, set_options)
+          expect(config.user['foo']['bar']).to eq(['abc', value])
+        end
+      end
+
+      context 'forcing the change' do
+        let(:set_options) { { force: true } }
+
+        it 'uses the new value' do
+          config.set(setting, value, set_options)
+          expect(config.user['foo']['bar']).to eq(value)
+        end
+
+        it_behaves_like 'a new setting file', "{\n  \"bar\": \"mock_value\"\n}"
+      end
     end
   end
 

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -224,24 +224,24 @@ describe PDK::Generate::Module do
         end
 
         it 'takes precedence over the template-url answer' do
-          PDK.config.user['module_defaults']['template-url'] = 'answer-template'
+          PDK.config.set(%w[user module_defaults template-url], 'answer-template')
           expect(PDK::Module::TemplateDir).to receive(:with).with(Addressable::URI.parse('cli-template#master'), anything, anything).and_yield(test_template_dir)
           described_class.invoke(invoke_opts.merge(:'template-url' => 'cli-template'))
         end
 
         it 'saves the template-url and template-ref to the answer file if it is not the default template' do
           described_class.invoke(invoke_opts.merge(:'template-url' => 'cli-template'))
-          expect(PDK.config.user['module_defaults']['template-url']).to eq(Addressable::URI.parse('cli-template#master').to_s)
+          expect(PDK.config.get(%w[user module_defaults template-url])).to eq(Addressable::URI.parse('cli-template#master').to_s)
         end
 
         it 'saves the template-url and template-ref to the answer file if it is not the default ref' do
           described_class.invoke(invoke_opts.merge(:'template-url' => default_template_url, :'template-ref' => '1.2.3'))
-          expect(PDK.config.user['module_defaults']['template-url']).to eq("#{default_template_url}#1.2.3")
+          expect(PDK.config.get(%w[user module_defaults template-url])).to eq("#{default_template_url}#1.2.3")
         end
 
         it 'clears the saved template-url answer if it is the default template' do
           described_class.invoke(invoke_opts.merge(:'template-url' => default_template_url))
-          expect(PDK.config.user['module_defaults']['template-url']).to eq(nil)
+          expect(PDK.config.get(%w[user module_defaults template-url])).to eq(nil)
         end
       end
 
@@ -253,7 +253,7 @@ describe PDK::Generate::Module do
 
         context 'and a template-url answer exists' do
           it 'uses the template-url from the answer file to generate the module' do
-            PDK.config.user['module_defaults']['template-url'] = 'answer-template'
+            PDK.config.set(%w[user module_defaults template-url], 'answer-template')
             expect(PDK::Module::TemplateDir).to receive(:with).with(Addressable::URI.parse('answer-template'), anything, anything).and_yield(test_template_dir)
             expect(logger).to receive(:info).with(a_string_matching(%r{generated at path}i))
             expect(logger).to receive(:info).with(a_string_matching(%r{In your module directory, add classes with the 'pdk new class' command}i))
@@ -272,10 +272,10 @@ describe PDK::Generate::Module do
             it 'uses the vendored template url' do
               template_uri = "file:///tmp/package/cache/pdk-templates.git##{PDK::Util::TemplateURI.default_template_ref}"
               expect(PDK::Module::TemplateDir).to receive(:with).with(Addressable::URI.parse(template_uri), anything, anything).and_yield(test_template_dir)
-              before = PDK.config.user['module_defaults']['template-url']
+              before = PDK.config.get(%w[user module_defaults template-url])
 
               described_class.invoke(invoke_opts)
-              expect(PDK.config.user['module_defaults']['template-url']).to eq(before)
+              expect(PDK.config.get(%w[user module_defaults template-url])).to eq(before)
             end
           end
 
@@ -286,10 +286,10 @@ describe PDK::Generate::Module do
 
             it 'uses the default template to generate the module' do
               expect(PDK::Module::TemplateDir).to receive(:with).with(any_args).and_yield(test_template_dir)
-              before = PDK.config.user['module_defaults']['template-url']
+              before = PDK.config.get(%w[user module_defaults template-url])
 
               described_class.invoke(invoke_opts)
-              expect(PDK.config.user['module_defaults']['template-url']).to eq(before)
+              expect(PDK.config.get(%w[user module_defaults template-url])).to eq(before)
             end
           end
         end
@@ -307,7 +307,7 @@ describe PDK::Generate::Module do
 
     subject(:answers) do
       interview_metadata
-      PDK.config.user['module_defaults']
+      PDK.config.get(%w[user module_defaults])
     end
 
     let(:module_name) { 'bar' }
@@ -723,9 +723,9 @@ describe PDK::Generate::Module do
       before(:each) do
         allow(described_class).to receive(:module_interview).with(any_args)
 
-        PDK.config.user['module_defaults']['forge_username'] = 'testuser123'
-        PDK.config.user['module_defaults']['license'] = 'MIT'
-        PDK.config.user['module_defaults']['author'] = 'Test User'
+        PDK.config.set(%w[user module_defaults forge_username], 'testuser123')
+        PDK.config.set(%w[user module_defaults license], 'MIT')
+        PDK.config.set(%w[user module_defaults author], 'Test User')
       end
 
       it 'uses the saved forge_username answer' do

--- a/spec/unit/pdk/util/template_uri_spec.rb
+++ b/spec/unit/pdk/util/template_uri_spec.rb
@@ -10,7 +10,7 @@ describe PDK::Util::TemplateURI do
   include_context 'mock configuration'
 
   before(:each) do
-    PDK.config.user['module_defaults']['template-url'] = nil
+    PDK.config.set(%w[user module_defaults template-url], nil)
     allow(PDK::Util).to receive(:module_root).and_return(nil)
     allow(PDK::Util).to receive(:package_install?).and_return(false)
   end
@@ -116,7 +116,7 @@ describe PDK::Util::TemplateURI do
 
         context 'and there are only answers' do
           before :each do
-            PDK.config.user['module_defaults']['template-url'] = 'answer-templates'
+            PDK.config.set(%w[user module_defaults template-url], 'answer-templates')
             allow(PDK::Util::Filesystem).to receive(:file?).with(File.join(module_root, 'metadata.json')).and_return(false)
           end
 
@@ -138,7 +138,7 @@ describe PDK::Util::TemplateURI do
 
         context 'and there are metadata and answers' do
           before :each do
-            PDK.config.user['module_defaults']['template-url'] = 'answer-templates'
+            PDK.config.set(%w[user module_defaults template-url], 'answer-templates')
           end
 
           it 'returns the metadata template' do
@@ -152,7 +152,7 @@ describe PDK::Util::TemplateURI do
 
       context 'when there are metadata and answers' do
         before :each do
-          PDK.config.user['module_defaults']['template-url'] = 'answer-templates'
+          PDK.config.set(%w[user module_defaults template-url], 'answer-templates')
           allow(PDK::Util::Filesystem).to receive(:file?).with(File.join(PDK::Util.module_root, 'metadata.json')).and_return(true)
           allow(PDK::Module::Metadata).to receive(:from_file).with(File.join(PDK::Util.module_root, 'metadata.json')).and_return(mock_metadata)
         end
@@ -445,7 +445,7 @@ describe PDK::Util::TemplateURI do
 
     context 'when the answers file has saved template-url value' do
       before(:each) do
-        PDK.config.user['module_defaults']['template-url'] = answers_template_url
+        PDK.config.set(%w[user module_defaults template-url], answers_template_url)
       end
 
       context 'that is the deprecated pdk-module-template' do
@@ -475,7 +475,7 @@ describe PDK::Util::TemplateURI do
 
     context 'when the answers file has no saved template-url value' do
       before(:each) do
-        PDK.config.user['module_defaults']['template-url'] = nil
+        PDK.config.set(%w[user module_defaults template-url], nil)
       end
 
       it 'does not include a PDK answers template option' do


### PR DESCRIPTION
Previously the PDK::Config class could only read (get) values, it could not set
them easily, and lacked logic to deal with different value types, for example
if you set a deep hash value, then the save data method on the namespace was
not triggered.

This commit:

* Adds a PDK::Config.set method which takes into account nested namespaces,
  setting deep hashes, creates missing hash structures, and can add to, or
  explicitly set array, values.  All of this is necessary for the CLI component

* Adds tests for the different scenarios

---

Now that the PDK::Config class now has a set method, we can add a `set config`
CLI command so users can set configuration values.  Later commits will add the
`remove config` CLI command.

This commit:
* Adds the basic `pdk set config` command
* Adds type conversion using the `--type` parameter
* Adds tests for the CLI command

---

Previously many calls within the PDK used `.user` directly.  However now that
there is a formal get and set method, accessing these directly is no longer
required and is a private API.  This commit updates any references to these
private methods and changes them to use .get and .set appropriately.

---

TODO
- [x] Add PDK::Config.set
- [x] Add `pdk set config` command
- [x] Add tests (unit/acceptance)
- [x] Replace any internal PDK calls that set config to use the new set method e.g. `PDK.config.user['foo']['bar'] = 'baz'` to `PDK.config.set('foo.bar', 'baz')`