### PR TITLE
(GH-1210) Require uri

### DIFF
--- a/lib/pdk/module/release.rb
+++ b/lib/pdk/module/release.rb
@@ -1,4 +1,5 @@
 require 'pdk'
+require 'uri'
 
 module PDK
   module Module


### PR DESCRIPTION
As reported in #1210, in some situations pdk will fail to publish a module due to a missing require for URI.

For this specific occurance we will eventually move to the forge SDK which will elimiate the issue. However, due to some dependency constraints we cannot to that yet.

This change simply adds a new require for uri, which will solve the issue described above until we are able to migrate to the Forge SDK.