### PR TITLE
(MAINT) Remove 'Feature Request' issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve the PDK
+title: ''
 labels: bug, needs-triage
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,0 @@
----
-name: Feature request
-about: Feature request issues should be opened on the https://github.com/puppetlabs/pdk-planning
-  repository instead of on this repo
-
----
-
-**Feature request issues should be opened on the [pdk-planning](https://github.com/puppetlabs/pdk-planning) repository instead of on this repo.**


### PR DESCRIPTION
We are moving feature requests to Discussions and therefore should remove the ability to raise features directly against the repo, bypassing the Discussions route.