### PR TITLE
(GH-874) Use PDK Context root for PDK Convert and Update

### DIFF
--- a/lib/pdk/cli/convert.rb
+++ b/lib/pdk/cli/convert.rb
@@ -14,14 +14,12 @@ module PDK::CLI
     flag nil, :'default-template', _('Convert the module to use the default PDK template.')
 
     run do |opts, _args, _cmd|
-      require 'pdk/module/convert'
-      require 'pdk/cli/util'
+      # Write the context information to the debug log
+      PDK.context.to_debug_log
 
-      PDK::CLI::Util.ensure_in_module!(
-        check_module_layout: true,
-        message:             _('`pdk convert` can only be run from inside a valid module directory.'),
-        log_level:           :info,
-      )
+      unless PDK.context.is_a?(PDK::Context::Module)
+        raise PDK::CLI::ExitWithError, _('`pdk convert` can only be run from inside a valid module directory.')
+      end
 
       if opts[:noop] && opts[:force]
         raise PDK::CLI::ExitWithError, _('You can not specify --noop and --force when converting a module')
@@ -48,7 +46,7 @@ module PDK::CLI
         opts[:'full-interview'] = false
       end
 
-      PDK::Module::Convert.invoke(PDK::Util.module_root, opts)
+      PDK::Module::Convert.invoke(PDK.context.root_path, opts)
     end
   end
 end

--- a/lib/pdk/cli/update.rb
+++ b/lib/pdk/cli/update.rb
@@ -10,14 +10,12 @@ module PDK::CLI
     PDK::CLI.template_ref_option(self)
 
     run do |opts, _args, _cmd|
-      require 'pdk/cli/util'
-      require 'pdk/util'
-      require 'pdk/module/update'
+      # Write the context information to the debug log
+      PDK.context.to_debug_log
 
-      PDK::CLI::Util.ensure_in_module!(
-        message:   _('`pdk update` can only be run from inside a valid module directory.'),
-        log_level: :info,
-      )
+      unless PDK.context.is_a?(PDK::Context::Module)
+        raise PDK::CLI::ExitWithError, _('`pdk update` can only be run from inside a valid module directory.')
+      end
 
       raise PDK::CLI::ExitWithError, _('This module does not appear to be PDK compatible. To make the module compatible with PDK, run `pdk convert`.') unless PDK::Util.module_pdk_compatible?
 
@@ -46,7 +44,7 @@ module PDK::CLI
 
       PDK::CLI::Util.analytics_screen_view('update', opts)
 
-      updater = PDK::Module::Update.new(PDK::Util.module_root, opts)
+      updater = PDK::Module::Update.new(PDK.context.root_path, opts)
 
       if updater.pinned_to_puppetlabs_template_tag?
         PDK.logger.info _(


### PR DESCRIPTION
Fixes #874 

Blocking until #872 is merged due to possible merge conflicts

Previously the pdk update and convert CLI commands had a strange failure mode
where if a "module" was nested inside another "module" but only the parent had
a metadata.json. When a user tried to update or convert the child module, the
files would be put in the parent.  This was due to the CLI using the lax
detection (in_module_root?) method to "find" the module, but use the strict
detection method (module_root) during the actual conversion.

This commit updates these CLI logic to use the new PDK.context object which
is far more consistent.  This commit also adds a test for these scenarios in
PDK update and convert.