### PR TITLE
(MAINT) Remove puppet 5 references in spec tests

### DIFF
--- a/lib/pdk/version.rb
+++ b/lib/pdk/version.rb
@@ -1,4 +1,4 @@
 module PDK
-  VERSION = '2.6.0-pre'.freeze
+  VERSION = '2.5.1'.freeze
   TEMPLATE_REF = '2.5.0'.freeze
 end

--- a/package-testing/Gemfile
+++ b/package-testing/Gemfile
@@ -13,11 +13,11 @@ def location_for(place_or_version, fake_version = nil)
   end
 end
 
-gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || 'https://github.com/voxpupuli/beaker.git#master')
-gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.9.0')
-gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '= 1.5.0')
-gem 'beaker-puppet', '= 1.21.0'
-gem 'beaker-rspec', '= 6.3.0'
+gem 'beaker', '~> 4.38'
+gem 'beaker-abs', '~> 0.11.0'
+gem 'beaker-hostgenerator', '~> 1.18.0'
+gem 'beaker-puppet', '= 1.29.0'
+gem 'beaker-rspec', '= 7.1.0'
 gem 'beaker-vmpooler', '= 1.4.0'
 gem 'i18n', '= 1.4.0' # pin for Ruby 2.1 support
 gem 'nokogiri', '~> 1.10.8'

--- a/package-testing/config/options.rb
+++ b/package-testing/config/options.rb
@@ -1,7 +1,4 @@
 {
-  ssh: {
-    keys: ['~/.ssh/id_rsa-acceptance'],
-  },
   preserve_hosts: 'onfail',
   provision: 'true',
 }

--- a/package-testing/config/options.rb
+++ b/package-testing/config/options.rb
@@ -1,4 +1,7 @@
 {
+  ssh: {
+    keys: ['~/.ssh/id_rsa-acceptance'],
+  },
   preserve_hosts: 'onfail',
   provision: 'true',
 }

--- a/package-testing/spec/package/version_selection_spec.rb
+++ b/package-testing/spec/package/version_selection_spec.rb
@@ -6,12 +6,11 @@ describe 'Test puppet & ruby version selection' do
     { envvar: 'PDK_PUPPET_VERSION', version: '5.5.0', expected_puppet: '5.5', expected_ruby: '2.4' },
     { envvar: 'PDK_PUPPET_VERSION', version: '6.21.0', expected_puppet: '6.21', expected_ruby: '2.5.9' },
     { envvar: 'PDK_PUPPET_VERSION', version: '6.23.0', expected_puppet: '6.23', expected_ruby: '2.5.9' },
-    { envvar: 'PDK_PUPPET_VERSION', version: '7.4.1', expected_puppet: '7.4', expected_ruby: '2.7.6' },
-    { envvar: 'PDK_PUPPET_VERSION', version: '7.8.0', expected_puppet: '7.8', expected_ruby: '2.7.6' },
+    { envvar: 'PDK_PUPPET_VERSION', version: '7.18.0', expected_puppet: '7.18', expected_ruby: '2.7.6' },
+    { envvar: 'PDK_PUPPET_VERSION', version: '7.20.0', expected_puppet: '7.20', expected_ruby: '2.7.6' },
     { envvar: 'PDK_PE_VERSION', version: '2018.1', expected_puppet: '5.5', expected_ruby: '2.4' },
     { envvar: 'PDK_PE_VERSION', version: '2019.8.7', expected_puppet: '6.23', expected_ruby: '2.5.9' },
-    { envvar: 'PDK_PE_VERSION', version: '2021.1', expected_puppet: '7.6', expected_ruby: '2.7.6' },
-    { envvar: 'PDK_PE_VERSION', version: '2021.2', expected_puppet: '7.8', expected_ruby: '2.7.6' },
+    { envvar: 'PDK_PE_VERSION', version: '2021.7.1', expected_puppet: '7.20', expected_ruby: '2.7.6' },
   ]
 
   before(:all) do

--- a/package-testing/spec/package/version_selection_spec.rb
+++ b/package-testing/spec/package/version_selection_spec.rb
@@ -3,14 +3,15 @@ require 'spec_helper_package'
 describe 'Test puppet & ruby version selection' do
   module_name = 'version_selection'
   test_cases = [
-    { envvar: 'PDK_PUPPET_VERSION', version: '5.5.0', expected_puppet: '5.5', expected_ruby: '2.4' },
     { envvar: 'PDK_PUPPET_VERSION', version: '6.21.0', expected_puppet: '6.21', expected_ruby: '2.5.9' },
     { envvar: 'PDK_PUPPET_VERSION', version: '6.23.0', expected_puppet: '6.23', expected_ruby: '2.5.9' },
-    { envvar: 'PDK_PUPPET_VERSION', version: '7.18.0', expected_puppet: '7.18', expected_ruby: '2.7.6' },
-    { envvar: 'PDK_PUPPET_VERSION', version: '7.20.0', expected_puppet: '7.20', expected_ruby: '2.7.6' },
-    { envvar: 'PDK_PE_VERSION', version: '2018.1', expected_puppet: '5.5', expected_ruby: '2.4' },
+    { envvar: 'PDK_PUPPET_VERSION', version: '7.18.0', expected_puppet: '7.18', expected_ruby: '2.7.7' },
+    { envvar: 'PDK_PUPPET_VERSION', version: '7.20.0', expected_puppet: '7.20', expected_ruby: '2.7.7' },
+
+
     { envvar: 'PDK_PE_VERSION', version: '2019.8.7', expected_puppet: '6.23', expected_ruby: '2.5.9' },
-    { envvar: 'PDK_PE_VERSION', version: '2021.7.1', expected_puppet: '7.20', expected_ruby: '2.7.6' },
+    { envvar: 'PDK_PE_VERSION', version: '2021.7.0', expected_puppet: '7.20', expected_ruby: '2.7.7' },
+    { envvar: 'PDK_PE_VERSION', version: '2021.7.1', expected_puppet: '7.20', expected_ruby: '2.7.7' },
   ]
 
   before(:all) do


### PR DESCRIPTION
Prior to this commit, spec tests expected puppet 5 which was removed in a previous commit. This commit fixes that and a couple of other test errors.