### PR TITLE
(MAINT) Require Ruby >= 2.5.0 in gemspec and simplify Gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ jobs:
     - rvm: 2.5
       env: CHECK=license_finder
       bundler_args: "--with development" # license_finder requires all gems installed. Also can't use an empty string so just include any bundler group
-    - rvm: 2.4
-      env: CHECK=spec
     - rvm: 2.5
       env: CHECK=spec
     - rvm: 2.7

--- a/Gemfile
+++ b/Gemfile
@@ -3,35 +3,13 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in pdk.gemspec
 gemspec
 
-if RUBY_VERSION < '2.3.0'
-  # avoid newer versions that do not support ruby 2.1 anymore
-  gem 'cri', '>= 2.10.1', '< 2.11.0'
-  gem 'ffi', '1.9.25'
-  gem 'nokogiri', '1.7.2'
-else
-  gem 'nokogiri', '~> 1.10.8'
-end
+gem 'nokogiri', '~> 1.10.8'
 
 group :development do
   gem 'activesupport', '4.2.9'
   gem 'github_changelog_generator', '~> 1.14'
-  if RUBY_VERSION < '2.2.0'
-    # pry-byebug >= 3.5.0 requires ruby 2.2.0 or newer
-    gem 'pry-byebug', '~> 3.4.0'
-    # byebug >= 9.1.0 requires ruby 2.2.0 or newer
-    gem 'byebug', '~> 9.0.6'
-    # required for github_changelog_generator
-    gem 'rack', '~> 1.0'
-  elsif RUBY_VERSION < '2.4.0'
-    # pry-byebug >= 3.8.0 requires ruby 2.4.0 or newer
-    gem 'pry-byebug', '~> 3.7.0'
-    # byebug >= 11.1.0 requires ruby 2.4.0 or newer
-    gem 'byebug', '~> 11.0.1'
-  else
-    gem 'pry-byebug', '~> 3.4'
-  end
-  # ruby-prof >= 1.0 requires Ruby 2.4.0 or newer
-  gem 'ruby-prof' if RUBY_VERSION >= '2.4.0'
+  gem 'pry-byebug', '~> 3.4'
+  gem 'ruby-prof'
   gem 'yard'
 end
 
@@ -39,13 +17,9 @@ group :test do
   gem 'coveralls'
   gem 'json', '~> 2.2.0'
   gem 'license_finder', '~> 6.1.2'
-  if RUBY_VERSION < '2.4'
-    # license_finder depends on rubyzip which requires Ruby 2.4 in 2.x
-    gem 'rubyzip', '< 2.0.0'
-  end
   gem 'parallel', '= 1.13.0'
   gem 'parallel_tests', '~> 2.24.0'
-  gem 'parser', '~> 2.5.1.2'
+  gem 'parser', '~> 2.7.1'
   gem 'rake', '~> 12.3', '>= 12.3.3'
   gem 'rspec', '~> 3.0'
   gem 'rspec-xsd'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,11 +17,13 @@ environment:
       SUITES: "acceptance:local_parallel"
       BUNDLE_JOBS: 4
       UPDATE_BUNDLER: true
-    - RUBY_VERSION: 24-x64
+    - RUBY_VERSION: 27-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       USE_MSYS: true
       SUITES: "spec"
       BUNDLE_JOBS: 1
-    - RUBY_VERSION: 24-x64
+    - RUBY_VERSION: 27-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       USE_MSYS: true
       SUITES: "test_pdk_as_library"
       BUNDLE_JOBS: 1

--- a/lib/pdk/tests/unit.rb
+++ b/lib/pdk/tests/unit.rb
@@ -183,6 +183,8 @@ module PDK
       end
 
       def self.merge_json_results(json_data)
+        require 'set'
+
         merged_json_result = {}
 
         # Merge messages

--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.1.9'
+  spec.required_ruby_version = '>= 2.5.0' # rubocop:disable Gemspec/RequiredRubyVersion
 
   spec.add_runtime_dependency 'bundler', '>= 1.15.0', '< 3.0.0'
   spec.add_runtime_dependency 'childprocess', '~> 0.7.1'

--- a/spec/unit/pdk/module/convert_spec.rb
+++ b/spec/unit/pdk/module/convert_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'set'
 require 'pdk/module/convert'
 
 describe PDK::Module::Convert do


### PR DESCRIPTION
I have a separate branch that modernizes Rubocop and fixes all the failures but that is too big/risky this close to release, will open that after we have tagged.