### PR TITLE
(MAINT) Bump package-testing nokogiri to ~> 1.10.8

### DIFF
--- a/package-testing/Gemfile
+++ b/package-testing/Gemfile
@@ -16,7 +16,8 @@ gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] ||
 gem 'beaker-puppet', '= 1.18.5'
 gem 'beaker-rspec', '= 6.2.4'
 gem 'beaker-vmpooler', '= 1.3.3'
-gem 'nokogiri', '= 1.10.4'
+gem 'i18n', '= 1.4.0' # pin for Ruby 2.1 support
+gem 'nokogiri', '~> 1.10.8'
 gem 'rake', '= 12.3.2'
 
 # net-ping has a implicit dependency on win32-security


### PR DESCRIPTION
Does anyone remember if we were still pinning this for a reason? The last commit to touch that line was removing pinning inside the `update_module_spec` test.