### PR TITLE
(GH-1128) Fix package-testing issues in PDK

### DIFF
--- a/package-testing/Gemfile
+++ b/package-testing/Gemfile
@@ -1,21 +1,24 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-def location_for(place, fake_version = nil)
-  if place =~ %r{^(git:[^#]*)#(.*)}
-    [fake_version, { git: Regexp.last_match(1), branch: Regexp.last_match(2), require: false }].compact
-  elsif place =~ %r{^file:\/\/(.*)}
-    ['>= 0', { path: File.expand_path(Regexp.last_match(1)), require: false }]
+def location_for(place_or_version, fake_version = nil)
+  git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
+  file_url_regex = %r{\Afile:\/\/(?<path>.*)}
+
+  if place_or_version && (git_url = place_or_version.match(git_url_regex))
+    [fake_version, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
+  elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
+    ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
   else
-    [place, { require: false }]
+    [place_or_version, { require: false }]
   end
 end
 
-gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '= 4.10.0')
-gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.7.0')
+gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || 'https://github.com/voxpupuli/beaker.git#master')
+gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.9.0')
 gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '= 1.5.0')
-gem 'beaker-puppet', '= 1.18.5'
-gem 'beaker-rspec', '= 6.2.4'
-gem 'beaker-vmpooler', '= 1.3.3'
+gem 'beaker-puppet', '= 1.21.0'
+gem 'beaker-rspec', '= 6.3.0'
+gem 'beaker-vmpooler', '= 1.4.0'
 gem 'i18n', '= 1.4.0' # pin for Ruby 2.1 support
 gem 'nokogiri', '~> 1.10.8'
 gem 'rake', '~> 12.3', '>= 12.3.3'

--- a/package-testing/Rakefile
+++ b/package-testing/Rakefile
@@ -48,7 +48,7 @@ namespace :acceptance do
       if ENV['LOCAL_PKG']
         $stderr.puts "SUITE_VERSION has not been set. Trying to determine it from the filename: '#{ENV['LOCAL_PKG']}'"
 
-        ENV['SUITE_VERSION'] = %r{^pdk[-_](\d+\.\d+\.\d+\.\d+(\.\d+\.g[a-f\d]+)?)}.match(File.basename(ENV['LOCAL_PKG']))[1]
+        ENV['SUITE_VERSION'] = %r{^pdk[-_](\d+\.\d+\.\d+\.\d+(.pre\d?)?(\.\d+\.g[a-f\d]+)?)}.match(File.basename(ENV['LOCAL_PKG'], '.dmg'))[1]
 
         unless ENV['SUITE_VERSION']
           abort "Could not find a valid SUITE_VERSION in the filename: '#{ENV['LOCAL_PKG']}'"

--- a/package-testing/spec/package/support/install_pdk.rb
+++ b/package-testing/spec/package/support/install_pdk.rb
@@ -28,8 +28,13 @@ module PackageHelpers
     package = File.basename(ENV['LOCAL_PKG'])
     scp_to(host, ENV['LOCAL_PKG'], package)
 
-    if host.platform =~ %r{windows}
+    case host.platform
+    when %r{windows}
       generic_install_msi_on(host, package)
+    when %r{osx}
+      package_volume_name = "pdk-#{ENV['SUITE_VERSION']}"
+      package_filename = "pdk-#{ENV['SUITE_VERSION']}-1-installer.pkg"
+      host.generic_install_dmg(package, package_volume_name, package_filename)
     else
       host.install_local_package(package)
     end

--- a/package-testing/spec/package/support/install_pdk.rb
+++ b/package-testing/spec/package/support/install_pdk.rb
@@ -62,7 +62,7 @@ module PackageHelpers
       url += "windows/pdk-#{ENV['SUITE_VERSION']}-x64.msi"
     when %r{osx}
       version, arch = platform.split('-')[1, 2]
-      url += "osx/#{version}/puppet5/#{arch}/pdk-#{ENV['SUITE_VERSION']}-1.osx#{version}.dmg"
+      url += "osx/#{version}/#{arch}/pdk-#{ENV['SUITE_VERSION']}-1.osx#{version}.dmg"
     else
       raise ArgumentError, "unknown platform #{platform}"
     end

--- a/package-testing/spec/package/support/spec_utils.rb
+++ b/package-testing/spec/package/support/spec_utils.rb
@@ -15,12 +15,7 @@ module SpecUtils
     if windows_node?
       cygpath ? '/home/Administrator' : 'c:/cygwin64/home/Administrator'
     else
-      case get_working_node.platform
-      when %r{\Aosx-10\.15-}
-        '/var/root'
-      else
-        '/root'
-      end
+      get_working_node.external_copy_base
     end
   end
 

--- a/package-testing/spec/package/version_selection_spec.rb
+++ b/package-testing/spec/package/version_selection_spec.rb
@@ -3,10 +3,12 @@ require 'spec_helper_package'
 describe 'Test puppet & ruby version selection' do
   module_name = 'version_selection'
   test_cases = [
+    { envvar: 'PDK_PUPPET_VERSION', version: '5.5.0', expected_puppet: '5.5', expected_ruby: '2.4' },
     { envvar: 'PDK_PUPPET_VERSION', version: '6.21.0', expected_puppet: '6.21', expected_ruby: '2.5.9' },
     { envvar: 'PDK_PUPPET_VERSION', version: '6.23.0', expected_puppet: '6.23', expected_ruby: '2.5.9' },
     { envvar: 'PDK_PUPPET_VERSION', version: '7.4.1', expected_puppet: '7.4', expected_ruby: '2.7.3' },
     { envvar: 'PDK_PUPPET_VERSION', version: '7.8.0', expected_puppet: '7.8', expected_ruby: '2.7.3' },
+    { envvar: 'PDK_PE_VERSION', version: '2018.1', expected_puppet: '5.5', expected_ruby: '2.4' },
     { envvar: 'PDK_PE_VERSION', version: '2019.8.7', expected_puppet: '6.23', expected_ruby: '2.5.9' },
     { envvar: 'PDK_PE_VERSION', version: '2021.1', expected_puppet: '7.6', expected_ruby: '2.7.3' },
     { envvar: 'PDK_PE_VERSION', version: '2021.2', expected_puppet: '7.8', expected_ruby: '2.7.3' },

--- a/package-testing/spec/package/version_selection_spec.rb
+++ b/package-testing/spec/package/version_selection_spec.rb
@@ -3,8 +3,13 @@ require 'spec_helper_package'
 describe 'Test puppet & ruby version selection' do
   module_name = 'version_selection'
   test_cases = [
-    { envvar: 'PDK_PUPPET_VERSION', version: '5.5.0', expected_puppet: '5.5', expected_ruby: '2.4' },
-    { envvar: 'PDK_PE_VERSION', version: '2018.1', expected_puppet: '5.5', expected_ruby: '2.4' },
+    { envvar: 'PDK_PUPPET_VERSION', version: '6.21.0', expected_puppet: '6.21', expected_ruby: '2.5.9' },
+    { envvar: 'PDK_PUPPET_VERSION', version: '6.23.0', expected_puppet: '6.23', expected_ruby: '2.5.9' },
+    { envvar: 'PDK_PUPPET_VERSION', version: '7.4.1', expected_puppet: '7.4', expected_ruby: '2.7.3' },
+    { envvar: 'PDK_PUPPET_VERSION', version: '7.8.0', expected_puppet: '7.8', expected_ruby: '2.7.3' },
+    { envvar: 'PDK_PE_VERSION', version: '2019.8.7', expected_puppet: '6.23', expected_ruby: '2.5.9' },
+    { envvar: 'PDK_PE_VERSION', version: '2021.1', expected_puppet: '7.6', expected_ruby: '2.7.3' },
+    { envvar: 'PDK_PE_VERSION', version: '2021.2', expected_puppet: '7.8', expected_ruby: '2.7.3' },
   ]
 
   before(:all) do


### PR DESCRIPTION
These PRs came about after the introduction of new platforms and changes to packaging. 

These support the testing of built packages on the various systems both from local machine and in CI. Without these updates we are unable to verify the packaging changes being made within Vanagon or PDK-runtime.