### PR TITLE
(PDK-1632) Only show validators that are available in the given PDK Context

### DIFF
--- a/lib/pdk/validate.rb
+++ b/lib/pdk/validate.rb
@@ -60,6 +60,7 @@ module PDK
     def self.invoke_validators_by_name(context, names, parallel = false, options = {})
       instances = names.select { |name| validator_names.include?(name) }
                        .map { |name| validator_hash[name].new(context, options) }
+                       .select { |instance| instance.valid_in_context? }
                        .each { |instance| instance.prepare_invoke! }
       report = PDK::Report.new
 

--- a/lib/pdk/validate/invokable_validator.rb
+++ b/lib/pdk/validate/invokable_validator.rb
@@ -19,9 +19,8 @@ module PDK
         :once
       end
 
-      # Whether this Validator can be invoked in this context. By default any Validator can work in any Context, except ::None
-      # @return [Boolean]
-      # @abstract
+      # Whether this Validator can be invoked in this context. By default any InvokableValidator can work in any Context, except ::None
+      # @see PDK::Validate::Validator
       def valid_in_context?
         !context.is_a?(PDK::Context::None)
       end

--- a/lib/pdk/validate/validator.rb
+++ b/lib/pdk/validate/validator.rb
@@ -40,6 +40,13 @@ module PDK
         @prepared = false
       end
 
+      # Whether this Validator can be invoked in this context. By default any Validator can work in any Context
+      # @return [Boolean]
+      # @abstract
+      def valid_in_context?
+        true
+      end
+
       # Returns the text used for the spinner to display to the user while invoking
       #
       # @return [String]

--- a/lib/pdk/validate/validator_group.rb
+++ b/lib/pdk/validate/validator_group.rb
@@ -97,6 +97,7 @@ module PDK
       # @api private
       def validator_instances
         @validator_instances ||= validators.map { |klass| klass.new(context, options.merge(parent_validator: self)) }
+                                           .select { |instance| instance.valid_in_context? }
       end
     end
   end

--- a/spec/support/validators.rb
+++ b/spec/support/validators.rb
@@ -18,6 +18,21 @@ class MockSuccessValidator < PDK::Validate::Validator
   end
 end
 
+# A mock validator which is not valid in any context
+class MockNoContextValidator < PDK::Validate::Validator
+  def name
+    'mocknocontext'
+  end
+
+  def valid_in_context?
+    false
+  end
+
+  def invoke(_report)
+    raise 'The MockNoContextValidator should never be invoked'
+  end
+end
+
 # A mock validator which has a single failure
 class MockFailedValidator < PDK::Validate::Validator
   def name

--- a/spec/unit/pdk/validate/validator_group_spec.rb
+++ b/spec/unit/pdk/validate/validator_group_spec.rb
@@ -124,7 +124,13 @@ describe PDK::Validate::ValidatorGroup do
 
   describe '.validator_instances' do
     before(:each) do
-      allow(validator_group).to receive(:validators).and_return([MockSuccessValidator, PDK::Validate::Validator])
+      allow(validator_group).to receive(:validators).and_return(
+        [
+          MockSuccessValidator,
+          PDK::Validate::Validator,
+          MockNoContextValidator,
+        ],
+      )
     end
 
     it 'returns instances of the classes in validators' do
@@ -144,6 +150,12 @@ describe PDK::Validate::ValidatorGroup do
       object_ids = validator_group.validator_instances.map(&:object_id)
       # Compare the object_ids on the second call
       expect(validator_group.validator_instances.map(&:object_id)).to eq(object_ids)
+    end
+
+    it 'only returns validators which are allowed in the PDK context' do
+      validator_group.validator_instances.each do |item|
+        expect(item).not_to be_a(MockNoContextValidator)
+      end
     end
   end
 end

--- a/spec/unit/pdk/validate/validator_spec.rb
+++ b/spec/unit/pdk/validate/validator_spec.rb
@@ -37,6 +37,10 @@ describe PDK::Validate::Validator do
     end
   end
 
+  it 'has a valid_in_context? as a boolean' do
+    expect(validator.valid_in_context?).to be(true).or be(false)
+  end
+
   it 'has a spinner_text of nil' do
     expect(validator.spinner_text).to be_nil
   end

--- a/spec/unit/pdk/validate_spec.rb
+++ b/spec/unit/pdk/validate_spec.rb
@@ -54,8 +54,9 @@ describe PDK::Validate do
     let(:validation_options) { {} }
     let(:mock_hash) do
       {
-        'mocksuccess' => MockSuccessValidator,
-        'mockfailed'  => MockFailedValidator,
+        'mocksuccess'   => MockSuccessValidator,
+        'mockfailed'    => MockFailedValidator,
+        'mocknocontext' => MockNoContextValidator,
       }
     end
 
@@ -95,6 +96,14 @@ describe PDK::Validate do
 
     context 'with only unknown validations' do
       let(:validators_to_run) { %w[unknown whodis] }
+
+      it_behaves_like 'a successful result', 0
+    end
+
+    context 'with only invalid in context validations' do
+      # The MockNoContextValidator will raise an error it is invoked. However, because
+      # it should be filtered out, it should never be invoked and therefore never raise.
+      let(:validators_to_run) { %w[mocknocontext] }
 
       it_behaves_like 'a successful result', 0
     end


### PR DESCRIPTION
Previously when a validator was created which was not valid in the PDK Context,
for example environment.conf validation in a Puppet Module, the validator would
not be invoked but a message would be logged saying that the validator had no
targets.  This is slightly confusing for users.

This commit changes the behaviour so that validators which are not valid in the
current PDK Context (Validator.is_valid_context?) are never run or have any
targets parsed.

This commit also updates the tests for these scenarios.