### PR TITLE
(MAINT) Release prep for v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v2.6.1](https://github.com/puppetlabs/pdk/tree/v2.6.1) - 2023-01-25
+
+[Full Changelog](https://github.com/puppetlabs/pdk/compare/v2.6.0...v2.6.1)
+
 ## [v2.6.0](https://github.com/puppetlabs/pdk/tree/v2.6.0) - 2023-01-17
 
 [Full Changelog](https://github.com/puppetlabs/pdk/compare/v2.5.0...v2.6.0)

--- a/docs/pdk_known_issues.md
+++ b/docs/pdk_known_issues.md
@@ -1,6 +1,27 @@
 # PDK known issues
 
-Known issues in the PDK 1.x release series.
+## PDK 2.6.1
+
+When using selecting Puppet versions PDK, you may encounter an `uninitialized constant` error if the target version is below 6.29 for Puppet 6 or 7.22 for Puppet 7.
+
+This is caused by an incompatible version of concurrent-ruby that is downloaded when PDK processes the selected Puppet version.
+
+To mitigate this issue, we recommend selecting only the latest puppet versions when using `--puppet-version`.
+
+For example:
+
+### Puppet 6
+
+```
+pdk validate --puppet-version 6.29
+```
+
+### Puppet 7
+
+```
+pdk validate --puppet-version 7.22
+```
+In scenarios where `--pe-version` is used, it is recommended that `--puppet-version` is used instead, with the correct target as described above.
 
 ## PDK 1.15.0 is incompatible with Bundler 2.1.0 and later
 

--- a/docs/release_notes_pdk.md
+++ b/docs/release_notes_pdk.md
@@ -2,6 +2,17 @@
 
 New features, enhancements, and resolved issues for the PDK 2.x release series.
 
+## PDK 2.6.1
+
+### New features and enhancements
+
+* A Ubuntu 22.04 compatible packages has been added.
+* An OSX 12 compatible package has been added.
+
+### Resolved issues
+
+* Versions 6.29 and 7.22 of the Puppet gem have been added to the packages. The two new gem releases resolve an issue where an incompatible version of `concurrent-ruby` may be dowloaded when creating a new module or running `pdk validate`.
+
 ## PDK 2.6.0
 
 ### New features and enhancements

--- a/lib/pdk/version.rb
+++ b/lib/pdk/version.rb
@@ -1,4 +1,4 @@
 module PDK
-  VERSION = '2.6.0'.freeze
+  VERSION = '2.6.1'.freeze
   TEMPLATE_REF = '2.7.1'.freeze
 end


### PR DESCRIPTION
Prep for v2.6.1.

This release does not include any functional changes for the PDK gem.
