### PR TITLE
(CONT-699) - Implement reusable workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,8 @@
 name: "ci"
 
 on:
-  pull_request:
-    branches:
-      - "main"
+  schedule:
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -7,10 +7,14 @@ on:
       description: "The target for the release. This can be a commit sha or a branch."
       required: false
       default: "main"
+    version:
+      description: "Version of gem to be released."
+      required: true
 
 jobs:
   release_prep:
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_release_prep.yml@main"
     with:
       target: "${{ github.event.inputs.target }}"
+      version: "${{ github.events.inputs.version }}"
     secrets: "inherit"


### PR DESCRIPTION
Prior to this PR, the version of the gem would need to be manually updated, pushed and merged into main each time before running release_prep.yml.

This PR introduces a "version" input parameter, that can be specified when running the workflow which eliminates the need for the above.