### PR TITLE
(SPIKE) - Pin `childprocess` to 4.0.0

### DIFF
--- a/lib/pdk/cli/exec/command.rb
+++ b/lib/pdk/cli/exec/command.rb
@@ -27,7 +27,7 @@ module PDK
           @argv = argv
 
           @process = ChildProcess.build(*@argv)
-          @process.leader = true
+          # @process.leader = true
 
           @stdout = Tempfile.new('stdout', mode: TEMPFILE_MODE).tap { |io| io.sync = true }
           @stderr = Tempfile.new('stderr', mode: TEMPFILE_MODE).tap { |io| io.sync = true }

--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4.0' # rubocop:disable Gemspec/RequiredRubyVersion
 
   spec.add_runtime_dependency 'bundler', '>= 1.15.0', '< 3.0.0'
-  spec.add_runtime_dependency 'childprocess', '~> 0.7.1'
+  spec.add_runtime_dependency 'childprocess', '~> 4.0.0'
   spec.add_runtime_dependency 'cri', '~> 2.10'
   spec.add_runtime_dependency 'diff-lcs', '1.3'
   spec.add_runtime_dependency 'ffi', '>= 1.9.25', '< 2.0.0'


### PR DESCRIPTION
Prior to this commit when attempting to spin up a child process from inside the pdk in a github actions runner a launch error is raised  due to a bug in child process. This commit raises the pin to v4.0.0 which includes the patch for this bug.