### PR TITLE
(PDK-1791) Bump PDK version

### DIFF
--- a/lib/pdk/version.rb
+++ b/lib/pdk/version.rb
@@ -1,4 +1,4 @@
 module PDK
-  VERSION = '2.5.0'.freeze
+  VERSION = '2.6.0-pre'.freeze
   TEMPLATE_REF = '2.5.0'.freeze
 end


### PR DESCRIPTION
This PR bumps the pdk version to 2.6.0-pre as per the post release guidance.