### PR TITLE
(PDK-1109) Add pdk remove config

### DIFF
--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -165,6 +165,7 @@ module PDK::CLI
   require 'pdk/cli/module'
   require 'pdk/cli/console'
   require 'pdk/cli/release'
+  require 'pdk/cli/remove'
 
   @base_cmd.add_command Cri::Command.new_basic_help
 end

--- a/lib/pdk/cli/remove.rb
+++ b/lib/pdk/cli/remove.rb
@@ -1,0 +1,20 @@
+module PDK::CLI
+  @remove_cmd = @base_cmd.define_command do
+    name 'remove'
+    usage _('remove [subcommand] [options]')
+    summary _('Remove or delete information about the PDK or current project.')
+    default_subcommand 'help'
+
+    run do |_opts, args, _cmd|
+      if args == ['help']
+        PDK::CLI.run(%w[remove --help])
+        exit 0
+      end
+
+      PDK::CLI.run(%w[remove help]) if args.empty?
+    end
+  end
+  @remove_cmd.add_command Cri::Command.new_basic_help
+end
+
+require 'pdk/cli/remove/config'

--- a/lib/pdk/cli/remove/config.rb
+++ b/lib/pdk/cli/remove/config.rb
@@ -1,0 +1,80 @@
+module PDK::CLI
+  module Remove
+    module Config
+      def self.run(opts, args)
+        item_name = (args.count > 0) ? args[0] : nil
+        item_value = (args.count > 1) ? args[1].strip : nil
+        item_value = nil if !item_value.nil? && item_value.empty?
+
+        force = opts[:force] || false
+
+        raise PDK::CLI::ExitWithError, _('Configuration name is required') if item_name.nil?
+
+        current_value = PDK.config.get(item_name)
+        raise PDK::CLI::ExitWithError, _("The configuration item '%{name}' can not be removed.") % { name: item_name } if current_value.is_a?(PDK::Config::Namespace)
+        if current_value.nil?
+          PDK.logger.info(_("Could not remove '%{name}' as it has not been set") % { name: item_name })
+          return 0
+        end
+
+        PDK.logger.info(_("Ignoring the item value '%{value}' as --force has been set") % { value: item_value }) if current_value.is_a?(Array) && !item_value.nil? && force
+        PDK.logger.info(_('Ignoring --force as the setting is not multi-valued')) if !current_value.is_a?(Array) && force
+
+        # FIXME: It'd be nice to shortcircuit deleting default values.  This causes the configuration file
+        # to be saved, even though nothing actually changes
+
+        # For most value types, just changing the value to nil is enough, however Arrays are a special case.
+        # Unless they're forced, array removal with either remove a single entry (matched by .to_s) or clear the
+        # array.  When forced, the array is completed removed just like a string or number.
+        if current_value.is_a?(Array) && !force
+          # If the user didn't set a value then set the array as empty, otherwise remove that one item
+          new_value = item_value.nil? ? [] : current_value.reject { |item| item.to_s == item_value }
+          if current_value.count == new_value.count
+            if item_value.nil?
+              PDK.logger.info(_("Could not remove '%{name}' as it is already empty") % { name: item_name })
+            else
+              PDK.logger.info(_("Could not remove '%{value}' from '%{name}' as it has not been set") % { value: item_value, name: item_name })
+            end
+            return 0
+          end
+          PDK.config.set(item_name, new_value, force: true)
+        else
+          # Set the value to nil for deleting.
+          PDK.config.set(item_name, nil, force: true)
+        end
+
+        # Output the result to the user
+        new_value = PDK.config.get(item_name)
+        if current_value.is_a?(Array) && !force
+          # Arrays have a special output format. If item_value is nil then the user wanted to empty/clear
+          # the array otherwise they just wanted to remove a single entry.
+          if item_value.nil?
+            PDK.logger.info(_("Cleared '%{name}' which had a value of '%{from}'") % { name: item_name, from: current_value })
+          else
+            PDK.logger.info(_("Removed '%{value}' from '%{name}'") % { value: item_value, name: item_name })
+          end
+        elsif !new_value.nil?
+          PDK.logger.info(_("Could not remove '%{name}' as it using a default value of '%{to}'") % { name: item_name, to: new_value })
+        else
+          PDK.logger.info(_("Removed '%{name}' which had a value of '%{from}'") % { name: item_name, from: current_value })
+        end
+
+        # Same output as `get config`
+        $stdout.puts _('%{name}=%{value}') % { name: item_name, value: new_value }
+        0
+      end
+    end
+  end
+
+  @remove_config_cmd = @remove_cmd.define_command do
+    name 'config'
+    usage _('config [name] [value]')
+    summary _('Remove or delete the configuration for <name>')
+
+    option :f, :force, _('Force multi-value configuration settings to be removed instead of emptied.'), argument: :forbidden
+
+    run do |opts, args, _cmd|
+      exit PDK::CLI::Remove::Config.run(opts, args)
+    end
+  end
+end

--- a/spec/acceptance/remove_config_spec.rb
+++ b/spec/acceptance/remove_config_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper_acceptance'
+require 'tempfile'
+
+describe 'pdk remove config' do
+  include_context 'with a fake TTY'
+
+  shared_examples 'a saved configuration file' do |new_content|
+    it 'saves the setting' do
+      # Force the command to run if not already
+      subject.exit_status # rubocop:disable RSpec/NamedSubject We don't actually know the name here
+      expect(File).to exist(ENV['PDK_ANSWER_FILE'])
+
+      actual_content = File.open(ENV['PDK_ANSWER_FILE'], 'rb:utf-8') { |f| f.read }
+      expect(actual_content).to eq(new_content)
+    end
+  end
+
+  shared_examples 'a saved JSON configuration file' do |new_json_content|
+    it 'saves the setting' do
+      # Force the command to run if not already
+      subject.exit_status # rubocop:disable RSpec/NamedSubject We don't actually know the name here
+      expect(File).to exist(ENV['PDK_ANSWER_FILE'])
+
+      actual_content_raw = File.open(ENV['PDK_ANSWER_FILE'], 'rb:utf-8') { |f| f.read }
+      actual_json_content = ::JSON.parse(actual_content_raw)
+      expect(actual_json_content).to eq(new_json_content)
+    end
+  end
+
+  RSpec.shared_context 'with a fake answer file' do |initial_content = nil|
+    before(:all) do
+      fake_answer_file = Tempfile.new('mock_answers.json')
+      unless initial_content.nil?
+        require 'json'
+        fake_answer_file.binmode
+        fake_answer_file.write(::JSON.pretty_generate(initial_content))
+      end
+      fake_answer_file.close
+      ENV['PDK_ANSWER_FILE'] = fake_answer_file.path
+    end
+
+    after(:all) do
+      File.delete(ENV['PDK_ANSWER_FILE']) if File.exist?(ENV['PDK_ANSWER_FILE']) # rubocop:disable PDK/FileDelete,PDK/FileExistPredicate Need actual file calls here
+      ENV.delete('PDK_ANSWER_FILE')
+    end
+  end
+
+  context 'when run outside of a module' do
+    describe command('pdk remove config') do
+      its(:exit_status) { is_expected.not_to eq 0 }
+      its(:stdout) { is_expected.to have_no_output }
+      its(:stderr) { is_expected.to match(%r{Configuration name is required}) }
+    end
+
+    context 'with a setting that does not exist' do
+      describe command('pdk remove config user.module_defaults.mock value') do
+        include_context 'with a fake answer file'
+
+        its(:exit_status) { is_expected.to eq 0 }
+        its(:stdout) { is_expected.to have_no_output }
+        its(:stderr) { is_expected.to match(%r{Could not remove 'user\.module_defaults\.mock' as it has not been set}) }
+      end
+    end
+
+    context 'with an existing array setting, not forced' do
+      describe command('pdk remove config user.module_defaults.mock value') do
+        include_context 'with a fake answer file', 'mock' => ['value', 'keep-value']
+
+        its(:exit_status) { is_expected.to eq 0 }
+        its(:stdout) { is_expected.to match(%r{user.module_defaults.mock=\["keep-value"\]}) }
+        its(:stderr) { is_expected.to match(%r{Removed 'value' from 'user\.module_defaults\.mock'}) }
+
+        it_behaves_like 'a saved JSON configuration file', 'mock' => ['keep-value']
+      end
+    end
+
+    context 'with an existing array setting, forced' do
+      describe command('pdk remove config user.module_defaults.mock --force') do
+        include_context 'with a fake answer file', 'mock' => ['value', 'keep-value']
+
+        its(:exit_status) { is_expected.to eq 0 }
+        its(:stdout) { is_expected.to match(%r{user.module_defaults.mock=$}) }
+        its(:stderr) { is_expected.to match(%r{Removed 'user\.module_defaults\.mock' which had a value of '\["value", "keep-value"\]}) }
+
+        it_behaves_like 'a saved JSON configuration file', {}
+      end
+    end
+
+    context 'with an existing non-array setting, not forced' do
+      describe command('pdk remove config user.module_defaults.mock value') do
+        include_context 'with a fake answer file', 'mock' => 1
+
+        its(:exit_status) { is_expected.to eq 0 }
+        its(:stdout) { is_expected.to match(%r{user.module_defaults.mock=$}) }
+        its(:stderr) { is_expected.to match(%r{Removed 'user\.module_defaults\.mock' which had a value of '1'}) }
+
+        it_behaves_like 'a saved JSON configuration file', {}
+      end
+    end
+
+    context 'with an existing setting, forced' do
+      describe command('pdk remove config --force user.module_defaults.mock value') do
+        include_context 'with a fake answer file', 'mock' => 'value'
+
+        its(:exit_status) { is_expected.to eq 0 }
+        its(:stdout) { is_expected.to match(%r{user.module_defaults.mock=$}) }
+        its(:stderr) { is_expected.to match(%r{Ignoring --force as the setting is not multi-valued}) }
+        its(:stderr) { is_expected.to match(%r{Removed 'user\.module_defaults\.mock' which had a value of 'value'}) }
+
+        it_behaves_like 'a saved JSON configuration file', {}
+      end
+    end
+  end
+end

--- a/spec/acceptance/remove_spec.rb
+++ b/spec/acceptance/remove_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper_acceptance'
+require 'fileutils'
+
+describe 'pdk set' do
+  include_context 'with a fake TTY'
+
+  context 'when run outside of a module' do
+    describe command('pdk set') do
+      its(:exit_status) { is_expected.to eq 0 }
+      # Should show the command help
+      its(:stdout) { is_expected.to match(%r{pdk set \[subcommand\] \[options\]}) }
+      its(:stderr) { is_expected.to have_no_output }
+    end
+  end
+end

--- a/spec/unit/pdk/cli/remove/config_spec.rb
+++ b/spec/unit/pdk/cli/remove/config_spec.rb
@@ -1,0 +1,261 @@
+require 'spec_helper'
+require 'pdk/cli'
+
+describe 'PDK::CLI::Remove::Config' do
+  describe '#run' do
+    subject(:run) { PDK::CLI::Remove::Config.run(cli_opts, cli_args) }
+
+    let(:force_opt) { nil }
+    let(:cli_opts) do
+      {
+        force: force_opt,
+      }
+    end
+    let(:setting_name) { nil }
+    let(:setting_value) { nil }
+    let(:cli_args) { [setting_name, setting_value].compact }
+
+    let(:pdk_config) { MockRemoveConfig.new }
+
+    SETTING_ARRAY_NONDEFAULT = 'user.array_nondefault'.freeze
+    SETTING_ARRAY_DEFAULT = 'user.array_default'.freeze
+    SETTING_NUMBER_NONDEFAULT = 'user.number_nondefault'.freeze
+    SETTING_NUMBER_DEFAULT = 'user.number_default'.freeze
+    SETTING_STRING_NONDEFAULT = 'user.string_nondefault'.freeze
+    SETTING_STRING_DEFAULT = 'user.string_default'.freeze
+    SETTING_HASH_NONDEFAULT = 'user.hash_nondefault'.freeze
+    SETTING_HASH_DEFAULT = 'user.hash_default'.freeze
+    SETTING_DEEPHASH_DEFAULT = 'user.hash_default.default.foo'.freeze
+    VALUE_ARRAY_DEFAULT = ['1', '2', '3', 1, 2, 3].freeze
+    VALUE_NUMBER_DEFAULT = 3
+    VALUE_STRING_DEFAULT = 'default'.freeze
+    VALUE_HASH_DEFAULT = { 'default' => { 'foo' => { 'bar' => 'baz' } } }.freeze
+
+    # Note, this class name needs to be unqiue in the ENTIRE rspec suite!
+    class MockRemoveConfig < PDK::Config
+      def user_config
+        @user_config ||= PDK::Config::Namespace.new('user') do
+          setting 'array_default' do
+            default_to do
+              VALUE_ARRAY_DEFAULT
+            end
+          end
+
+          setting 'string_default' do
+            default_to do
+              VALUE_STRING_DEFAULT
+            end
+          end
+
+          setting 'number_default' do
+            default_to do
+              VALUE_NUMBER_DEFAULT
+            end
+          end
+
+          setting 'hash_default' do
+            default_to do
+              VALUE_HASH_DEFAULT
+            end
+          end
+        end
+      end
+
+      def system_config
+        @system_config ||= PDK::Config::Namespace.new('system') { ; }
+      end
+
+      def project_config
+        @project_config ||= PDK::Config::Namespace.new('project') { ; }
+      end
+    end
+
+    before(:each) do
+      allow(PDK).to receive(:config).and_return(pdk_config)
+      allow($stdout).to receive(:puts)
+
+      pdk_config.set(SETTING_STRING_NONDEFAULT, 'non-default', force: true)
+      pdk_config.set(SETTING_NUMBER_NONDEFAULT, -1000, force: true)
+      pdk_config.set(SETTING_ARRAY_NONDEFAULT, ['non-default', -6000], force: true)
+      pdk_config.set(SETTING_HASH_NONDEFAULT, { 'non-default' => { 'bar' => 'baz' } }, force: true)
+    end
+
+    RSpec.shared_examples 'a missing name error' do
+      it 'raises with missing name' do
+        expect { run }.to raise_error(PDK::CLI::ExitWithError, %r{name is required})
+      end
+    end
+
+    RSpec.shared_examples 'an un-removable setting error' do
+      it 'raises with can not be removed' do
+        expect { run }.to raise_error(PDK::CLI::ExitWithError, %r{can not be removed})
+      end
+    end
+
+    RSpec.shared_examples 'a removed setting' do |setting_under_test, expected_value, log_msg_regex|
+      let(:setting_name) { setting_under_test }
+
+      it 'removes the setting' do
+        # Ensure that the value is different than what we want to set it to
+        expect(pdk_config.get(setting_name)).not_to eq(expected_value)
+        # Ensure that the config.set method is actually called for the setting we are changing
+        expect(pdk_config).to receive(:set).with(setting_name, anything, force: true).and_call_original
+        # This is default log message regex, typically for strings and numbers.  Arrays
+        # are complex so the actual test can set the required regex
+        log_msg_regex = %r{Removed .+ which had a value of} if log_msg_regex.nil?
+        expect(PDK.logger).to receive(:info).with(log_msg_regex)
+
+        expect(run).to eq(0)
+        expect(pdk_config.get(setting_name)).to eq(expected_value)
+      end
+    end
+
+    RSpec.shared_examples 'a removed setting with a default' do |setting_under_test, initial_value, expected_default_value|
+      let(:setting_name) { setting_under_test }
+
+      before(:each) do
+        pdk_config.set(setting_name, initial_value)
+      end
+
+      it 'resets back to default' do
+        # Ensure that the config.set method is actually called for the setting we are changing
+        expect(pdk_config).to receive(:set).with(setting_name, anything, force: true).and_call_original
+        # Ensure that a log message occurs to state that this is now using the default value
+        expect(PDK.logger).to receive(:info).with(%r{as it using a default value of})
+        # Ensure that the value is different than what we want to set it to
+        expect(pdk_config.get(setting_name)).not_to eq(expected_default_value)
+        expect(run).to eq(0)
+        expect(pdk_config.get(setting_name)).to eq(expected_default_value)
+      end
+    end
+
+    RSpec.shared_examples 'a setting which cannot be forced' do |setting_under_test|
+      let(:setting_name) { setting_under_test }
+      let(:force_opt) { true }
+
+      it 'logs a message that --force is ignored' do
+        expect(PDK.logger).to receive(:info).with(%r{Ignoring --force as the})
+        run
+      end
+    end
+
+    context 'with no arguments or flags' do
+      include_examples 'a missing name error'
+    end
+
+    context 'with a setting name that is a root namespace' do
+      let(:setting_name) { 'user' }
+
+      include_examples 'an un-removable setting error'
+    end
+
+    context 'when removing a string type setting' do
+      it_behaves_like 'a removed setting', SETTING_STRING_NONDEFAULT, nil
+      it_behaves_like 'a removed setting with a default', SETTING_STRING_DEFAULT, 'koala', VALUE_STRING_DEFAULT
+      it_behaves_like 'a setting which cannot be forced', SETTING_STRING_DEFAULT
+    end
+
+    context 'when removing a number type setting' do
+      it_behaves_like 'a removed setting', SETTING_NUMBER_NONDEFAULT, nil
+      it_behaves_like 'a removed setting with a default', SETTING_NUMBER_DEFAULT, -6000, VALUE_NUMBER_DEFAULT
+      it_behaves_like 'a setting which cannot be forced', SETTING_NUMBER_NONDEFAULT
+    end
+
+    context 'when removing a hash type setting' do
+      it_behaves_like 'a removed setting', SETTING_HASH_NONDEFAULT, nil
+      it_behaves_like 'a removed setting with a default', SETTING_HASH_DEFAULT, { 'something' => 'value' }, VALUE_HASH_DEFAULT
+      it_behaves_like 'a setting which cannot be forced', SETTING_HASH_NONDEFAULT
+    end
+
+    context 'when removing a deep hash type setting' do
+      let(:setting_name) { SETTING_DEEPHASH_DEFAULT }
+
+      it_behaves_like 'a removed setting', SETTING_DEEPHASH_DEFAULT, nil
+
+      it 'only removes the the setting and and any child values' do
+        expected_value = { 'default' => { 'foo' => nil } }
+        expect(pdk_config.get(SETTING_HASH_DEFAULT)).not_to eq(expected_value)
+        run
+        expect(pdk_config.get(SETTING_HASH_DEFAULT)).to eq(expected_value)
+      end
+    end
+
+    context 'when removing an array type setting' do
+      context 'without --force' do
+        context 'without an item value' do
+          it_behaves_like 'a removed setting', SETTING_ARRAY_NONDEFAULT, [], %r{Cleared .+ which had a value of}
+          # An empty array does not use the default value, only an undefined (or nil)
+          # setting will trigger the default
+          context 'which has a default value' do
+            include_examples 'a removed setting', SETTING_ARRAY_DEFAULT, [], %r{Cleared .+ which had a value of}
+          end
+        end
+
+        context 'with an item value which removes the last array item' do
+          let(:setting_value) { 'quokka' }
+
+          before(:each) do
+            pdk_config.set(setting_name, ['quokka'], force: true)
+          end
+
+          it_behaves_like 'a removed setting', SETTING_ARRAY_NONDEFAULT, [], %r{Removed .+ from .+}
+          # An empty array does not use the default value, only an undefined (or nil)
+          # setting will trigger the default
+          context 'which has a default value' do
+            include_examples 'a removed setting', SETTING_ARRAY_DEFAULT, [], %r{Removed .+ from .+}
+          end
+        end
+
+        context 'with an item value which removes the second last array item' do
+          let(:setting_value) { 'quokka' }
+
+          before(:each) do
+            pdk_config.set(setting_name, %w[quokka kangaroo], force: true)
+          end
+
+          it_behaves_like 'a removed setting', SETTING_ARRAY_NONDEFAULT, ['kangaroo'], %r{Removed .+ from .+}
+          # An empty array does not use the default value, only an undefined (or nil)
+          # setting will trigger the default
+          context 'which has a default value' do
+            include_examples 'a removed setting', SETTING_ARRAY_DEFAULT, ['kangaroo'], %r{Removed .+ from .+}
+          end
+        end
+      end
+
+      context 'with --force' do
+        let(:force_opt) { true }
+
+        context 'without an item value' do
+          it_behaves_like 'a removed setting', SETTING_ARRAY_NONDEFAULT, nil
+          it_behaves_like 'a removed setting with a default', SETTING_ARRAY_DEFAULT, ['koala'], VALUE_ARRAY_DEFAULT
+        end
+
+        context 'with an item value which removes the last array item' do
+          # Using a setting_value with --force doesn't make much sense, so
+          # the setting_value is just ignored.
+          let(:setting_value) { 'quokka' }
+
+          before(:each) do
+            pdk_config.set(setting_name, ['quokka'], force: true)
+            expect(PDK.logger).to receive(:info).with(%r{Ignoring the item value .+ as --force has been set})
+          end
+
+          it_behaves_like 'a removed setting', SETTING_ARRAY_NONDEFAULT, nil
+          it_behaves_like 'a removed setting with a default', SETTING_ARRAY_DEFAULT, ['koala'], VALUE_ARRAY_DEFAULT
+        end
+
+        context 'with an item value which removes the second last array item' do
+          let(:setting_value) { 'quokka' }
+
+          before(:each) do
+            pdk_config.set(setting_name, %w[quokka kangaroo], force: true)
+            expect(PDK.logger).to receive(:info).with(%r{Ignoring the item value .+ as --force has been set})
+          end
+
+          it_behaves_like 'a removed setting', SETTING_ARRAY_NONDEFAULT, nil
+          it_behaves_like 'a removed setting with a default', SETTING_ARRAY_DEFAULT, ['koala'], VALUE_ARRAY_DEFAULT
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
~Blocked on https://github.com/puppetlabs/pdk-planning/pull/70~

---

Now that the PDK::Config class now has a set method, we can add a `remove config`
CLI command so users can remove configuration values.

This commit:
* Adds the basic `pdk remove config` command
* Adds tests for the CLI command