### PR TITLE
WIP: Add Puppet plan validator

### DIFF
--- a/lib/pdk/validate.rb
+++ b/lib/pdk/validate.rb
@@ -23,6 +23,7 @@ module PDK
       autoload :PuppetEPPValidator, 'pdk/validate/puppet/puppet_epp_validator'
       autoload :PuppetLintValidator, 'pdk/validate/puppet/puppet_lint_validator'
       autoload :PuppetSyntaxValidator, 'pdk/validate/puppet/puppet_syntax_validator'
+      autoload :PuppetPlanSyntaxValidator, 'pdk/validate/puppet/puppet_plan_syntax_validator'
       autoload :PuppetValidatorGroup, 'pdk/validate/puppet/puppet_validator_group'
     end
 

--- a/lib/pdk/validate/puppet/puppet_plan_syntax_validator.rb
+++ b/lib/pdk/validate/puppet/puppet_plan_syntax_validator.rb
@@ -1,0 +1,54 @@
+require 'pdk'
+
+module PDK
+  module Validate
+    module Puppet
+      class PuppetPlanSyntaxValidator < PuppetSyntaxValidator
+        def name
+          'puppet-syntax-plan'
+        end
+
+        def pattern
+          contextual_pattern('plans/**/*.pp')
+        end
+
+        def pattern_ignore
+        end
+
+        def spinner_text_for_targets(_targets)
+          _('Checking Puppet plan syntax (%{pattern}).') % { pattern: pattern.join(' ') }
+        end
+
+        def parse_options(targets)
+          # Due to PDK-1266 we need to run `puppet parser validate` with an empty
+          # modulepath. On *nix, Ruby treats `/dev/null` as an empty directory
+          # however it doesn't do so with `NUL` on Windows. The workaround for
+          # this to ensure consistent behaviour is to create an empty temporary
+          # directory and use that as the modulepath.
+          ['parser', 'validate', '--tasks', '--config', null_file, '--modulepath', validate_tmpdir].concat(targets)
+        end
+
+        def invoke(report)
+          super
+        ensure
+          remove_validate_tmpdir
+        end
+
+        def validate_tmpdir
+          require 'tmpdir'
+
+          @validate_tmpdir ||= Dir.mktmpdir('puppet-parser-validate-plan')
+        end
+
+        def remove_validate_tmpdir
+          return unless @validate_tmpdir
+          return unless PDK::Util::Filesystem.directory?(@validate_tmpdir)
+
+          PDK::Util::Filesystem.remove_entry_secure(@validate_tmpdir)
+          @validate_tmpdir = nil
+        end
+
+      end
+    end
+  end
+end

--- a/lib/pdk/validate/puppet/puppet_validator_group.rb
+++ b/lib/pdk/validate/puppet/puppet_validator_group.rb
@@ -11,6 +11,7 @@ module PDK
         def validators
           [
             PuppetSyntaxValidator,
+            PuppetPlanSyntaxValidator,
             PuppetLintValidator,
             PuppetEPPValidator,
           ].freeze


### PR DESCRIPTION
Currently Puppet plans are silently ignored in `pdk validate`. As a Bolt user I'd like to check Bolt plan syntax before trying to apply it.

This is somehow related to https://tickets.puppetlabs.com/browse/PDK-1194