### PR TITLE
(GH-1118) Add ability to skip validating files

### DIFF
--- a/docs/pdk_testing.md
+++ b/docs/pdk_testing.md
@@ -125,6 +125,25 @@ send your validation output to a file in either JUnit or text format.
     command [reference](pdk_reference.md#).
 
 
+### Ignoring files during module validation
+
+There are times when certain files can be ignored when validating the contents of a Puppet module. PDK provides a configuration option to list sets of files to ignore when running any of the validators.
+
+To configure PDK to ignore a file, use `pdk set config project.validate.ignore`.
+The `project.validate.ignore` setting accepts multiple files. To add one or more files, run the command for each file or pattern you want to add.
+
+For example, to ignore a file called `example.yaml` in the folder called `config`, you would run the following command:
+
+```
+pdk set config project.validate.ignore "config/example.yaml"
+```
+
+To add a wildcard, use a valid [Git ignore pattern](http://git-scm.com/docs/gitignore):
+
+```
+pdk set config project.validate.ignore "config/*.yaml"
+```
+
 ## Unit testing modules
 
 Create and run unit tests to verify that your Puppet code compiles on supported
@@ -211,4 +230,3 @@ correctly performs the functions you expect it to.
 PDK reports what Ruby and Puppet versions it is testing against, and after tests
 are completed, test results. For a complete list of command options and usage
 information, see the PDK command [reference](pdk_reference.md#).
-

--- a/lib/pdk/config.rb
+++ b/lib/pdk/config.rb
@@ -94,6 +94,12 @@ module PDK
         if context.is_a?(PDK::Context::ControlRepo)
           mount :environment, PDK::ControlRepo.environment_conf_as_config(File.join(context.root_path, 'environment.conf'))
         end
+
+        mount :validate, PDK::Config::YAML.new('validate', file: File.join(context.root_path, 'pdk.yaml'), persistent_defaults: true) do
+          setting 'ignore' do
+            default_to { [] }
+          end
+        end
       end
     end
 

--- a/lib/pdk/validate/invokable_validator.rb
+++ b/lib/pdk/validate/invokable_validator.rb
@@ -213,6 +213,14 @@ module PDK
           end
         end
 
+        # block will always be [] because it is intialized in config
+        ignore_files = PDK.config.get_within_scopes('validate.ignore')
+        unless ignore_files.nil? || ignore_files.empty?
+          Array(ignore_files).each do |pattern|
+            ignore_pathspec.add(pattern)
+          end
+        end
+
         ignore_pathspec
       end
     end

--- a/spec/unit/pdk/config_spec.rb
+++ b/spec/unit/pdk/config_spec.rb
@@ -17,6 +17,7 @@ describe PDK::Config do
   end
 
   before(:each) do
+    allow(PDK::Util::Filesystem).to receive(:file?).with(%r{pdk\.yaml}).and_call_original
     # Allow the JSON Schema documents to actually be read. Rspec matchers are LIFO
     allow(PDK::Util::Filesystem).to receive(:file?).with(%r{_schema\.json}).and_call_original
   end


### PR DESCRIPTION
This introduces a project level setting for a list of ignored files or patterns for the pdk validate command. Discussion: https://github.com/puppetlabs/pdk/discussions/1066


```
# New directory with malformed yaml files
❯ ls foo | select name

Name
----
foo.yaml
wakka.yaml

# rando malformed yaml in working directory
❯ ls *.yaml  | select name

Name
----
hiera.yaml
outside.yaml

# add a wildcard for the foo directory to the ignore list
❯ pdk set config project.validate.ignore "'foo/*.yaml'"
pdk (INFO): Added new value 'foo/*.yaml' to 'project.pdk_validate.ignore'
project.pdk_validate.ignore=["foo/*.yaml"]

# run validate which ignores anything in foo, but validates outside.yaml
❯ pdk validate yaml
pdk (INFO): Using Ruby 2.7.3
pdk (INFO): Using Puppet 7.7.0
+ [X] Running yaml validators ...
|__ [X] Checking YAML syntax (**/*.yaml **/*.yml).
pdk (ERROR): yaml-syntax: Unsupported class: Tried to load unspecified class: Date (outside.yaml)
```

Closes #1118 and #1117 