### PR TITLE
(CONT-650) Bump dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,18 +4,20 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'github_changelog_generator', '~> 1.14'
-  gem 'pry-byebug', '~> 3.4'
+  gem 'github_changelog_generator', '~> 1.15.2'
   gem 'ruby-prof'
   gem 'yard'
+
+  gem 'pry'
+  gem 'pry-stack_explorer'
+  gem 'fuubar'
 end
 
 group :test do
   gem 'codecov'
-  gem 'license_finder', '~> 6.1.2'
-  gem 'parallel', '= 1.13.0'
-  gem 'parallel_tests', '~> 2.24.0'
-  gem 'rake', '~> 12.3', '>= 12.3.3'
+  gem 'parallel'
+  gem 'parallel_tests'
+  gem 'rake'
   gem 'rspec', '~> 3.0'
   gem 'rubocop', '~> 1.28.0', require: false
   gem 'rubocop-rspec', '~> 2.0.1', require: false
@@ -30,7 +32,6 @@ group :acceptance do
 end
 
 group :acceptance_ci do
-  gem 'puppet_litmus'
   gem 'puppetlabs_spec_helper'
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -111,8 +111,3 @@ rescue LoadError
     raise 'Install yard to generate YARD documentation'
   end
 end
-
-desc 'Check for unapproved licenses in dependencies'
-task(:license_finder) do
-  system('license_finder --decisions-file=.dependency_decisions.yml') || raise(StandardError, 'Unapproved license(s) found on dependencies')
-end

--- a/package-testing/Gemfile
+++ b/package-testing/Gemfile
@@ -19,7 +19,7 @@ gem 'beaker-hostgenerator', '~> 1.18.0'
 gem 'beaker-puppet', '= 1.29.0'
 gem 'beaker-rspec', '= 7.1.0'
 gem 'beaker-vmpooler', '= 1.4.0'
-gem 'nokogiri', '~> 1.10.8'
+gem 'nokogiri', '~> 1.13.6'
 gem 'rake', '~> 12.3', '>= 12.3.3'
 
 # net-ping has a implicit dependency on win32-security

--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.4.0' # rubocop:disable Gemspec/RequiredRubyVersion
+  spec.required_ruby_version = '>= 2.5.9' # rubocop:disable Gemspec/RequiredRubyVersion
 
   spec.add_runtime_dependency 'bundler', '>= 2.3.0', '< 3.0.0'
   spec.add_runtime_dependency 'childprocess', '~> 4.1.0'
@@ -41,4 +41,3 @@ Gem::Specification.new do |spec|
   # Used in the pdk-templates
   spec.add_runtime_dependency 'deep_merge', '~> 1.2.2'
 end
-

--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -19,26 +19,26 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4.0' # rubocop:disable Gemspec/RequiredRubyVersion
 
-  spec.add_runtime_dependency 'bundler', '>= 1.15.0', '< 3.0.0'
-  spec.add_runtime_dependency 'childprocess', '~> 4.0.0'
-  spec.add_runtime_dependency 'cri', '~> 2.10'
-  spec.add_runtime_dependency 'diff-lcs', '>=1.4.4', '< 1.5'
-  spec.add_runtime_dependency 'ffi', '>= 1.9.25', '< 2.0.0'
+  spec.add_runtime_dependency 'bundler', '>= 2.3.0', '< 3.0.0'
+  spec.add_runtime_dependency 'childprocess', '~> 4.1.0'
+  spec.add_runtime_dependency 'cri', '~> 2.15.11'
+  spec.add_runtime_dependency 'diff-lcs', '>= 1.5.0'
+  spec.add_runtime_dependency 'ffi', '>= 1.15.5', '< 2.0.0'
   spec.add_runtime_dependency 'hitimes', '2.0.0'
   spec.add_runtime_dependency 'json-schema', '2.8.0'
-  spec.add_runtime_dependency 'json_pure', '~> 2.1.0' if RUBY_VERSION < '2.7'
-  spec.add_runtime_dependency 'json_pure', '~> 2.5.1' if RUBY_VERSION >= '2.7'
+  spec.add_runtime_dependency 'json_pure', '~> 2.6.2'
   spec.add_runtime_dependency 'minitar', '~> 0.6'
   spec.add_runtime_dependency 'pathspec', '~> 0.2.1'
-  spec.add_runtime_dependency 'tty-prompt', '~> 0.22'
-  spec.add_runtime_dependency 'tty-spinner', '~> 0.5'
-  spec.add_runtime_dependency 'tty-which', '~> 0.3'
+  spec.add_runtime_dependency 'tty-prompt', '~> 0.23'
+  spec.add_runtime_dependency 'tty-spinner', '~> 0.9'
+  spec.add_runtime_dependency 'tty-which', '~> 0.5'
 
   # Analytics dependencies
-  spec.add_runtime_dependency 'concurrent-ruby', '~> 1.1.5'
-  spec.add_runtime_dependency 'facter', '>= 2.5.1', '< 5.0.0'
+  spec.add_runtime_dependency 'concurrent-ruby', '~> 1.1.10'
+  spec.add_runtime_dependency 'facter', '>= 4.0.0', '< 5.0.0'
   spec.add_runtime_dependency 'httpclient', '~> 2.8.3'
 
   # Used in the pdk-templates
-  spec.add_runtime_dependency 'deep_merge', '~> 1.1'
+  spec.add_runtime_dependency 'deep_merge', '~> 1.2.2'
 end
+


### PR DESCRIPTION
In a previous change support for Ruby 2.4x was dropped.

This change contains some small dependency bumps to align.

