### PR TITLE
(CONT-719) Require JSON gem

### DIFF
--- a/lib/pdk/util/puppet_version.rb
+++ b/lib/pdk/util/puppet_version.rb
@@ -1,4 +1,5 @@
 require 'pdk'
+require 'json'
 
 module PDK
   module Util


### PR DESCRIPTION
Prior to this change puppet version selection via PDK_PE_VERSION would fail due to an uninitialized constant (JSON).

It would appear that 2.7 no longer lazy loads the json gem so in this change we are explicitly requiring it.