### PR TITLE
(GH-828) Munge backslash in rake paths for unit tests

### DIFF
--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -89,6 +89,11 @@ module PDK
         setup
 
         tests = options[:tests]
+        # Due to how rake handles paths in the command line options, any backslashed path (Windows platforms) needs to be converted
+        # to forward slash. We can't use File.expand_path as the files aren't guaranteed to be on-disk
+        #
+        # Ref - https://github.com/puppetlabs/pdk/issues/828
+        tests.tr!('\\', '/') unless tests.nil?
 
         environment = { 'CI_SPEC_OPTIONS' => '--format j' }
         environment['PUPPET_GEM_VERSION'] = options[:puppet] if options[:puppet]

--- a/spec/unit/pdk/test/unit_spec.rb
+++ b/spec/unit/pdk/test/unit_spec.rb
@@ -465,6 +465,15 @@ describe PDK::Test::Unit do
         exit_code = described_class.invoke(report, tests: 'a_test_spec.rb')
         expect(exit_code).to eq(-1)
       end
+
+      context 'with Windows paths' do
+        it 'uses forward slashes to invoke rake' do
+          expect(described_class).to receive(:parse_output).once
+          expect(described_class).to receive(:rake).with(%r{path/a_test_spec.rb}, anything, anything).and_call_original
+          exit_code = described_class.invoke(report, tests: 'path\\a_test_spec.rb')
+          expect(exit_code).to eq(-1)
+        end
+      end
     end
   end
   # rubocop:enable RSpec/AnyInstance


### PR DESCRIPTION
Fixes #828

Rake doesn't accept backslash as a path separator in the rake command line and
expects ALL paths to use forward slash as the separator.  This commit updates
the PDK::Test::Unit class to munge Windows paths prior to invoking rake.