### PR TITLE
(IAC-1438) - Removal of Inappropriate Terminology

### DIFF
--- a/.dependency_decisions.yml
+++ b/.dependency_decisions.yml
@@ -1,41 +1,41 @@
 ---
-- - :whitelist
+- - :permit
   - MIT
   - :who: DavidS
     :why: standard license
     :versions: []
     :when: 2017-07-28 11:11:09.971500380 Z
-- - :whitelist
+- - :permit
   - Apache 2.0
   - :who: DavidS
     :why: standard license
     :versions: []
     :when: 2017-07-28 11:12:21.086779416 Z
-- - :whitelist
+- - :permit
   - ruby
   - :who: DavidS
     :why: standard license
     :versions: []
     :when: 2017-07-28 11:12:28.578927478 Z
-- - :whitelist
+- - :permit
   - Simplified BSD
   - :who: DavidS
     :why: standard license
     :versions: []
     :when: 2017-07-28 11:12:36.924605442 Z
-- - :whitelist
+- - :permit
   - New BSD
   - :who: DavidS
     :why: standard license
     :versions: []
     :when: 2017-07-28 11:14:00.252514982 Z
-- - :whitelist
+- - :permit
   - Apache License, v2
   - :who: DavidS
     :why: standard license
     :versions: []
     :when: 2017-07-28 11:14:07.999759997 Z
-- - :whitelist
+- - :permit
   - Ruby or LGPLv3+
   - :who: DavidS
     :why: standard license
@@ -62,7 +62,7 @@
     :why: https://github.com/defunkt/colored/blob/829bde0f8832406be1cacc5c99c49d976e05ccfc/LICENSE
     :versions: []
     :when: 2017-07-28 11:23:25.554994001 Z
-- - :whitelist
+- - :permit
   - ISC
   - :who: scotje
     :why: MIT equivalent

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -45,8 +45,6 @@ Naming/HeredocDelimiterNaming:
   Description: Use descriptive heredoc delimiters.
   StyleGuide: "#heredoc-delimiters"
   Enabled: false
-  Blacklist:
-  - !ruby/regexp /(^|\s)(EO[A-Z]{1}|END)(\s|$)/
 
 Naming/MemoizedInstanceVariableName:
   Description: Memoized method name should match memo instance variable name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,7 +347,7 @@ See the [release notes](https://puppet.com/docs/pdk/latest/release_notes.html) f
 - \(PDK-1266\) Clear modulepath value when validating manifest syntax [\#629](https://github.com/puppetlabs/pdk/pull/629) ([rodjek](https://github.com/rodjek))
 - \(PDK-1272\) Convert user/module module names to user-module [\#626](https://github.com/puppetlabs/pdk/pull/626) ([rodjek](https://github.com/rodjek))
 - \(PDK-1276\) Skip non-file YAML validator targets [\#625](https://github.com/puppetlabs/pdk/pull/625) ([rodjek](https://github.com/rodjek))
-- \(PDK-1273\) Whitelist Ruby symbols in YAML validator [\#624](https://github.com/puppetlabs/pdk/pull/624) ([rodjek](https://github.com/rodjek))
+- \(PDK-1273\) Allowlist Ruby symbols in YAML validator [\#624](https://github.com/puppetlabs/pdk/pull/624) ([rodjek](https://github.com/rodjek))
 
 **Merged pull requests:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ PS> cd ..\testmodule
 
 # 4. Run the pdk binstub
 PS> ruby.exe bin\pdk --version
-1.10.0.pre (heads/master-g3e22a80)
+1.10.0.pre (heads/main-g3e22a80)
 ```
 
 # Running tests
@@ -66,7 +66,7 @@ Environment Variable | Usage
 # Release Process
 
 1. Bump the version in `lib/pdk/version.rb`.
-1. In a clean checkout of master, run `bundle exec rake changelog`.
+1. In a clean checkout of main, run `bundle exec rake changelog`.
 1. Edit PR titles and tags, until `bundle exec rake changelog` output makes sense.
 1. Run `bundle exec rake gettext:pot` to update the translations.
 1. Commit and PR the changes.

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ end
 group :test do
   gem 'coveralls'
   gem 'json', '~> 2.2.0'
-  gem 'license_finder', '~> 5.4.1'
+  gem 'license_finder', '~> 6.1.2'
   if RUBY_VERSION < '2.4'
     # license_finder depends on rubyzip which requires Ruby 2.4 in 2.x
     gem 'rubyzip', '< 2.0.0'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pdk [![Build Status](https://travis-ci.org/puppetlabs/pdk.svg?branch=master)](https://travis-ci.org/puppetlabs/pdk) [![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/x70e2fqllbaootpd?svg=true)](https://ci.appveyor.com/project/puppetlabs/pdk) [![Coverage Status](https://coveralls.io/repos/github/puppetlabs/pdk/badge.svg?branch=master)](https://coveralls.io/github/puppetlabs/pdk?branch=master)
+# pdk [![Build Status](https://travis-ci.org/puppetlabs/pdk.svg?branch=main)](https://travis-ci.org/puppetlabs/pdk) [![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/x70e2fqllbaootpd?svg=true)](https://ci.appveyor.com/project/puppetlabs/pdk) [![Coverage Status](https://coveralls.io/repos/github/puppetlabs/pdk/badge.svg?branch=main)](https://coveralls.io/github/puppetlabs/pdk?branch=main)
 
 * [Installation](#installation)
 * [Basic usage](#basic-usage)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,10 @@
 environment:
   LOG_SPEC_ORDER: true
   matrix:
-    # FIXME: enable ruby 2.5 on windows once puppet and puppet-module gems have unpinned ffi
-    # - RUBY_VERSION: 25-x64
-    #   USE_MSYS: true
-    #   SUITES: "spec"
-    #   BUNDLE_JOBS: 4
+    - RUBY_VERSION: 25-x64
+      USE_MSYS: true
+      SUITES: "spec"
+      BUNDLE_JOBS: 4
     - RUBY_VERSION: 25-x64
       USE_MSYS: true
       SUITES: "acceptance:smoke"
@@ -20,14 +19,6 @@ environment:
       UPDATE_BUNDLER: true
     - RUBY_VERSION: 24-x64
       USE_MSYS: true
-      SUITES: "spec"
-      BUNDLE_JOBS: 1
-    - RUBY_VERSION: 23-x64
-      USE_CYGWIN: true
-      SUITES: "spec"
-      BUNDLE_JOBS: 1
-    - RUBY_VERSION: 21-x64
-      USE_CYGWIN: true
       SUITES: "spec"
       BUNDLE_JOBS: 1
     - RUBY_VERSION: 24-x64

--- a/docs/customizing_module_config.md
+++ b/docs/customizing_module_config.md
@@ -46,7 +46,7 @@ configuration of that file. For example:
 
 -   To see a complete updated list of `sync.yml` settings, see the
     [`pdk-template`
-    README](https://github.com/puppetlabs/pdk-templates/blob/master/README.md).
+    README](https://github.com/puppetlabs/pdk-templates/blob/main/README.md).
 
 
 For example, this `.sync.yml` file removes the `appveyor.yml` file from the

--- a/docs/pdk_reference.md
+++ b/docs/pdk_reference.md
@@ -120,7 +120,7 @@ module](pdk_converting_modules.md#convert-a-module) topic.
 |`--full-interview`|Include interview questions related to publishing on the Forge to create module metadata.|None.|If not specified, asks only basic module metadata questions.|
 |`--noop`|Runs the command in a no operation or "no-op" mode. This shows what changes PDK will make without actually executing the changes.|None.|If not specified, the command makes the requested changes.|
 |`--skip-interview`|Skip interview questions and use default values to create module metadata.|None.|If not specified, asks basic module metadata questions.|
-|`--template-ref=<VALUE>`|Specifies the reference to use for the specified template for this module. This option is valid only if you have specified a template with the `--template-url` option.|A template branch name, tag name, or commit SHA for the specified template.|If you have specified a custom template, or if you installed PDK as a gem, this option defaults to "master". Otherwise, defaults to the defaults to the currently installed PDK version.|
+|`--template-ref=<VALUE>`|Specifies the reference to use for the specified template for this module. This option is valid only if you have specified a template with the `--template-url` option.|A template branch name, tag name, or commit SHA for the specified template.|If you have specified a custom template, or if you installed PDK as a gem, this option defaults to "main". Otherwise, defaults to the defaults to the currently installed PDK version.|
 |`--template-url=<GIT_URL>`|Specifies a template to use for this module.|A valid Git URL or a path to a local template.|A valid Git URL or a path to a local template.|
 
 ## `pdk new class` command
@@ -196,7 +196,7 @@ topic.
 |`--license=<IDENTIFIER>`|Specifies the license for this module is written under.|See the [SPDX](https://spdx.org) License List for a list of open source licenses, or use `proprietary`.|`Apache-2.0`|
 |`--skip-interview`|Skip interview questions and use default values to create module metadata.|None.|If not specified, PDK asks basic module metadata questions.|
 |`<TARGET_DIR>`|Specifies the directory that the new module will be created in.|A valid directory path.|Creates a directory with the given `module_name` inside the current directory.|
-|`--template-ref=<VALUE>`|Specifies the reference to use for the specified template for this module. This option is valid only if you have specified a template with the `--template-url` option.|A template branch name, tag name, or commit SHA for the specified template.|If you have specified a custom template, or if you installed PDK as a gem, this option defaults to "master". Otherwise, defaults to the defaults to the currently installed PDK version.|
+|`--template-ref=<VALUE>`|Specifies the reference to use for the specified template for this module. This option is valid only if you have specified a template with the `--template-url` option.|A template branch name, tag name, or commit SHA for the specified template.|If you have specified a custom template, or if you installed PDK as a gem, this option defaults to "main". Otherwise, defaults to the defaults to the currently installed PDK version.|
 |`--template-url=<GIT_URL>`|Specifies a template to use for this module.|A valid Git URL or path to a local template.|If not specified, defaults to the `[pdk-template](https://github.com/puppetlabs/pdk-template)`|
 
 ## `pdk new task` command
@@ -408,7 +408,7 @@ changes](pdk_updating_modules.md). For step-by-step instructions, see the
 |--------|-----------|------|-------|
 |`--force`|Update the module without prompts. Cannot be used together with `--noop`.|None.|If not specified, PDK prompts for user input.|
 |`--noop`|Shows what changes PDK would make, but does not actually make those changes. Cannot be used together with `--force`.|None.|If not specified, PDK prompts for user input and makes changes to the module on confirmation. |
-|`--template-ref=<VALUE>`|Specifies the reference to use for the specified template for this module.|A template branch name, tag name, or commit SHA for the specified template.|If you have specified a custom template, previously updated your module to a non-default `--template-ref` value, this defaults to the value previously specified in your module metadata. Otherwise, defaults to the currently installed PDK version (on PDK native package installations) or "master" (on PDK gem installations).|
+|`--template-ref=<VALUE>`|Specifies the reference to use for the specified template for this module.|A template branch name, tag name, or commit SHA for the specified template.|If you have specified a custom template, previously updated your module to a non-default `--template-ref` value, this defaults to the value previously specified in your module metadata. Otherwise, defaults to the currently installed PDK version (on PDK native package installations) or "main" (on PDK gem installations).|
 
 ## `pdk validate` command
 

--- a/docs/release_notes_pdk.md
+++ b/docs/release_notes_pdk.md
@@ -25,7 +25,7 @@ page for more information.
 You can now set PDK to warn, and optionally autocorrect, the use of legacy
 Facter facts in your manifests. To enable this, set `disable_legacy_facts` to
 `true` in the common section of their `.sync.yml` file. See the pdk-templates
-[README](https://github.com/puppetlabs/pdk-templates/blob/master/README.md) for
+[README](https://github.com/puppetlabs/pdk-templates/blob/main/README.md) for
 detailed information. [PDK-1591](https://tickets.puppetlabs.com/browse/PDK-1591)
 
 #### Set, update, delete configuration keys from command line
@@ -170,7 +170,7 @@ but not identifying, usage information.
 
 #### `pdk module build` now rejects unprintable characters in file names
 
-To ensure that the module is compatible with all Puppet masters regardless of
+To ensure that the module is compatible with all Puppet servers regardless of
 their locale, `pdk module build` now rejects files that contain non-ASCII
 characters in their name. Issue reported by [Laura
 Macchi](https://tickets.puppetlabs.com/secure/ViewProfile.jspa?name=lmacchi).
@@ -631,10 +631,10 @@ See the curl issues
 [CVE-2019-5436](https://curl.haxx.se/docs/CVE-2019-5436.html) for details about
 these issues. [PDK-1369](https://tickets.puppetlabs.com/browse/PDK-1369)
 
-#### Default `template-ref` for custom templates is now "master"
+#### Default `template-ref` for custom templates is now "main"
 
 With PDK installed from a package, if you've specified a custom template for
-PDK, the default `template-ref` is now "master". Prior to this release, the
+PDK, the default `template-ref` is now "main". Prior to this release, the
 `template-ref` defaulted to the default version of the packaged template.
 [PDK-1354](https://tickets.puppetlabs.com/browse/PDK-1354)
 

--- a/ext/PuppetDevelopmentKit/PuppetDevelopmentKit.psd1.erb
+++ b/ext/PuppetDevelopmentKit/PuppetDevelopmentKit.psd1.erb
@@ -12,10 +12,10 @@
   PrivateData       = @{
     PSData = @{
       # Tags = @()
-      LicenseUri = 'https://github.com/puppetlabs/pdk/blob/master/LICENSE'
+      LicenseUri = 'https://github.com/puppetlabs/pdk/blob/main/LICENSE'
       ProjectUri = 'https://github.com/puppetlabs/pdk'
       # IconUri = ''
-      ReleaseNotes = 'https://github.com/puppetlabs/pdk/blob/master/CHANGELOG.md'
+      ReleaseNotes = 'https://github.com/puppetlabs/pdk/blob/main/CHANGELOG.md'
     }
   }
 }

--- a/ext/PuppetDevelopmentKitBeta/PuppetDevelopmentKitBeta.psd1.erb
+++ b/ext/PuppetDevelopmentKitBeta/PuppetDevelopmentKitBeta.psd1.erb
@@ -12,10 +12,10 @@
   PrivateData       = @{
     PSData = @{
       # Tags = @()
-      LicenseUri = 'https://github.com/puppetlabs/pdk/blob/master/LICENSE'
+      LicenseUri = 'https://github.com/puppetlabs/pdk/blob/main/LICENSE'
       ProjectUri = 'https://github.com/puppetlabs/pdk'
-      IconUri = 'https://cdn.rawgit.com/puppetlabs/puppet-chocolatey-packages/master/icons/puppet.png'
-      ReleaseNotes = 'https://github.com/puppetlabs/pdk/blob/master/CHANGELOG.md'
+      IconUri = 'https://cdn.rawgit.com/puppetlabs/puppet-chocolatey-packages/main/icons/puppet.png'
+      ReleaseNotes = 'https://github.com/puppetlabs/pdk/blob/main/CHANGELOG.md'
     }
   }
 }

--- a/ext/build_defaults.yml
+++ b/ext/build_defaults.yml
@@ -1,4 +1,4 @@
 ---
-packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=main'
 packaging_repo: 'packaging'
 packager: 'puppetlabs'

--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -139,7 +139,7 @@ module PDK
 
         example_results = {
           # Only possibilities are passed, failed, pending:
-          # https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/example.rb#L548
+          # https://github.com/rspec/rspec-core/blob/main/lib/rspec/core/example.rb#L548
           'passed' => [],
           'failed' => [],
           'pending' => [],

--- a/lib/pdk/util/template_uri.rb
+++ b/lib/pdk/util/template_uri.rb
@@ -26,13 +26,13 @@ module PDK
       #
       # file:///c:/foo (git clone location)
       # c:/foo (shell paths)
-      # file:///c:/foo#master (only for metadata)
-      # c:/foo#master (only for metadata)
+      # file:///c:/foo#main (only for metadata)
+      # c:/foo#main (only for metadata)
       #
       # non output formats:
       #
       # /c:/foo (internal use only)
-      # /c:/foo#master (internal use only)
+      # /c:/foo#main (internal use only)
       #
       def initialize(opts_or_uri)
         require 'addressable'

--- a/lib/pdk/util/vendored_file.rb
+++ b/lib/pdk/util/vendored_file.rb
@@ -55,8 +55,7 @@ module PDK
         uri = URI.parse(url)
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
-        # TODO: Get rid of this, possible workaround:
-        # https://github.com/glennsarti/dev-tools/blob/master/RubyCerts.ps1
+        # TODO: Get rid of this
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE if Gem.win_platform?
         request = Net::HTTP::Get.new(uri.request_uri)
         response = http.request(request)

--- a/lib/pdk/validate/yaml/yaml_syntax_validator.rb
+++ b/lib/pdk/validate/yaml/yaml_syntax_validator.rb
@@ -4,7 +4,7 @@ module PDK
   module Validate
     module YAML
       class YAMLSyntaxValidator < InternalRubyValidator
-        YAML_WHITELISTED_CLASSES = [Symbol].freeze
+        YAML_ALLOWLISTED_CLASSES = [Symbol].freeze
 
         def ignore_dotfiles
           false
@@ -53,7 +53,7 @@ module PDK
           end
 
           begin
-            ::YAML.safe_load(PDK::Util::Filesystem.read_file(target), YAML_WHITELISTED_CLASSES, [], true)
+            ::YAML.safe_load(PDK::Util::Filesystem.read_file(target), YAML_ALLOWLISTED_CLASSES, [], true)
 
             report.add_event(
               file:     target,

--- a/spec/acceptance/build_spec.rb
+++ b/spec/acceptance/build_spec.rb
@@ -18,7 +18,7 @@ describe 'pdk build', module_command: true do
       'requirements'            => [{ 'name' => 'puppet', 'version_requirement' => '> 6.21.0 < 7.0.0' }],
       'pdk-version'             => '1.2.3',
       'template-url'            => 'https://github.com/puppetlabs/pdk-templates',
-      'template-ref'            => 'heads/master-0-g1234abc',
+      'template-ref'            => 'heads/main-0-g1234abc',
     }
 
     context 'when the module has complete metadata' do

--- a/spec/acceptance/update_spec.rb
+++ b/spec/acceptance/update_spec.rb
@@ -24,7 +24,7 @@ describe 'pdk update', module_command: true do
     context 'that is not up to date' do
       before(:all) do
         metadata = JSON.parse(File.read('metadata.json'))
-        metadata['template-ref'] = 'heads/master-0-g1234567'
+        metadata['template-ref'] = 'heads/main-0-g1234567'
 
         File.open('metadata.json', 'w') do |f|
           f.puts metadata.to_json

--- a/spec/acceptance/version_changer_spec.rb
+++ b/spec/acceptance/version_changer_spec.rb
@@ -86,13 +86,13 @@ end
         its(:stderr) { is_expected.not_to match(%r{Using Puppet file://}i) }
       end
 
-      # Note that there is no guarantee that the master branch of puppet is compatible with the PDK under test
+      # Note that there is no guarantee that the main branch of puppet is compatible with the PDK under test
       # so we can only test that the validate command is using the expected puppet gem location
       describe command('pdk validate --puppet-dev') do
         its(:stderr) { is_expected.to match(%r{Using Puppet file://}i) }
       end
 
-      # Note that there is no guarantee that the master branch of puppet is compatible with the PDK under test
+      # Note that there is no guarantee that the main branch of puppet is compatible with the PDK under test
       # so we can only test that the test command is using the expected puppet gem location
       describe command('pdk test unit --puppet-dev') do
         its(:stderr) { is_expected.to match(%r{Using Puppet file://}i) }

--- a/spec/unit/pdk/cli/update_spec.rb
+++ b/spec/unit/pdk/cli/update_spec.rb
@@ -68,7 +68,7 @@ describe 'PDK::CLI update' do
             }
           ],
           "pdk-version": "99.99.0",
-          "template-url": "https://github.com/puppetlabs/pdk-templates#master",
+          "template-url": "https://github.com/puppetlabs/pdk-templates#main",
           "template-ref": "tags/99.99.0"
         }
         EOT

--- a/spec/unit/pdk/module/update_spec.rb
+++ b/spec/unit/pdk/module/update_spec.rb
@@ -316,10 +316,10 @@ describe PDK::Module::Update do
     end
 
     context 'when the template-ref describes a branch commit' do
-      let(:template_ref) { 'heads/master-4-g1234abc' }
+      let(:template_ref) { 'heads/main-4-g1234abc' }
 
       it 'returns the branch name and the commit SHA' do
-        is_expected.to eq('master@1234abc')
+        is_expected.to eq('main@1234abc')
       end
     end
   end
@@ -341,14 +341,14 @@ describe PDK::Module::Update do
 
     context 'when the default_template_ref specifies a branch head' do
       before(:each) do
-        allow(PDK::Util).to receive(:default_template_ref).and_return('master')
+        allow(PDK::Util).to receive(:default_template_ref).and_return('main')
         allow(PDK::Util::Git).to receive(:ls_remote)
           .with(template_url, 'main')
           .and_return('3cdd84e8f0aae30bf40d15556482fc8752899312')
       end
 
       include_context 'with mock metadata'
-      let(:template_ref) { 'master-0-g07678c8' }
+      let(:template_ref) { 'main-0-g07678c8' }
 
       it 'returns the branch name and the commit SHA' do
         is_expected.to eq('main@3cdd84e')

--- a/spec/unit/pdk/util/git_spec.rb
+++ b/spec/unit/pdk/util/git_spec.rb
@@ -120,7 +120,7 @@ describe PDK::Util::Git do
     subject { described_class.ls_remote(repo, ref) }
 
     let(:repo) { 'https://github.com/puppetlabs/pdk-templates' }
-    let(:ref) { 'master' }
+    let(:ref) { 'main' }
 
     before(:each) do
       allow(described_class).to receive(:git).with('ls-remote', '--refs', repo, ref).and_return(git_result)
@@ -150,14 +150,14 @@ describe PDK::Util::Git do
         {
           exit_code: 0,
           stdout:    [
-            "master-sha\trefs/heads/master",
-            "masterful-sha\trefs/heads/masterful",
+            "main-sha\trefs/heads/main",
+            "mainful-sha\trefs/heads/mainful",
           ].join("\n"),
         }
       end
 
       it 'returns only the SHA for the exact ref match' do
-        is_expected.to eq('master-sha')
+        is_expected.to eq('main-sha')
       end
     end
   end

--- a/spec/unit/pdk/util/template_uri_spec.rb
+++ b/spec/unit/pdk/util/template_uri_spec.rb
@@ -331,7 +331,7 @@ describe PDK::Util::TemplateURI do
       context 'not in development mode' do
         let(:development_mode) { false }
 
-        it 'returns master' do
+        it 'returns main' do
           is_expected.to eq('main')
         end
       end
@@ -351,7 +351,7 @@ describe PDK::Util::TemplateURI do
       context 'in development mode' do
         let(:development_mode) { true }
 
-        it 'returns master' do
+        it 'returns main' do
           is_expected.to eq('main')
         end
       end
@@ -371,7 +371,7 @@ describe PDK::Util::TemplateURI do
       context 'in development mode' do
         let(:development_mode) { true }
 
-        it 'returns master' do
+        it 'returns main' do
           is_expected.to eq('main')
         end
       end


### PR DESCRIPTION
Removal of any offensive or inappropriate terminology from the code base.
Update `license_finder` gem so that `whitelist` can be replaced with `:permit`
Update the running of spec tests on Appveyor; stop running on Ruby 2.1/2.3 and start running on ruby 2.5