### PR TITLE
(GH-905) Ensure release failure includes error message

### DIFF
--- a/lib/pdk/module/release.rb
+++ b/lib/pdk/module/release.rb
@@ -163,7 +163,7 @@ module PDK
           http.request(request)
         end
 
-        raise PDK::CLI::ExitWithError, _('Error uploading to Puppet Forge: %{result}') % { result: response } unless response.is_a?(Net::HTTPSuccess)
+        raise PDK::CLI::ExitWithError, _('Error uploading to Puppet Forge: %{result}') % { result: response.body } unless response.is_a?(Net::HTTPSuccess)
         PDK.logger.info _('Publish to Forge was successful')
       end
 

--- a/spec/unit/pdk/module/release_spec.rb
+++ b/spec/unit/pdk/module/release_spec.rb
@@ -345,6 +345,7 @@ describe PDK::Module::Release do
       let(:http_response) { Net::HTTPUnauthorized.new(nil, nil, nil) }
 
       it 'raises' do
+        allow(http_response).to receive(:body)
         expect { instance.run_publish({}, tarball_path) }.to raise_error(PDK::CLI::ExitWithError)
       end
     end


### PR DESCRIPTION
Prior to this commit, a failure to publish to the forge returns the string representing a `Net::HTTPBadRequest` object instead of text including the actual error message. This commit ensures that the body of the error is instead written to the error stream.

Resolves #905 