### PR TITLE
pdksync - (CAT-1618) - Remove deprecated/obsolete codecov gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ group :development do
 end
 
 group :test do
-  gem 'codecov'
   gem 'parallel'
   gem 'parallel_tests'
   gem 'rake'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,11 +7,6 @@ if ENV.fetch('COVERAGE', nil) == 'yes'
     SimpleCov::Formatter::Console
   ]
 
-  if ENV['CI'] == 'true'
-    require 'codecov'
-    SimpleCov.formatters << SimpleCov::Formatter::Codecov
-  end
-
   SimpleCov.start do
     track_files 'lib/**/*.rb'
 


### PR DESCRIPTION
(CAT-1618) - Remove deprecated/obsolete codecov gem
pdk version: `3.0.0` 
