### PR TITLE
(MAINT) Test against v7

### DIFF
--- a/package-testing/spec/package/airgapped_usage_spec.rb
+++ b/package-testing/spec/package/airgapped_usage_spec.rb
@@ -27,8 +27,8 @@ describe 'Basic usage in an air-gapped environment' do
     end
 
     context 'when validating the module' do
-      context 'with puppet 6.x' do
-        puppet_version = '6.x'
+      context 'with puppet 7.x' do
+        puppet_version = '7.x'
         let(:ruby_version) { ruby_for_puppet(puppet_version) }
 
         describe command("pdk validate --puppet-version=#{puppet_version}") do

--- a/package-testing/spec/package/validate_a_new_module_spec.rb
+++ b/package-testing/spec/package/validate_a_new_module_spec.rb
@@ -17,8 +17,8 @@ describe 'C100321 - Generate a module and validate it (i.e. ensure bundle instal
   end
 
   context 'when validating the module' do
-    context 'with puppet 6.x' do
-      puppet_version = '6.x'
+    context 'with puppet 7.x' do
+      puppet_version = '7.x'
       let(:ruby_version) { ruby_for_puppet(puppet_version) }
 
       describe command("pdk validate --puppet-version=#{puppet_version}") do


### PR DESCRIPTION
All of the pipelines have been migrated to ruby 2.7.5. This was causing some tests to fail because PDK was initialising the test modules and inferring the puppet version from the current ruby version set by RVM.. at least that is what I think was happening.

There were two tests in particular that were targeting v6 explicitly. This PR bumps them to v7 which has allowed the tests to pass.