### PR TITLE
Adds AIX support when creating a new module

### DIFF
--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -54,6 +54,10 @@ module PDK
           'operatingsystem'        => 'windows',
           'operatingsystemrelease' => %w[2019 10],
         },
+        'AIX' => {
+          'operatingsystem'        => 'AIX',
+          'operatingsystemrelease' => %w[6.1 7.1 7.2],
+        },
       }.freeze
 
       DEFAULT_OPERATING_SYSTEMS = [


### PR DESCRIPTION
  * Previously when creating a new module AIX was not
    an option when choosing supported operating systems.
    This resulted in many modules written with PDK to not support
    AIX.  This fixes that issue by adding AIX.