### PR TITLE
(RE-13453) Remove old gpg key from build_defaults.yaml

### DIFF
--- a/ext/build_defaults.yml
+++ b/ext/build_defaults.yml
@@ -2,4 +2,3 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 packager: 'puppetlabs'
-gpg_key: '7F438280EF8D349F'


### PR DESCRIPTION
The `gpg_key` setting is overridden by the one in `build-data`. Remove the
local soon-to-be-expired GPG key from the local repo for clarity and
cleanliness.