### PR TITLE
(maint) Loosen facter dependency

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
 
   # Analytics dependencies
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.1.5'
-  spec.add_runtime_dependency 'facter', '~> 2.5.1'
+  spec.add_runtime_dependency 'facter', '>= 2.5.1', '< 5.0.0'
   spec.add_runtime_dependency 'httpclient', '~> 2.8.3'
 
   # Used in the pdk-templates


### PR DESCRIPTION
Previously facter was locked to 2.5.1. As we're planning to increaase the minimum supported Facter version in Puppet 7 to at least 3, we should update this in PDK as well. Otherwise, projects using the latest puppet would not be able to install PDK.

