### PR TITLE
(CONT-720) Fix default version selection

### DIFF
--- a/lib/pdk/util/ruby_version.rb
+++ b/lib/pdk/util/ruby_version.rb
@@ -61,10 +61,7 @@ module PDK
                                       # PDK::Util::PuppetVersion.find_gem_for('5.5.10')[:ruby_version]
                                       #
                                       # For using the latest puppet gem:
-                                      # PDK::Util::PuppetVersion.latest_available[:ruby_version]
-                                      #
-                                      # Temporarily lock to Ruby 2.5.x as default until 2.7.x ecosystem is sorted
-                                      versions.keys.detect { |v| v =~ %r{^2\.5} }
+                                      PDK::Util::PuppetVersion.latest_available[:ruby_version]
                                     else
                                       # TODO: may not be a safe assumption that highest available version should be default
                                       # WARNING Do NOT use PDK::Util::PuppetVersion.*** methods as it can recurse into this


### PR DESCRIPTION
Prior to this change the packaged version of PDK would default to returning ruby 2.5.9 regardless of the latest puppet version.

This change fixes that by ensuring that we get the ruby version from the latest puppet verison by default.