### PR TITLE
Add forge token env

### DIFF
--- a/lib/pdk/cli/release/publish.rb
+++ b/lib/pdk/cli/release/publish.rb
@@ -11,7 +11,7 @@ module PDK::CLI
     option nil, :'forge-upload-url', _('Set forge upload url path.'),
            argument: :required, default: 'https://forgeapi.puppetlabs.com/v3/releases'
 
-    option nil, :'forge-token', _('Set Forge API token or use env variable PUPPET_FORGE_TOKEN.'), argument: :required, default: ENV['PUPPET_FORGE_TOKEN']
+    option nil, :'forge-token', _('Set Forge API token (you may also set via environment variable PDK_FORGE_TOKEN)'), argument: :required
 
     run do |opts, _args, cmd|
       # Make sure build is being run in a valid module directory with a metadata.json
@@ -27,6 +27,16 @@ module PDK::CLI
       opts[:'skip-build'] = true
       opts[:'skip-versionset'] = true
       opts[:force] = true unless PDK::CLI::Util.interactive?
+      opts[:'forge-token'] ||= PDK::Util::Env['PDK_FORGE_TOKEN']
+
+      if opts[:'forge-token'].nil? || opts[:'forge-token'].empty?
+        PDK.logger.error _(
+          'You must supply a Forge API token either via `--forge-token` option ' \
+          'or PDK_FORGE_TOKEN environment variable.',
+        )
+
+        exit 1
+      end
 
       Release.prepare_publish_interview(TTY::Prompt.new(help_color: :cyan), opts) unless opts[:force]
 

--- a/lib/pdk/cli/release/publish.rb
+++ b/lib/pdk/cli/release/publish.rb
@@ -11,7 +11,7 @@ module PDK::CLI
     option nil, :'forge-upload-url', _('Set forge upload url path.'),
            argument: :required, default: 'https://forgeapi.puppetlabs.com/v3/releases'
 
-    option nil, :'forge-token', _('Set Forge API token.'), argument: :required, default: nil
+    option nil, :'forge-token', _('Set Forge API token or use env variable PUPPET_FORGE_TOKEN.'), argument: :required, default: ENV['PUPPET_FORGE_TOKEN']
 
     run do |opts, _args, cmd|
       # Make sure build is being run in a valid module directory with a metadata.json

--- a/lib/pdk/module/release.rb
+++ b/lib/pdk/module/release.rb
@@ -210,7 +210,7 @@ module PDK
       end
 
       def forge_token
-        options[:'forge-token']
+        options[:'forge-token'] || ENV['PUPPET_FORGE_TOKEN']
       end
 
       def forge_upload_url

--- a/lib/pdk/module/release.rb
+++ b/lib/pdk/module/release.rb
@@ -210,7 +210,7 @@ module PDK
       end
 
       def forge_token
-        options[:'forge-token'] || ENV['PUPPET_FORGE_TOKEN']
+        options[:'forge-token']
       end
 
       def forge_upload_url


### PR DESCRIPTION
@logicminds it wouldn't let me push to your fork, but I took your commit and changed a couple things:

- renamed the env var to be more consistent with existing PDK env vars
- removed the default value from the CLI help and instead just fall-back to env if CLI value is empty
- use the PDK::Util env helpers
- added unit tests

Supersedes #912 