### PR TITLE
(CONT-669) Use bundle info command

### DIFF
--- a/lib/pdk/util/changelog_generator.rb
+++ b/lib/pdk/util/changelog_generator.rb
@@ -9,7 +9,7 @@ module PDK
 
       # Raises if the github_changelog_generator is not available
       def self.github_changelog_generator_available!
-        check_command = PDK::CLI::Exec::InteractiveCommand.new(PDK::CLI::Exec.bundle_bin, 'show', 'github_changelog_generator')
+        check_command = PDK::CLI::Exec::InteractiveCommand.new(PDK::CLI::Exec.bundle_bin, 'info', 'github_changelog_generator')
         check_command.context = :module
 
         result = check_command.execute!


### PR DESCRIPTION
Prior to this change `github_changelog_generator_available!` would call `bundle show github_changelog_generator` to check for the existence of the gem.

This command has been deprecated deprecated which causes the following warning to be displayed when a user runs a `release` command

`[DEPRECATED] use bundle info github_changelog_generator instead of `bundle show github_changelog_generator

This change replaces the `show` command with `info` as suggested.