### PR TITLE
(GH-1113) (GH-917) Fix forge-token handling

### DIFF
--- a/lib/pdk/cli/release.rb
+++ b/lib/pdk/cli/release.rb
@@ -146,6 +146,7 @@ module PDK::CLI
         opts[:'skip-changelog'] = !answers['changelog']
         opts[:'skip-dependency'] = !answers['dependency']
         opts[:'skip-documentation'] = !answers['documentation']
+        opts[:'skip-publish'] = !answers['publish']
 
         prepare_version_interview(prompt, opts) if answers['setversion']
 

--- a/lib/pdk/cli/release.rb
+++ b/lib/pdk/cli/release.rb
@@ -22,7 +22,8 @@ module PDK::CLI
     option nil, :'forge-upload-url', _('Set forge upload url path.'),
            argument: :required, default: 'https://forgeapi.puppetlabs.com/v3/releases'
 
-    option nil, :'forge-token', _('Set Forge API token.'), default: nil
+    option nil, :'forge-token', _('Set Forge API token.'),
+           argument: :optional
 
     option nil, :version, _('Update the module to the specified version prior to release. When not specified, the new version will be computed from the Changelog where possible.'),
            argument: :required

--- a/spec/unit/pdk/cli/release_spec.rb
+++ b/spec/unit/pdk/cli/release_spec.rb
@@ -34,6 +34,15 @@ describe 'PDK::CLI release' do
       allow(PDK::Util).to receive(:exit_process).and_raise('exit_process mock should not be called')
     end
 
+    it 'calls PDK::Module::Release.new with the correct opts' do
+      expect(PDK::Module::Release).to receive(:new).with(Object, hash_including(
+                                                                   :'forge-token' => 'cli123',
+                                                                   :force => true,
+                                                                   :'forge-upload-url' => 'https://example.com',
+                                                                 ))
+      PDK::CLI.run(%w[release --forge-token=cli123 --force --forge-upload-url=https://example.com])
+    end
+
     it 'calls PDK::Module::Release.run' do
       expect(release_object).to receive(:run).and_return(nil)
 


### PR DESCRIPTION
This PR contains two fixes:

## (GH-1113) Fix incorrect opt type for `forge-token`

Prior to this fix, the `forge-token` option defined in the PDK::CLI's
`release` subcommand did not have the `argument:` attribute set.
This meant that the underlying Cri lib treated it as a boolean option
and the forge token value was set to `true` and passed to the
`PDK::Module::Release` object.

This fix sets the `argument:` attribute with the value `:required`,
which emulates the way it is set in the `publish` subcommand.

Closes: #1113

------------------

## (GH-917) Fix incorrect 'Missing forge-token' error throwing

Prior to this fix, the `forge-token` option defined in the PDK::CLI's
`release` subcommand did not have the `argument:` attribute set.
This meant that the underlying Cri lib treated it as a boolean option
and the forge token value was set to `true` and passed to the
`PDK::Module::Release` object.

This fix sets the `argument:` attribute with the value `:optional`,
which allows it to be optional but treated as an arg that needs the
value extracted after `=`

Resolves: #917 