### PR TITLE
Add PDK_BUNDLE_IGNORE_CONFIG env support

### DIFF
--- a/lib/pdk/cli/exec/command.rb
+++ b/lib/pdk/cli/exec/command.rb
@@ -178,7 +178,7 @@ module PDK
 
           resolved_env.merge!(@environment.dup)
 
-          resolved_env['BUNDLE_IGNORE_CONFIG'] = '1'
+          resolved_env['BUNDLE_IGNORE_CONFIG'] = (ENV['PDK_BUNDLE_IGNORE_CONFIG'] || '1')
 
           if [:module, :pwd].include?(context)
             require 'pdk/util'


### PR DESCRIPTION
Hello,

For some context that can be useful to define specific bundle configuration for pdk.

Example: In my case I update pdk with pdk docker images and gitlab-ci, but I also add toml as optional for `:test` group:
```
Gemfile:
  optional:
    ':test':
      - gem: 'toml'
```

When I run pdk update, that create a dependency fail. I would like to ignore test group with `BUNDLE_WITHOUT`, but I can't if `BUNDLE_IGNORE_CONFIG` is define.

Regards,