### PR TITLE
(FIXUP) Make system config path absolute instead of relative on POSIX hosts

### DIFF
--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -148,7 +148,7 @@ module PDK
 
     def system_configdir
       return @system_configdir unless @system_configdir.nil?
-      return @system_configdir = File.join('opt', 'puppetlabs', 'pdk', 'config') unless Gem.win_platform?
+      return @system_configdir = File.join(File::SEPARATOR, 'opt', 'puppetlabs', 'pdk', 'config') unless Gem.win_platform?
 
       return @system_configdir = File.join(PDK::Util::Env['ProgramData'], 'PuppetLabs', 'PDK') unless PDK::Util::Env['ProgramData'].nil?
       @system_configdir = File.join(PDK::Util::Env['AllUsersProfile'], 'PuppetLabs', 'PDK')

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -349,7 +349,7 @@ describe PDK::Util do
       end
 
       it 'returns a path inside the system opt directory' do
-        is_expected.to eq(File.join('opt', 'puppetlabs', 'pdk', 'config'))
+        is_expected.to match(%r{\A/opt/})
       end
     end
   end


### PR DESCRIPTION
Pretty much what it says on the tin.