### PR TITLE
(MAINT) Mock PDK::Util::Env.fetch resp for util_spec.rb:292

### DIFF
--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -292,11 +292,14 @@ describe PDK::Util do
     context 'when running on a POSIX host' do
       before(:each) do
         allow(Gem).to receive(:win_platform?).and_return(false)
-        allow(Dir).to receive(:home).and_return('/home/test')
+        allow(Dir).to receive(:home).with(any_args).and_return('/home/test')
+        allow(PDK::Util::Env).to receive(:fetch)
+          .with('XDG_CONFIG_HOME', '/home/test/.config')
+          .and_return('/xdg_home/test/.config')
       end
 
       it 'returns a path inside the users .config directory' do
-        is_expected.to eq(File.join('/home/test', '.config', 'pdk'))
+        is_expected.to eq('/xdg_home/test/.config/pdk')
       end
     end
   end


### PR DESCRIPTION
Prior to this commit, when running this test in the context of a
Github Actions runner, due to the `XDG_CONFIG_HOME` being set,
the PDK::Util::Env.fetch method was returning the value of this
ENV var, given it was set and did not need to return the fallback
value (2nd arg).

This commit now mocks the return PDK::Util::Env.fetch so it is
consistent whether `XDG_CONFIG_HOME` is set or not.