### PR TITLE
bundler: disable installing unsupported system_tests gem in most situ…

### DIFF
--- a/lib/pdk/cli/bundle.rb
+++ b/lib/pdk/cli/bundle.rb
@@ -38,6 +38,10 @@ EOF
       command = PDK::CLI::Exec::InteractiveCommand.new(PDK::CLI::Exec.bundle_bin, *args).tap do |c|
         c.context = :pwd
         c.update_environment(gemfile_env)
+        # while all other commands should exclude system_tests to avoid support for unsupported gems,
+        # the bundle sub-command specifically should not take that liberty as it is an experimental
+        # and unsupported outlet for this kind of work.
+        c.environment.delete('BUNDLE_WITHOUT')
       end
 
       result = command.execute!

--- a/lib/pdk/util/bundler.rb
+++ b/lib/pdk/util/bundler.rb
@@ -226,7 +226,8 @@ module PDK
         end
 
         def self.gemfile_env(gem_overrides)
-          gemfile_env = {}
+          # in default mode, never install gems from the system_tests group, as the PDK doesn't officially supports them
+          gemfile_env = { 'BUNDLE_WITHOUT' => 'system_tests' }
 
           return gemfile_env unless gem_overrides.respond_to?(:each)
 

--- a/spec/unit/pdk/cli/bundle_spec.rb
+++ b/spec/unit/pdk/cli/bundle_spec.rb
@@ -17,6 +17,7 @@ describe 'Running `pdk bundle`' do
         PDK::CLI::Exec::InteractiveCommand,
         :context=           => true,
         :update_environment => true,
+        :environment        => {},
         :execute!           => command_result,
       )
       allow(PDK::CLI::Exec::InteractiveCommand).to receive(:new)

--- a/spec/unit/pdk/cli/console_spec.rb
+++ b/spec/unit/pdk/cli/console_spec.rb
@@ -67,7 +67,7 @@ describe 'pdk console' do
       allow(PDK::Util::Bundler).to receive(:ensure_bundle!).with(puppet: '5.4.0')
       command = instance_double(PDK::CLI::Exec::InteractiveCommand)
       allow(command).to receive(:context=).with(:pwd)
-      allow(command).to receive(:update_environment).with('PUPPET_GEM_VERSION' => '5.4.0')
+      allow(command).to receive(:update_environment).with('BUNDLE_WITHOUT' => 'system_tests', 'PUPPET_GEM_VERSION' => '5.4.0')
       allow(command).to receive(:execute!).and_return(exit_code: 0)
       allow(PDK::Util).to receive(:module_root).and_return('/modules/ntp')
       args = [
@@ -93,7 +93,7 @@ describe 'pdk console' do
       allow(PDK::Util::Bundler).to receive(:ensure_bundle!).with(puppet: '5.4.0')
       command = instance_double(PDK::CLI::Exec::InteractiveCommand)
       allow(command).to receive(:context=).with(:pwd)
-      allow(command).to receive(:update_environment).with('PUPPET_GEM_VERSION' => '5.4.0')
+      allow(command).to receive(:update_environment).with('BUNDLE_WITHOUT' => 'system_tests', 'PUPPET_GEM_VERSION' => '5.4.0')
       allow(command).to receive(:execute!).and_return(exit_code: 0)
       allow(PDK::Util).to receive(:module_root).and_return('/modules/ntp')
       args = [
@@ -126,7 +126,7 @@ describe 'pdk console' do
       allow(PDK::Util::Bundler).to receive(:ensure_bundle!).with(puppet: '5.4.0')
       command = instance_double(PDK::CLI::Exec::InteractiveCommand)
       allow(command).to receive(:context=).with(:pwd)
-      allow(command).to receive(:update_environment).with('PUPPET_GEM_VERSION' => '5.4.0')
+      allow(command).to receive(:update_environment).with('BUNDLE_WITHOUT' => 'system_tests', 'PUPPET_GEM_VERSION' => '5.4.0')
       allow(command).to receive(:execute!).and_return(exit_code: 0)
       allow(PDK::CLI::Exec::InteractiveCommand).to receive(:new).and_return(command)
       expect { console_cmd.run(['--puppet-version=5', '--run-once', '--quiet', '--execute=$foo = 123']) }.to exit_zero
@@ -139,7 +139,7 @@ describe 'pdk console' do
       command = instance_double(PDK::CLI::Exec::InteractiveCommand)
       allow(PDK::Util::RubyVersion).to receive(:versions).and_return('2.5.3' => '2.5.0')
       allow(command).to receive(:context=).with(:pwd)
-      allow(command).to receive(:update_environment).with('PUPPET_GEM_VERSION' => '5.5.10')
+      allow(command).to receive(:update_environment).with('BUNDLE_WITHOUT' => 'system_tests', 'PUPPET_GEM_VERSION' => '5.5.10')
       allow(command).to receive(:execute!).and_return(exit_code: 0)
       allow(PDK::CLI::Exec::InteractiveCommand).to receive(:new).and_return(command)
       expect { console_cmd.run(['--pe-version=2018.1', '--run-once', '--quiet', '--execute=$foo = 123']) }.to exit_zero
@@ -152,7 +152,7 @@ describe 'pdk console' do
       command = instance_double(PDK::CLI::Exec::InteractiveCommand)
       allow(PDK::Util::RubyVersion).to receive(:versions).and_return('2.5.3' => '2.5.0')
       allow(command).to receive(:context=).with(:pwd)
-      allow(command).to receive(:update_environment).with('PUPPET_GEM_VERSION' => 'file:///home/user1/.pdk/cache/src/puppet')
+      allow(command).to receive(:update_environment).with('BUNDLE_WITHOUT' => 'system_tests', 'PUPPET_GEM_VERSION' => 'file:///home/user1/.pdk/cache/src/puppet')
       allow(command).to receive(:execute!).and_return(exit_code: 0)
       allow(PDK::CLI::Exec::InteractiveCommand).to receive(:new).and_return(command)
       expect { console_cmd.run(['--puppet-dev', '--run-once', '--quiet', '--execute=$foo = 123']) }.to exit_zero
@@ -163,7 +163,7 @@ describe 'pdk console' do
         allow(PDK::Util::Bundler).to receive(:ensure_bundle!).with(puppet: '5.4.0')
         command = instance_double(PDK::CLI::Exec::InteractiveCommand)
         allow(command).to receive(:context=).with(:pwd)
-        allow(command).to receive(:update_environment).with('PUPPET_GEM_VERSION' => '5.4.0')
+        allow(command).to receive(:update_environment).with('BUNDLE_WITHOUT' => 'system_tests', 'PUPPET_GEM_VERSION' => '5.4.0')
         allow(command).to receive(:execute!).and_return(exit_code: 0)
         allow(PDK::Util).to receive(:module_root).and_return('C:/modules/ntp')
         args = [
@@ -180,7 +180,7 @@ describe 'pdk console' do
       allow(PDK::Util::Bundler).to receive(:ensure_bundle!).with(puppet: '5.4.0')
       command = instance_double(PDK::CLI::Exec::InteractiveCommand)
       allow(command).to receive(:context=).with(:pwd)
-      allow(command).to receive(:update_environment).with('PUPPET_GEM_VERSION' => '5.4.0')
+      allow(command).to receive(:update_environment).with('BUNDLE_WITHOUT' => 'system_tests', 'PUPPET_GEM_VERSION' => '5.4.0')
       allow(command).to receive(:execute!).and_return(exit_code: 0)
       allow(PDK::Util).to receive(:module_root).and_return('/modules/ntp')
       args = [

--- a/spec/unit/pdk/util/bundler_spec.rb
+++ b/spec/unit/pdk/util/bundler_spec.rb
@@ -543,7 +543,7 @@ RSpec.describe PDK::Util::Bundler do
         it 'does not update the command environment' do
           cmd_double = allow_command([bundle_regex, 'lock', %r{--lockfile}, '--update'], exit_code: 0)
 
-          expect(cmd_double).to receive(:update_environment).with({})
+          expect(cmd_double).to receive(:update_environment).with('BUNDLE_WITHOUT' => 'system_tests')
 
           instance.update_lock!(with: overrides)
         end


### PR DESCRIPTION
…ations

This compromises between stable and quick operations for the regular supported commands and allowing more free-form usage with the `pdk bundle` command.