### PR TITLE
(GH-958) Add Spec tests for Ruby 2.5, 2.7 on Github Actions

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,0 +1,63 @@
+name: "Static, Spec & License Tests"
+
+on: [pull_request]
+
+jobs:
+  StaticAndSpecTests:
+    name: "Static & Spec Tests (Ruby ${{ matrix.ruby_version }})"
+    env:
+      BUNDLE_JOBS: 4
+      BUNDLE_WITHOUT: "development"
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ['2.5', '2.7']
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v2
+
+    - name: "Activate Ruby ${{ matrix.ruby_version }}"
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby_version }}
+        bundler-cache: true
+
+    - name: Rubocop
+      run: bundle exec rake rubocop
+
+    - name: 'Spec:Coverage'
+      run: bundle exec rake spec:coverage
+
+    - name: 'Test PDK as Library'
+      run: bundle exec rake test_pdk_as_library
+
+    - name: 'Upload CodeCov Report'
+      uses: codecov/codecov-action@v1
+      with:
+        directory: coverage
+        fail_ci_if_error: true
+
+  LicenseFinder:
+    name: "License Finder (Ruby ${{ matrix.ruby_version }})"
+    env:
+      BUNDLE_JOBS: 4
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ['2.5', '2.7']
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v2
+
+    - name: "Activate Ruby ${{ matrix.ruby_version }}"
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby_version }}
+        bundler-cache: true
+
+    - name: 'License Finder'
+      run: bundle exec rake license_finder 

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :development do
 end
 
 group :test do
-  gem 'coveralls'
+  gem 'codecov'
   gem 'json', '~> 2.2.0'
   gem 'license_finder', '~> 6.1.2'
   gem 'parallel', '= 1.13.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,12 @@
 if ENV['COVERAGE'] == 'yes'
-  require 'coveralls'
+  require 'codecov'
   require 'simplecov'
   require 'simplecov-console'
 
   SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,
     SimpleCov::Formatter::Console,
-    Coveralls::SimpleCov::Formatter,
+    SimpleCov::Formatter::Codecov,
   ]
   SimpleCov.start do
     track_files 'lib/**/*.rb'


### PR DESCRIPTION
This PR adds the following test / coverage suites to a
Github Actions workflow on both Ruby 2.5 and 2.7:

- `rubocop`
- `spec:coverage`
- `license_finder`
- `test_pdk_as_library`
- `spec`

Closes: #958 