### PR TITLE
(PUPDOC-5424) Adding a registered trademark icon

### DIFF
--- a/docs/pdk.md
+++ b/docs/pdk.md
@@ -34,7 +34,6 @@ validate, and test modules.
             <li><a class="xref" href="customizing_module_config.md">Customizing module configuration</a></li>
             <li><a class="xref" href="pdk_building_module_packages.md">Building a module package</a></li>
         </ul>
-    </p>
     <p>Testing modules
         <ul>
             <li><a class="xref" href="pdk_testing.md#validating-modules">Validating module syntax and style</a></li>
@@ -49,7 +48,7 @@ validate, and test modules.
     </p>
    </td>
    <td>
-      <p>Learning to write Puppet code
+      <p>Learning to write Puppet® code
             <ul>
                 <li><a class="xref" href="https://puppet.com/docs/puppet/latest/modules_fundamentals.html" target="_blank">Module fundamentals</a></li>
                 <li><a class="xref" href="https://puppet.com/docs/puppet/latest/bgtm.html" target="_blank">Beginner's guide to writing modules</a></li>

--- a/docs/pdk.md
+++ b/docs/pdk.md
@@ -34,6 +34,7 @@ validate, and test modules.
             <li><a class="xref" href="customizing_module_config.md">Customizing module configuration</a></li>
             <li><a class="xref" href="pdk_building_module_packages.md">Building a module package</a></li>
         </ul>
+    </p>
     <p>Testing modules
         <ul>
             <li><a class="xref" href="pdk_testing.md#validating-modules">Validating module syntax and style</a></li>

--- a/docs/pdk_install.md
+++ b/docs/pdk_install.md
@@ -307,7 +307,7 @@ below about opting out.
 
 We collect these values for every analytics event:
 
--   A random non-identifying user ID. This ID is shared with Bolt analytics, if
+-   A random non-identifying user ID. This ID is shared with Puppet Bolt® analytics, if
     you've installed Bolt and enabled analytics.
 -   PDK installation method (`package` or `gem`).
 -   Version of PDK.


### PR DESCRIPTION
## Summary
Adding a registered trademark icon to the first instance of words that have been earmarked.

Prior to this commit the documentation had no trace of registered trademark icons.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
