### PR TITLE
(MAINT) Default to Ruby 2.5.x on packaged installations

### DIFF
--- a/lib/pdk/util/ruby_version.rb
+++ b/lib/pdk/util/ruby_version.rb
@@ -60,7 +60,11 @@ module PDK
                                       #
                                       # PDK::Util::PuppetVersion.find_gem_for('5.5.10')[:ruby_version]
                                       #
-                                      PDK::Util::PuppetVersion.latest_available[:ruby_version]
+                                      # For using the latest puppet gem:
+                                      # PDK::Util::PuppetVersion.latest_available[:ruby_version]
+                                      #
+                                      # Temporarily lock to Ruby 2.5.x as default until 2.7.x ecosystem is sorted
+                                      versions.keys.detect { |v| v =~ %r{^2\.5} }
                                     else
                                       # TODO: may not be a safe assumption that highest available version should be default
                                       # WARNING Do NOT use PDK::Util::PuppetVersion.*** methods as it can recurse into this


### PR DESCRIPTION
There are some issues with dependencies with Bolt/Puppet under Ruby 2.7.x. This change allows us to dark-ship the Ruby 2.7.1 runtime in the PDK packages without it being activated unintentionally, even if it contains a `puppet` gem installation.