### PR TITLE
(MAINT) Update version selection package tests to be more recent

### DIFF
--- a/package-testing/spec/package/version_selection_spec.rb
+++ b/package-testing/spec/package/version_selection_spec.rb
@@ -4,7 +4,7 @@ describe 'Test puppet & ruby version selection' do
   module_name = 'version_selection'
   test_cases = [
     { envvar: 'PDK_PUPPET_VERSION', version: '5.5.0', expected_puppet: '5.5', expected_ruby: '2.4' },
-    { envvar: 'PDK_PE_VERSION', version: '2017.3', expected_puppet: '5.3', expected_ruby: '2.4' },
+    { envvar: 'PDK_PE_VERSION', version: '2018.1', expected_puppet: '5.5', expected_ruby: '2.4' },
   ]
 
   before(:all) do


### PR DESCRIPTION
`puppet-debugger` 1.0.0 now included in the Ruby 2.4 dev gems doesn't support Puppet < 5.5.