### PR TITLE
(GH-1083) Bump childprocess to '~> 4.0.0'; Disable @process.leader

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -20,12 +20,12 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4.0' # rubocop:disable Gemspec/RequiredRubyVersion
 
   spec.add_runtime_dependency 'bundler', '>= 1.15.0', '< 3.0.0'
-  spec.add_runtime_dependency 'childprocess', '~> 0.7.1'
+  spec.add_runtime_dependency 'childprocess', '~> 4.0.0'
   spec.add_runtime_dependency 'cri', '~> 2.10'
   spec.add_runtime_dependency 'diff-lcs', '1.3'
   spec.add_runtime_dependency 'ffi', '>= 1.9.25', '< 2.0.0'
   spec.add_runtime_dependency 'gettext-setup', '~> 0.24'
-  spec.add_runtime_dependency 'hitimes', '1.3.0'
+  spec.add_runtime_dependency 'hitimes', '2.0.0'
   spec.add_runtime_dependency 'json-schema', '2.8.0'
   spec.add_runtime_dependency 'json_pure', '~> 2.1.0'
   spec.add_runtime_dependency 'minitar', '~> 0.6'


### PR DESCRIPTION
Prior to this commit, it was observed on Windows Server 2016, 2019
Github Actions instances that invoking the pdk would result in
ACCESS_DENIED errors.

When the ChildProcess.leader parameter is set to true, it will set
the `CREATE_BREAKAWAY_FROM_JOB` and `JOB_OBJECT_LIMIT_BREAKAWAY_OK`
flags in the Win32. This is not required in Windows > Server 2008 / 7
and can potentially cause issues when Task Scheduler attempts to
schedule a job that invokes a program with insufficient privileges.

This commit also bumps `childprocess` to `~> 4.0.0` and `hitimes`
to `2.0.0` to resolve dependency issues after bumping `childprocess`

Closes: #1083 