### PR TITLE
(#869) Ensure bundle update on convert/update

### DIFF
--- a/lib/pdk/module/convert.rb
+++ b/lib/pdk/module/convert.rb
@@ -53,18 +53,15 @@ module PDK
           return unless continue
         end
 
-        # Remove these files straight away as these changes are not something that the user needs to review.
-        if needs_bundle_update?
-          update_manager.unlink_file('Gemfile.lock')
-          update_manager.unlink_file(File.join('.bundle', 'config'))
-        end
+        # Remove these files straight away as these changes are not something
+        # that the user needs to review.
+        update_manager.unlink_file('Gemfile.lock')
+        update_manager.unlink_file(File.join('.bundle', 'config'))
 
         update_manager.sync_changes!
 
-        if needs_bundle_update?
-          require 'pdk/util/bundler'
-          PDK::Util::Bundler.ensure_bundle!
-        end
+        require 'pdk/util/bundler'
+        PDK::Util::Bundler.ensure_bundle!
 
         add_tests! if adding_tests?
 
@@ -108,10 +105,6 @@ module PDK
         test_generators.each do |gen|
           gen.run if gen.can_run?
         end
-      end
-
-      def needs_bundle_update?
-        update_manager.changed?('Gemfile')
       end
 
       def stage_changes!

--- a/lib/pdk/module/update.rb
+++ b/lib/pdk/module/update.rb
@@ -33,19 +33,15 @@ module PDK
           return unless PDK::CLI::Util.prompt_for_yes(message)
         end
 
-        # Remove these files straight away as these changes are not something that the user needs to review.
-        if needs_bundle_update?
-          update_manager.unlink_file('Gemfile.lock')
-          update_manager.unlink_file(File.join('.bundle', 'config'))
-        end
+        # Remove these files straight away as these changes are not something
+        # that the user needs to review.
+        update_manager.unlink_file('Gemfile.lock')
+        update_manager.unlink_file(File.join('.bundle', 'config'))
 
         update_manager.sync_changes!
 
-        if needs_bundle_update?
-          require 'pdk/util/bundler'
-
-          PDK::Util::Bundler.ensure_bundle!
-        end
+        require 'pdk/util/bundler'
+        PDK::Util::Bundler.ensure_bundle!
 
         print_result 'Update completed'
       end

--- a/spec/unit/pdk/module/convert_spec.rb
+++ b/spec/unit/pdk/module/convert_spec.rb
@@ -104,7 +104,10 @@ describe PDK::Module::Convert do
       allow(template_dir).to receive(:render).and_yield(template_files[:path], template_files[:content], template_files[:status])
       allow(update_manager).to receive(:changes).and_return(changes)
       allow(update_manager).to receive(:changed?).with('Gemfile').and_return(false)
+      allow(update_manager).to receive(:unlink_file).with('Gemfile.lock')
+      allow(update_manager).to receive(:unlink_file).with(File.join('.bundle', 'config'))
       allow(PDK::Util::Filesystem).to receive(:write_file).with('convert_report.txt', anything)
+      allow(PDK::Util::Bundler).to receive(:ensure_bundle!)
     end
 
     after(:each, after_hook: true) do
@@ -183,7 +186,6 @@ describe PDK::Module::Convert do
         allow(update_manager).to receive(:changed?).with('Gemfile').and_return(true)
         allow(update_manager).to receive(:remove_file).with(anything)
         allow(update_manager).to receive(:unlink_file).with(anything)
-        allow(PDK::Util::Bundler).to receive(:ensure_bundle!)
         allow($stdout).to receive(:puts).with(%r{You can find a report of differences in convert_report.txt.})
       end
 

--- a/spec/unit/pdk/module/update_spec.rb
+++ b/spec/unit/pdk/module/update_spec.rb
@@ -27,29 +27,6 @@ describe PDK::Module::Update do
     end
   end
 
-  shared_context 'requires bundle install' do
-    context 'if the Gemfile is updated' do
-      before(:each) do
-        allow(instance).to receive(:needs_bundle_update?).and_return(true)
-        allow(instance.update_manager).to receive(:remove_file)
-        allow(instance.update_manager).to receive(:unlink_file)
-        allow(PDK::Util::Bundler).to receive(:ensure_bundle!)
-      end
-
-      it 'removes the existing Gemfile.lock' do
-        expect(instance.update_manager).to receive(:unlink_file).with('Gemfile.lock')
-      end
-
-      it 'removes the bundler project config' do
-        expect(instance.update_manager).to receive(:unlink_file).with(File.join('.bundle', 'config'))
-      end
-
-      it 'triggers a bundle install' do
-        expect(PDK::Util::Bundler).to receive(:ensure_bundle!)
-      end
-    end
-  end
-
   describe '#pinned_to_puppetlabs_template_tag?' do
     subject { instance.pinned_to_puppetlabs_template_tag? }
 
@@ -173,6 +150,9 @@ describe PDK::Module::Update do
       allow(PDK::Util::Git).to receive(:tag?).with(String, String).and_return(true)
       allow(instance.update_manager).to receive(:sync_changes!)
       allow(instance.update_manager).to receive(:changes?).and_return(changes)
+      allow(instance.update_manager).to receive(:unlink_file).with('Gemfile.lock')
+      allow(instance.update_manager).to receive(:unlink_file).with(File.join('.bundle', 'config'))
+      allow(PDK::Util::Bundler).to receive(:ensure_bundle!)
     end
 
     after(:each) do
@@ -252,8 +232,6 @@ describe PDK::Module::Update do
         it 'syncs the pending changes' do
           expect(instance.update_manager).to receive(:sync_changes!)
         end
-
-        include_context 'requires bundle install'
       end
 
       context 'without force' do
@@ -273,8 +251,6 @@ describe PDK::Module::Update do
           it 'prints the result' do
             expect(instance).to receive(:print_result)
           end
-
-          include_context 'requires bundle install'
         end
 
         context 'if the user chooses not to continue' do


### PR DESCRIPTION
Change the upgrade & convert process so that it always ensures the bundle is up to date. Depending on detecting changes to `Gemfile` is not sufficient as it doesn't detect changes to unlisted dependencies.

Fixes #869 