### PR TITLE
(maint) Fix rubocop lint warnings

### DIFF
--- a/lib/pdk/cli/util/option_normalizer.rb
+++ b/lib/pdk/cli/util/option_normalizer.rb
@@ -44,7 +44,7 @@ module PDK
               target = PDK::Report.default_target
             end
 
-            { method: "write_#{format}".to_sym, target: target }
+            { method: :"write_#{format}", target: target }
           end
         end
       end

--- a/lib/pdk/config/namespace.rb
+++ b/lib/pdk/config/namespace.rb
@@ -217,7 +217,9 @@ module PDK
       # @api private
       def read_only!
         @read_only = true
-        @mounts.each { |_, child| child.read_only! }
+        # pass the read_only! method as a block to the each_value method. This means that
+        # for each value in the @mounts hash, the read_only! method will be called on that value.
+        @mounts.each_value(&:read_only!)
       end
 
       private

--- a/lib/pdk/report.rb
+++ b/lib/pdk/report.rb
@@ -93,13 +93,17 @@ module PDK
     # This report is designed for interactive use by a human and so excludes
     # all passing events in order to be consise.
     #
-    # @param target [#write] an IO object that the report will be written to.
-    #   Defaults to PDK::Report.default_target.
+    # @param target [String, IO] The IO target to write the report to.
+    #   If a String is provided, the report will be written to a file with the given path.
+    #   If an IO object is provided, the report will be written to the IO object.
+    #   If no target is provided, the default target PDK::Report.default_target will be used.
+    #
+    # @return [void]
     def write_text(target = self.class.default_target)
       coverage_report = nil
       report = []
 
-      events.each do |_tool, tool_events|
+      events.each_value do |tool_events|
         tool_events.each do |event|
           if event.rspec_puppet_coverage?
             coverage_report = event.to_text

--- a/lib/pdk/util.rb
+++ b/lib/pdk/util.rb
@@ -95,7 +95,7 @@ module PDK
     def development_mode?
       require 'pdk/util/version'
 
-      (!PDK::Util::Version.git_ref.nil? || PDK::VERSION.end_with?('.pre'))
+      !PDK::Util::Version.git_ref.nil? || PDK::VERSION.end_with?('.pre')
     end
     module_function :development_mode?
 

--- a/lib/pdk/util/puppet_version.rb
+++ b/lib/pdk/util/puppet_version.rb
@@ -206,10 +206,14 @@ module PDK
         version.nil? ? nil : { gem_version: version, ruby_version: PDK::Util::RubyVersion.default_ruby_version }
       end
 
+      # Finds the specified requirement in the package cache.
+      #
+      # @param requirement [Gem::Requirement] The requirement to search for.
+      # @return [Hash] A hash containing the gem version and ruby version if found, or nil if not found.
       def find_in_package_cache(requirement)
         require 'pdk/util/ruby_version'
 
-        PDK::Util::RubyVersion.versions.each do |ruby_version, _|
+        PDK::Util::RubyVersion.versions.each_key do |ruby_version|
           PDK::Util::RubyVersion.use(ruby_version)
           version = PDK::Util::RubyVersion.available_puppet_versions.find { |r| requirement.satisfied_by?(r) }
           return { gem_version: version, ruby_version: ruby_version } unless version.nil?

--- a/spec/support/file_based_namespaces.rb
+++ b/spec/support/file_based_namespaces.rb
@@ -50,7 +50,7 @@ RSpec.shared_examples 'a file based namespace' do |content, expected_settings|
 
     it 'does not add or lose any data when round tripping the serialization' do
       # Force the file to be loaded
-      expected_settings.each { |k, _| subject[k] }
+      expected_settings.each_key { |k| subject[k] }
       # Force a setting to be saved by setting a single known value
       expect(PDK::Util::Filesystem).to receive(:write_file).with(subject.file, content)
       key = expected_settings.keys[0]

--- a/spec/support/validators.rb
+++ b/spec/support/validators.rb
@@ -74,7 +74,7 @@ end
 RSpec::Matchers.define :have_number_of_events do |state, expected_count|
   def get_event_count(report, state)
     count = 0
-    report.events.each do |_source, events|
+    report.events.each_value do |events|
       count += events.count { |event| event.state == state }
     end
 


### PR DESCRIPTION
## Summary
[Nightly CI](https://github.com/puppetlabs/pdk/actions/runs/7080321967/job/19268045866) is failing with the following rubocop warnings:

```ruby
Run bundle exec rubocop --format github
  bundle exec rubocop --format github
  shell: /usr/bin/bash -e {0}
  env:
    PUPPET_GEM_VERSION: ~> 7.0

Error: Lint/SymbolConversion: Unnecessary symbol conversion; use `:"write_#{format}"` instead.
Error: Style/HashEachMethods: Use `each_value` instead of `each` and remove the unused `_` block argument.
Error: Style/HashEachMethods: Use `each_value` instead of `each` and remove the unused `_tool` block argument.
Error: Style/RedundantParentheses: Don't use parentheses around a logical expression.
Error: Style/HashEachMethods: Use `each_key` instead of `each` and remove the unused `_` block argument.
Error: Style/HashEachMethods: Use `each_key` instead of `each` and remove the unused `_` block argument.
Error: Style/HashEachMethods: Use `each_value` instead of `each` and remove the unused `_source` block argument.
Error: Process completed with exit code 1.
```

Linting has been fixed and comments added where appropriate.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
