### PR TITLE
(CONT-479) Bump nokogiri

### DIFF
--- a/package-testing/Gemfile
+++ b/package-testing/Gemfile
@@ -20,7 +20,7 @@ gem 'beaker-puppet', '= 1.29.0'
 gem 'beaker-rspec', '= 7.1.0'
 gem 'beaker-vmpooler', '= 1.4.0'
 gem 'i18n', '= 1.4.0' # pin for Ruby 2.1 support
-gem 'nokogiri', '~> 1.10.8'
+gem 'nokogiri', '~> 1.13.6'
 gem 'rake', '~> 12.3', '>= 12.3.3'
 
 # net-ping has a implicit dependency on win32-security


### PR DESCRIPTION
Nokogiri < v1.13.6 does not type-check all inputs into the XML and HTML4 SAX parsers. For CRuby users, this may allow specially crafted untrusted inputs to cause illegal memory access errors (segfault) or reads from unrelated memory.

This commit bumps the nokogiri gem used in package testing to 1.13.6.