### PR TITLE
(CONT-437) Identify Packages Owned By Puppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ PDK includes the following tools:
 
 |Tool|Description|Owned by Puppet|
 |----|-----------|---------------|
+|facterdb|A gem that contains facts for Operating Systems.| N |
 |metadata-json-lint|Validates and lints `metadata.json` files in modules against Puppet module metadata style guidelines.| N |
 |pdk|Tool to generate and test modules and module content, such as classes, from the command line.| Y |
+|puppet-debugger|Provides a REPL based debugger console.| N |
 |puppet-lint|Checks your Puppet code against the recommendations in the Puppet language style guide.| Y |
 |puppet-syntax|Checks for correct syntax in Puppet manifests, templates, and Hiera YAML.| N |
 |puppetlabs_spec_helper|Provides classes, methods, and Rake tasks to help with spec testing Puppet code.| Y |

--- a/README.md
+++ b/README.md
@@ -15,16 +15,15 @@ PDK includes testing tools, a complete module skeleton, and command line tools t
 
 PDK includes the following tools:
 
-Tool   | Description
-----------------|-------------------------
-metadata-json-lint | Validates and lints `metadata.json` files in modules against  Puppet's module metadatastyle guidelines.
-pdk | Command line tool for generating and testing modules
-puppet-lint | Checks your Puppet code against the recommendations in the Puppet Language style guide.
-puppet-syntax | Checks for correct syntax in Puppet manifests, templates, and Hiera YAML.
-puppetlabs_spec_helper | Provides classes, methods, and Rake tasks to help with spec testing Puppet code.
-rspec-puppet | Tests the behavior of Puppet when it compiles your manifests into a catalog of Puppet resources.
-rspec-puppet-facts | Adds support for running rspec-puppet tests against the facts for your supported operating systems.
-puppet-debugger | Provides a REPL based debugger console.
+|Tool|Description|Owned by Puppet|
+|----|-----------|---------------|
+|metadata-json-lint|Validates and lints `metadata.json` files in modules against Puppet module metadata style guidelines.| N |
+|pdk|Tool to generate and test modules and module content, such as classes, from the command line.| Y |
+|puppet-lint|Checks your Puppet code against the recommendations in the Puppet language style guide.| Y |
+|puppet-syntax|Checks for correct syntax in Puppet manifests, templates, and Hiera YAML.| N |
+|puppetlabs_spec_helper|Provides classes, methods, and Rake tasks to help with spec testing Puppet code.| Y |
+|rspec-puppet|Tests the behavior of Puppet when it compiles your manifests into a catalog of Puppet resources.| Y |
+|rspec-puppet-facts|Adds support for running `rspec-puppet` tests against the facts for your supported operating systems.| N |
 
 
 ## Installation

--- a/docs/pdk_overview.md
+++ b/docs/pdk_overview.md
@@ -43,13 +43,12 @@ PDK includes development and testing tools built by Puppet and by the Puppet
 open source community. PDK also installs its own Ruby environment and any gems
 it needs.
 
-|Tool|Description|
-|----|-----------|
-|metadata-json-lint|Validates and lints `metadata.json` files in modules against Puppet module metadata style guidelines.|
-|pdk|Tool to generate and test modules and module content, such as classes, from the command line.|
-|puppet-lint|Checks your Puppet code against the recommendations in the Puppet language style guide.|
-|puppet-syntax|Checks for correct syntax in Puppet manifests, templates, and Hiera YAML.|
-|puppetlabs_spec_helper|Provides classes, methods, and Rake tasks to help with spec testing Puppet code.|
-|rspec-puppet|Tests the behavior of Puppet when it compiles your manifests into a catalog of Puppet resources.|
-|rspec-puppet-facts|Adds support for running `rspec-puppet` tests against the facts for your supported operating systems.|
-
+|Tool|Description|Owned by Puppet|
+|----|-----------|---------------|
+|metadata-json-lint|Validates and lints `metadata.json` files in modules against Puppet module metadata style guidelines.| N |
+|pdk|Tool to generate and test modules and module content, such as classes, from the command line.| Y |
+|puppet-lint|Checks your Puppet code against the recommendations in the Puppet language style guide.| Y |
+|puppet-syntax|Checks for correct syntax in Puppet manifests, templates, and Hiera YAML.| N |
+|puppetlabs_spec_helper|Provides classes, methods, and Rake tasks to help with spec testing Puppet code.| Y |
+|rspec-puppet|Tests the behavior of Puppet when it compiles your manifests into a catalog of Puppet resources.| Y |
+|rspec-puppet-facts|Adds support for running `rspec-puppet` tests against the facts for your supported operating systems.| N |

--- a/docs/pdk_overview.md
+++ b/docs/pdk_overview.md
@@ -45,8 +45,10 @@ it needs.
 
 |Tool|Description|Owned by Puppet|
 |----|-----------|---------------|
+|facterdb|A gem that contains facts for Operating Systems.| N |
 |metadata-json-lint|Validates and lints `metadata.json` files in modules against Puppet module metadata style guidelines.| N |
 |pdk|Tool to generate and test modules and module content, such as classes, from the command line.| Y |
+|puppet-debugger|Provides a REPL based debugger console.| N |
 |puppet-lint|Checks your Puppet code against the recommendations in the Puppet language style guide.| Y |
 |puppet-syntax|Checks for correct syntax in Puppet manifests, templates, and Hiera YAML.| N |
 |puppetlabs_spec_helper|Provides classes, methods, and Rake tasks to help with spec testing Puppet code.| Y |


### PR DESCRIPTION
Prior to this commit the documentation does not idenitfy the specific packages owned by Puppet vs the packages owned by the community.

This commit adds a row for in the PDK packages table and will make it easier to identify the packages that Puppet own.