### PR TITLE
Update plan exception in puppet_syntax_validator.rb

### DIFF
--- a/lib/pdk/validate/puppet/puppet_syntax_validator.rb
+++ b/lib/pdk/validate/puppet/puppet_syntax_validator.rb
@@ -37,7 +37,7 @@ module PDK
         end
 
         def pattern_ignore
-          contextual_pattern('plans/**/*.pp')
+          contextual_pattern('**/plans/**/*.pp')
         end
 
         def spinner_text_for_targets(_targets)

--- a/spec/unit/pdk/validate/invokable_validator_spec.rb
+++ b/spec/unit/pdk/validate/invokable_validator_spec.rb
@@ -382,7 +382,7 @@ CONTENTS
 
       it 'does not match the ignored files' do
         expect(target_files[0].count).to eq(4)
-        expect(target_files[0]).to eq(['manifests/init.pp', 'plans/foo.pp', 'plans/fine.yaml', 'plans/nested/thing.pp', 'nested/plans/nested/thing.pp', 'nested/nested/plans/nested/thing.pp'] )
+        expect(target_files[0]).to eq(['manifests/init.pp', 'plans/foo.pp', 'plans/fine.yaml', 'plans/nested/thing.pp', 'nested/plans/nested/thing.pp', 'nested/nested/plans/nested/thing.pp'])
       end
     end
   end

--- a/spec/unit/pdk/validate/invokable_validator_spec.rb
+++ b/spec/unit/pdk/validate/invokable_validator_spec.rb
@@ -381,7 +381,7 @@ CONTENTS
       end
 
       it 'does not match the ignored files' do
-        expect(target_files[0].count).to eq(4)
+        expect(target_files[0].count).to eq(6)
         expect(target_files[0]).to eq(['manifests/init.pp', 'plans/foo.pp', 'plans/fine.yaml', 'plans/nested/thing.pp', 'nested/plans/nested/thing.pp', 'nested/nested/plans/nested/thing.pp'])
       end
     end

--- a/spec/unit/pdk/validate/invokable_validator_spec.rb
+++ b/spec/unit/pdk/validate/invokable_validator_spec.rb
@@ -321,7 +321,7 @@ describe PDK::Validate::InvokableValidator do
 
     context 'when specifying an ignore pattern' do
       before(:each) do
-        allow(validator).to receive(:pattern_ignore).and_return('/plans/**/**.pp')
+        allow(validator).to receive(:pattern_ignore).and_return('**/plans/**/**.pp')
 
         allow(PDK::Util::Filesystem).to receive(:directory?).and_return(true)
         allow(PDK::Util::Filesystem).to receive(:glob).with(glob_pattern, anything).and_return(globbed_files)
@@ -335,6 +335,8 @@ describe PDK::Validate::InvokableValidator do
           File.join('manifests', 'init.pp'),
           File.join('plans', 'foo.pp'),
           File.join('plans', 'nested', 'thing.pp'),
+          File.join('nested', 'plans', 'nested', 'thing.pp'),
+          File.join('nested', 'nested', 'plans', 'nested', 'thing.pp'),
         ]
       end
       let(:globbed_files) { files.map { |file| File.join(context_root, file) } }
@@ -364,6 +366,8 @@ describe PDK::Validate::InvokableValidator do
           File.join('plans', 'foo.pp'),
           File.join('plans', 'fine.yaml'),
           File.join('plans', 'nested', 'thing.pp'),
+          File.join('nested', 'plans', 'nested', 'thing.pp'),
+          File.join('nested', 'nested', 'plans', 'nested', 'thing.pp'),
         ]
       end
       let(:globbed_files) { files.map { |file| File.join(context_root, file) } }
@@ -378,7 +382,7 @@ CONTENTS
 
       it 'does not match the ignored files' do
         expect(target_files[0].count).to eq(4)
-        expect(target_files[0]).to eq(['manifests/init.pp', 'plans/foo.pp', 'plans/fine.yaml', 'plans/nested/thing.pp'])
+        expect(target_files[0]).to eq(['manifests/init.pp', 'plans/foo.pp', 'plans/fine.yaml', 'plans/nested/thing.pp', 'nested/plans/nested/thing.pp', 'nested/nested/plans/nested/thing.pp'] )
       end
     end
   end

--- a/spec/unit/pdk/validate/puppet/puppet_syntax_validator_spec.rb
+++ b/spec/unit/pdk/validate/puppet/puppet_syntax_validator_spec.rb
@@ -30,7 +30,7 @@ describe PDK::Validate::Puppet::PuppetSyntaxValidator do
 
   describe '.pattern_ignore' do
     it 'does not contextually matches plan files' do
-      expect(validator).to receive(:contextual_pattern).with('plans/**/*.pp') # rubocop:disable RSpec/SubjectStub This is fine
+      expect(validator).to receive(:contextual_pattern).with('**/plans/**/*.pp') # rubocop:disable RSpec/SubjectStub This is fine
       validator.pattern_ignore
     end
   end


### PR DESCRIPTION
This update has been requested by a customer to allow for locations of plan directories in other directory locations other than just /modulename/plans to be ignored by puppet validator