### PR TITLE
(PDK-1758) supplement `in_module_root` with check for `metadata.json`

### DIFF
--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -187,7 +187,8 @@ module PDK
     # @return [boolean] True if any folders from MODULE_FOLDERS are found in the current dir,
     #   false otherwise.
     def in_module_root?(path = Dir.pwd)
-      PDK::Util::MODULE_FOLDERS.any? { |dir| PDK::Util::Filesystem.directory?(File.join(path, dir)) }
+      PDK::Util::MODULE_FOLDERS.any? { |dir| PDK::Util::Filesystem.directory?(File.join(path, dir)) } ||
+        PDK::Util::Filesystem.file?(File.join(path, 'metadata.json'))
     end
     module_function :in_module_root?
 

--- a/spec/unit/pdk/util_spec.rb
+++ b/spec/unit/pdk/util_spec.rb
@@ -455,6 +455,11 @@ describe PDK::Util do
       end
     end
 
+    it 'detects metadata.json within the folder and determines that it is the root of a module' do
+      allow(PDK::Util::Filesystem).to receive(:file?).with(File.join(test_path, 'metadata.json')).and_return(true)
+      expect(described_class.in_module_root?(test_path)).to eq(true)
+    end
+
     it 'uses the current directory if a directory is not specified' do
       expect(PDK::Util::Filesystem).to receive(:directory?) { |path| expect(path).to start_with(Dir.pwd) }.at_least(:once)
       described_class.in_module_root?


### PR DESCRIPTION
Prior to this change the `in_module_root` function looked only for specific folders within the project to determine if it was at the root. 
This check supplements it with a check to see if `metadata.json` is present enabling  modules that only contain `/files` without looking for such a common folder name.
