### PR TITLE
(PDK-1085) Fail gracefully when no unit tests available

### DIFF
--- a/lib/pdk/util/json_finder.rb
+++ b/lib/pdk/util/json_finder.rb
@@ -39,6 +39,7 @@ module PDK
                                end
         end
 
+        return [] if @objects.nil?
         @objects = @objects.compact
       end
 


### PR DESCRIPTION
Avoids throwing when `--parallel` and `--format` are used together and there are no unit tests available
