### PR TITLE
Don't attempt to modify a frozen string when parsing '--tests' paths

### DIFF
--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -93,7 +93,7 @@ module PDK
         # to forward slash. We can't use File.expand_path as the files aren't guaranteed to be on-disk
         #
         # Ref - https://github.com/puppetlabs/pdk/issues/828
-        tests.tr!('\\', '/') unless tests.nil?
+        tests = tests.tr('\\', '/') unless tests.nil?
 
         environment = { 'CI_SPEC_OPTIONS' => '--format j' }
         environment['PUPPET_GEM_VERSION'] = options[:puppet] if options[:puppet]


### PR DESCRIPTION
Fixes issue #886

Prior to this, when specifying the path(s) to a spec file to test with the `--tests` option, PDK was failing with:
> /pdk-1.18.0/lib/pdk/tests/unit.rb:96:in `tr!': can't modify frozen String (RuntimeError)

After this, `pdk test unit --path some/spec/file.rb` works and does not throw an error.