### PR TITLE
(maint) bump concurrent-ruby version

### DIFF
--- a/package-testing/spec/package/support/serverspec_monkeypatch.rb
+++ b/package-testing/spec/package/support/serverspec_monkeypatch.rb
@@ -14,8 +14,7 @@ option_keys = Specinfra::Configuration.singleton_class.const_get(:VALID_OPTIONS_
 option_keys << :cwd
 option_keys << :run_as
 
-Specinfra::Configuration.singleton_class.send(:remove_const, :VALID_OPTIONS_KEYS) # rubocop:disable RSpec/RemoveConst
-Specinfra::Configuration.singleton_class.const_set(:VALID_OPTIONS_KEYS, option_keys.freeze)
+stub_const('Specinfra::Configuration::VALID_OPTIONS_KEYS', options.keys.freeze)
 RSpec.configuration.add_setting :cwd
 RSpec.configuration.add_setting :run_as
 

--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'tty-which', '~> 0.5'
 
   # Analytics dependencies
-  spec.add_runtime_dependency 'concurrent-ruby', '1.1.10'
+  spec.add_runtime_dependency 'concurrent-ruby', '1.2.2'
   spec.add_runtime_dependency 'facter', '~> 4.0'
   spec.add_runtime_dependency 'httpclient', '~> 2.8.3'
 


### PR DESCRIPTION
puppet-runtime doesnt support old (buggy) versions anymore
fixes building with pdk-vanagon

https://github.com/puppetlabs/puppet-runtime/commit/f201ef92c5c7b9930acc337c1e8f515e979b959c