### PR TITLE
(CAT-1601) Update Puppet test version

### DIFF
--- a/package-testing/spec/package/airgapped_usage_spec.rb
+++ b/package-testing/spec/package/airgapped_usage_spec.rb
@@ -28,8 +28,8 @@ describe 'Basic usage in an air-gapped environment' do
     end
 
     context 'when validating the module' do
-      context 'with puppet 7.x' do
-        puppet_version = '7.x'
+      context 'with puppet 8.x' do
+        puppet_version = '8.x'
         let(:ruby_version) { ruby_for_puppet(puppet_version) }
 
         describe command("pdk validate --puppet-version=#{puppet_version}") do

--- a/package-testing/spec/package/support/spec_utils.rb
+++ b/package-testing/spec/package/support/spec_utils.rb
@@ -52,6 +52,7 @@ module SpecUtils
                    when /^5\./ then '2.4.*'
                    when /^6\./ then '2.5.*'
                    when /^7\./ then '2.7.*'
+                   when /^8\./ then '3.2.*'
                    end
 
     return unless ruby_pattern

--- a/package-testing/spec/package/validate_a_new_module_spec.rb
+++ b/package-testing/spec/package/validate_a_new_module_spec.rb
@@ -18,8 +18,8 @@ describe 'C100321 - Generate a module and validate it (i.e. ensure bundle instal
   end
 
   context 'when validating the module' do
-    context 'with puppet 7.x' do
-      puppet_version = '7.x'
+    context 'with puppet 8.x' do
+      puppet_version = '8.x'
       let(:ruby_version) { ruby_for_puppet(puppet_version) }
 
       describe command("pdk validate --puppet-version=#{puppet_version}") do


### PR DESCRIPTION
Update create new module tests to run against Puppet 8 rather than Puppet 7.

Successful Run: https://jenkins-platform.delivery.puppetlabs.net/view/PDK/view/pdk-vanagon/job/platform_pdk_pdk-int-sys-testing_main/SLAVE_LABEL=k8s-beaker,TEST_TARGET=windows2019-64workstation./248/console

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
