### PR TITLE
Update lower puppet requirements bound when creating new modules

### DIFF
--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -81,7 +81,7 @@ module PDK
           OPERATING_SYSTEMS[os_name]
         }.flatten,
         'requirements' => [
-          { 'name' => 'puppet', 'version_requirement' => '>= 4.10.0 < 8.0.0' },
+          { 'name' => 'puppet', 'version_requirement' => '>= 6.21.0 < 8.0.0' },
         ],
       }.freeze
 

--- a/spec/acceptance/build_spec.rb
+++ b/spec/acceptance/build_spec.rb
@@ -15,7 +15,7 @@ describe 'pdk build', module_command: true do
       'issues_url'              => 'https://github.com/testuser/puppet-build/issues',
       'dependencies'            => [],
       'operatingsystem_support' => [{ 'operatingsystem' => 'windows', 'operatingsystemrelease' => ['10'] }],
-      'requirements'            => [{ 'name' => 'puppet', 'version_requirement' => '> 4.10.0 < 7.0.0' }],
+      'requirements'            => [{ 'name' => 'puppet', 'version_requirement' => '> 6.21.0 < 7.0.0' }],
       'pdk-version'             => '1.2.3',
       'template-url'            => 'https://github.com/puppetlabs/pdk-templates',
       'template-ref'            => 'heads/master-0-g1234abc',

--- a/spec/unit/pdk/cli/update_spec.rb
+++ b/spec/unit/pdk/cli/update_spec.rb
@@ -64,7 +64,7 @@ describe 'PDK::CLI update' do
           "requirements": [
             {
               "name": "puppet",
-              "version_requirement": ">= 4.10.0 < 7.0.0"
+              "version_requirement": ">= 6.21.0 < 7.0.0"
             }
           ],
           "pdk-version": "99.99.0",

--- a/spec/unit/pdk/util/puppet_version_spec.rb
+++ b/spec/unit/pdk/util/puppet_version_spec.rb
@@ -555,8 +555,8 @@ describe PDK::Util::PuppetVersion do
     let(:metadata) { PDK::Module::Metadata.new }
 
     context 'with default metadata' do
-      it 'searches for a Puppet gem >= 4.10.0 < 8.0.0' do
-        requirement = Gem::Requirement.create(['>= 4.10.0', '< 8.0.0'])
+      it 'searches for a Puppet gem >= 6.21.0 < 8.0.0' do
+        requirement = Gem::Requirement.create(['>= 6.21.0', '< 8.0.0'])
         expect(described_class.instance).to receive(:find_gem).with(requirement)
 
         described_class.from_module_metadata(metadata)


### PR DESCRIPTION
Since puppet5 is EOL, new modules should be created with up-to-date version
requirements.