### PR TITLE
Add ability to set a forge token for release

### DIFF
--- a/lib/pdk/cli/release/publish.rb
+++ b/lib/pdk/cli/release/publish.rb
@@ -11,7 +11,7 @@ module PDK::CLI
     option nil, :'forge-upload-url', _('Set forge upload url path.'),
            argument: :required, default: 'https://forgeapi.puppetlabs.com/v3/releases'
 
-    option nil, :'forge-token', _('Set Forge API token.'), argument: :required, default: nil
+    option nil, :'forge-token', _('Set Forge API token or use env variable PUPPET_FORGE_TOKEN.'), argument: :required, default: ENV['PUPPET_FORGE_TOKEN']
 
     run do |opts, _args, cmd|
       # Make sure build is being run in a valid module directory with a metadata.json

--- a/lib/pdk/module/release.rb
+++ b/lib/pdk/module/release.rb
@@ -210,7 +210,7 @@ module PDK
       end
 
       def forge_token
-        options[:'forge-token']
+        options[:'forge-token'] || ENV['PUPPET_FORGE_TOKEN']
       end
 
       def forge_upload_url


### PR DESCRIPTION
  * Previously when using the release command the user
    had to enter the forge token every time they released.
    This is annoying and is not compatible with CI systems.

    This commit allows the user or CI to set PUPPET_FORGE_TOKEN
    environment variable so they are not burdened with prompts.

    This also makes the default cli option the value of the environment variable.

    Note: when help is displayed the token is also displayed.