### PR TITLE
(PDK-1085) Fail gracefully when no unit tests available

### DIFF
--- a/lib/pdk/util/json_finder.rb
+++ b/lib/pdk/util/json_finder.rb
@@ -39,6 +39,7 @@ module PDK
                                end
         end
 
+        return [] if @objects.nil?
         @objects = @objects.compact
       end
 

--- a/spec/acceptance/test_unit_spec.rb
+++ b/spec/acceptance/test_unit_spec.rb
@@ -35,6 +35,12 @@ describe 'pdk test unit', module_command: true do
       its(:stderr) { is_expected.to match(%r{No files for parallel_spec to run against}i) }
     end
 
+    describe command('pdk test unit --parallel --format=text:test_output.txt') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stderr) { is_expected.to match(%r{preparing to run the unit tests}i) }
+      its(:stderr) { is_expected.to match(%r{No examples found}i) }
+    end
+
     context 'with passing tests' do
       # FIXME: facterversion pin and facterdb issues
       include_context 'with spec file', 'passing_spec.rb', <<-EOF


### PR DESCRIPTION
Avoids throwing when `--parallel` and `--format` are used together and there are no unit tests available

Closes: #1085 