### PR TITLE
(CONT-747) Add Ruby 3.2.x to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '2.5'
-          - '2.7'
+          - "2.7"
+          - "3.2"
     name: "spec (ruby ${{ matrix.ruby_version }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
     secrets: "inherit"
@@ -30,8 +30,8 @@ jobs:
           - "ubuntu-latest"
           - "windows-2019"
         ruby_version:
-          - "2.5"
           - "2.7"
+          - "3.2"
     name: "acceptance (ruby ${{ matrix.ruby_version }} | ${{ matrix.os }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_acceptance.yml@main"
     secrets: "inherit"


### PR DESCRIPTION
Puppet 8 will run on ruby 3.2.x.

This change adds Ruby 3.2 to our test matrix so that we can begin testing for Puppet 8 readiness.