### PR TITLE
(CONT-1154) Disable console command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ PDK includes the following tools:
 |facterdb|A gem that contains facts for Operating Systems.| N |
 |metadata-json-lint|Validates and lints `metadata.json` files in modules against Puppet module metadata style guidelines.| N |
 |pdk|Tool to generate and test modules and module content, such as classes, from the command line.| Y |
-|puppet-debugger|Provides a REPL based debugger console.| N |
 |puppet-lint|Checks your Puppet code against the recommendations in the Puppet language style guide.| Y |
 |puppet-syntax|Checks for correct syntax in Puppet manifests, templates, and Hiera YAML.| N |
 |puppetlabs_spec_helper|Provides classes, methods, and Rake tasks to help with spec testing Puppet code.| Y |
@@ -106,51 +105,6 @@ pdk test unit
 ```
 
 This command runs all available unit tests.
-
-## Experimental features
-
-### `pdk console` command
-The pdk console command executes a session of the puppet debugger when inside a module and allows for exploration of puppet code.  See the official [puppet debugger site](https://www.puppet-debugger.com) for more info and the official docs [site here.](https://docs.puppet-debugger.com)
-
-To use, execute `pdk console` from inside your module directory.  You can also supply the `--puppet-version` or `--puppet-dev` to swap out the puppet version when using the console.
-
-Example (from within a module):
-
-* `pdk console --puppet-version=5`
-
-The `pdk console` command will also pass through any puppet debugger arguments you wish to use.
-
-Example:
-
-* `pdk console  --no-facterdb`
-* `pdk console --play https://gist.github.com/logicminds/4f6bcfd723c92aad1f01f6a800319fa4`
-* `pdk console -e "md5('sdfasdfasdf')" --run-once --quiet`
-
-Use `pdk console -h` for a further explanation of pass through arguments.
-
-If you receive the following error you do not have the puppet-debugger gem installed.
-
-```
-pdk console -h
-Error: Unknown Puppet subcommand 'debugger'
-See 'puppet help' for help on available puppet subcommands
-```
-
-To fix this you will need to add the following entry to your .sync.yml file and run pdk update:
-
-```
-Gemfile:
-  required:
-    ":development":
-      - gem: puppet-debugger
-        version: "~> 0.14"
-```  
-
-**NOTE**: The puppet-debugger gem has been added to the [puppet-module-* gems](https://github.com/puppetlabs/puppet-module-gems/pull/117), so once you get the gem update you no longer need the .sync.yml entry.
-
-### `pdk bundle` command
-
-This command executes arbitrary commands in a bundler context within the module you're currently working on. Arguments to this command are passed straight through to bundler. This command is experimental  and can lead to errors that can't be resolved by PDK itself.
 
 ## Module Compatibility
 

--- a/docs/pdk_overview.md
+++ b/docs/pdk_overview.md
@@ -48,7 +48,6 @@ it needs.
 |facterdb|A gem that contains facts for Operating Systems.| N |
 |metadata-json-lint|Validates and lints `metadata.json` files in modules against Puppet module metadata style guidelines.| N |
 |pdk|Tool to generate and test modules and module content, such as classes, from the command line.| Y |
-|puppet-debugger|Provides a REPL based debugger console.| N |
 |puppet-lint|Checks your Puppet code against the recommendations in the Puppet language style guide.| Y |
 |puppet-syntax|Checks for correct syntax in Puppet manifests, templates, and Hiera YAML.| N |
 |puppetlabs_spec_helper|Provides classes, methods, and Rake tasks to help with spec testing Puppet code.| Y |

--- a/lib/pdk/cli.rb
+++ b/lib/pdk/cli.rb
@@ -153,7 +153,7 @@ module PDK
     require 'pdk/cli/test'
     require 'pdk/cli/update'
     require 'pdk/cli/validate'
-    require 'pdk/cli/console'
+    # require 'pdk/cli/console' Temporarily disabled while we work on the puppet-debugger gem. It will be back soon! (CONT-1154)
     require 'pdk/cli/release'
     require 'pdk/cli/remove'
 

--- a/spec/unit/pdk/cli/console_spec.rb
+++ b/spec/unit/pdk/cli/console_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'pdk/cli'
 
-describe 'pdk console' do
+describe 'pdk console', skip: 'Temporarily disabled (CONT-1154)' do
   let(:console_cmd) { PDK::CLI.instance_variable_get(:@console_cmd) }
   let(:module_path) { '/path/to/testmodule' }
   let(:context) { PDK::Context::Module.new(module_path, module_path) }


### PR DESCRIPTION
## Summary

The console command relies on puppet-debugger which currently does not support Ruby 3 and Puppet 8.

Given that the command has always been an experimental feature of PDK, a decision was made to disable it for this release.

This will give us time to work on some updates for a later release.
