### PR TITLE
Update Rakefile to use ABS as hypervisor

### DIFF
--- a/package-testing/Gemfile
+++ b/package-testing/Gemfile
@@ -11,7 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '= 4.10.0')
-gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.6.0')
+gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.7.0')
 gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '= 1.2.6')
 gem 'beaker-puppet', '= 1.18.5'
 gem 'beaker-rspec', '= 6.2.4'

--- a/package-testing/Gemfile
+++ b/package-testing/Gemfile
@@ -11,7 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '= 4.10.0')
-gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '= 0.5.0')
+gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.6.0')
 gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '= 1.2.6')
 gem 'beaker-puppet', '= 1.18.5'
 gem 'beaker-rspec', '= 6.2.4'

--- a/package-testing/Rakefile
+++ b/package-testing/Rakefile
@@ -69,7 +69,8 @@ namespace :acceptance do
 
     puts "Generating beaker hosts using TEST_TARGET value #{test_target}"
 
-    cli = BeakerHostGenerator::CLI.new(["#{test_target}{type=foss}", '--disable-default-role'])
+
+    cli = BeakerHostGenerator::CLI.new(["#{test_target}{type=foss}", '--disable-default-role', '--hypervisor abs'])
 
     File.open('acceptance_hosts.yml', 'w') do |hosts_file|
       hosts_file.print(cli.execute)

--- a/package-testing/Rakefile
+++ b/package-testing/Rakefile
@@ -70,7 +70,7 @@ namespace :acceptance do
     puts "Generating beaker hosts using TEST_TARGET value #{test_target}"
 
 
-    cli = BeakerHostGenerator::CLI.new(["#{test_target}{type=foss}", '--disable-default-role', '--hypervisor abs'])
+    cli = BeakerHostGenerator::CLI.new(["#{test_target}{type=foss}", '--disable-default-role', '--hypervisor', 'abs'])
 
     File.open('acceptance_hosts.yml', 'w') do |hosts_file|
       hosts_file.print(cli.execute)

--- a/package-testing/config/options.rb
+++ b/package-testing/config/options.rb
@@ -3,4 +3,5 @@
     keys: ['~/.ssh/id_rsa-acceptance'],
   },
   preserve_hosts: 'onfail',
+  provision: 'true'
 }


### PR DESCRIPTION
With this change, beaker-abs will be used instead of the vmpooler hypervisor in beaker.
In CI, since the ABS_RESOURCE_HOSTS variable is set, it will pick the existing node to run
with