### PR TITLE
(CONT-694) Bump PDK Template Version

### DIFF
--- a/lib/pdk/version.rb
+++ b/lib/pdk/version.rb
@@ -1,4 +1,4 @@
 module PDK
   VERSION = '2.7.0'.freeze
-  TEMPLATE_REF = '2.7.1'.freeze
+  TEMPLATE_REF = '2.7.2'.freeze
 end


### PR DESCRIPTION
This commit ensures that the default pdk-template version is set to 2.7.2.