### PR TITLE
(CONT-1130) Bump PDK gem version

### DIFF
--- a/lib/pdk/version.rb
+++ b/lib/pdk/version.rb
@@ -1,4 +1,4 @@
 module PDK
-  VERSION = '3.0.0.pre'.freeze
+  VERSION = '3.0.0'.freeze
   TEMPLATE_REF = 'main'.freeze
 end


### PR DESCRIPTION
## Summary
This change bumps PDKs gem version to 3.0.0.

## Additional Context
N/A

## Related Issues (if any)
N/A

## Checklist
N/A