### PR TITLE
Allow `pdk convert` and `pdk update` to work in a ControlRepo context

### DIFF
--- a/lib/pdk/cli/convert.rb
+++ b/lib/pdk/cli/convert.rb
@@ -18,8 +18,9 @@ module PDK
         # Write the context information to the debug log
         PDK.context.to_debug_log
 
-        raise PDK::CLI::ExitWithError, '`pdk convert` can only be run from inside a valid module directory.' unless PDK.context.is_a?(PDK::Context::Module) ||
-                                                                                                                    PDK.context.is_a?(PDK::Context::ControlRepo)
+        unless PDK.context.is_a?(PDK::Context::Module) || PDK.context.is_a?(PDK::Context::ControlRepo)
+          raise PDK::CLI::ExitWithError, '`pdk convert` can only be run from inside a valid module directory.'
+        end
 
         raise PDK::CLI::ExitWithError, 'You can not specify --noop and --force when converting a module' if opts[:noop] && opts[:force]
 

--- a/lib/pdk/cli/convert.rb
+++ b/lib/pdk/cli/convert.rb
@@ -18,7 +18,7 @@ module PDK
         # Write the context information to the debug log
         PDK.context.to_debug_log
 
-        raise PDK::CLI::ExitWithError, '`pdk convert` can only be run from inside a valid module directory.' unless PDK.context.is_a?(PDK::Context::Module)
+        raise PDK::CLI::ExitWithError, '`pdk convert` can only be run from inside a valid module directory.' unless PDK.context.is_a?(PDK::Context::Module) || PDK.context.is_a?(PDK::Context::ControlRepo)
 
         raise PDK::CLI::ExitWithError, 'You can not specify --noop and --force when converting a module' if opts[:noop] && opts[:force]
 

--- a/lib/pdk/cli/convert.rb
+++ b/lib/pdk/cli/convert.rb
@@ -18,7 +18,8 @@ module PDK
         # Write the context information to the debug log
         PDK.context.to_debug_log
 
-        raise PDK::CLI::ExitWithError, '`pdk convert` can only be run from inside a valid module directory.' unless PDK.context.is_a?(PDK::Context::Module) || PDK.context.is_a?(PDK::Context::ControlRepo)
+        raise PDK::CLI::ExitWithError, '`pdk convert` can only be run from inside a valid module directory.' unless PDK.context.is_a?(PDK::Context::Module) ||
+                                                                                                                    PDK.context.is_a?(PDK::Context::ControlRepo)
 
         raise PDK::CLI::ExitWithError, 'You can not specify --noop and --force when converting a module' if opts[:noop] && opts[:force]
 

--- a/lib/pdk/cli/update.rb
+++ b/lib/pdk/cli/update.rb
@@ -14,8 +14,9 @@ module PDK
         # Write the context information to the debug log
         PDK.context.to_debug_log
 
-        raise PDK::CLI::ExitWithError, '`pdk update` can only be run from inside a valid module directory.' unless PDK.context.is_a?(PDK::Context::Module) ||
-                                                                                                                   PDK.context.is_a?(PDK::Context::ControlRepo)
+        unless PDK.context.is_a?(PDK::Context::Module) || PDK.context.is_a?(PDK::Context::ControlRepo)
+          raise PDK::CLI::ExitWithError, '`pdk update` can only be run from inside a valid module directory.'
+        end
 
         raise PDK::CLI::ExitWithError, 'This module does not appear to be PDK compatible. To make the module compatible with PDK, run `pdk convert`.' unless PDK::Util.module_pdk_compatible?
 

--- a/lib/pdk/cli/update.rb
+++ b/lib/pdk/cli/update.rb
@@ -14,7 +14,8 @@ module PDK
         # Write the context information to the debug log
         PDK.context.to_debug_log
 
-        raise PDK::CLI::ExitWithError, '`pdk update` can only be run from inside a valid module directory.' unless PDK.context.is_a?(PDK::Context::Module) || PDK.context.is_a?(PDK::Context::ControlRepo)
+        raise PDK::CLI::ExitWithError, '`pdk update` can only be run from inside a valid module directory.' unless PDK.context.is_a?(PDK::Context::Module) ||
+                                                                                                                   PDK.context.is_a?(PDK::Context::ControlRepo)
 
         raise PDK::CLI::ExitWithError, 'This module does not appear to be PDK compatible. To make the module compatible with PDK, run `pdk convert`.' unless PDK::Util.module_pdk_compatible?
 

--- a/lib/pdk/cli/update.rb
+++ b/lib/pdk/cli/update.rb
@@ -14,7 +14,7 @@ module PDK
         # Write the context information to the debug log
         PDK.context.to_debug_log
 
-        raise PDK::CLI::ExitWithError, '`pdk update` can only be run from inside a valid module directory.' unless PDK.context.is_a?(PDK::Context::Module)
+        raise PDK::CLI::ExitWithError, '`pdk update` can only be run from inside a valid module directory.' unless PDK.context.is_a?(PDK::Context::Module) || PDK.context.is_a?(PDK::Context::ControlRepo)
 
         raise PDK::CLI::ExitWithError, 'This module does not appear to be PDK compatible. To make the module compatible with PDK, run `pdk convert`.' unless PDK::Util.module_pdk_compatible?
 


### PR DESCRIPTION
## Summary
Allow `pdk convert` and `pdk update` commands to be ran if  `PDK_FEATURE_FLAGS=controlrepo` set. 

## Current Behavior
```bash
$ git clone https://github.com/puppetlabs/control-repo
$ cd control-repo
$ PDK_FEATURE_FLAGS=controlrepo pdk convert
pdk (ERROR): `pdk convert` can only be run from inside a valid module directory.
```

## Expected Behavior
```bash
$ git clone https://github.com/puppetlabs/control-repo
$ cd control-repo
$ PDK_FEATURE_FLAGS=controlrepo pdk convert

We need to create the metadata.json file for this module, so we're going to ask you 4 questions.
If the question is not applicable to this module, accept the default option shown after each question. You can modify any answers at any time by manually updating the metadata.json file.

[Q 1/4] If you have a Puppet Forge username, add it here.
We can use this to upload your module to the Forge when it's complete.
--> garrettrowell

[Q 2/4] Who wrote this module?
This is used to credit the module's author.
--> Garrett Rowell

[Q 3/4] What license does this module code fall under?
This should be an identifier from https://spdx.org/licenses/. Common values are "Apache-2.0", "MIT", or "proprietary".
--> Apache-2.0

[Q 4/4] What operating systems does this module support?
Use the up and down keys to move between the choices, space to select and enter to continue.
--> RedHat based Linux, Debian based Linux, Windows


------------Files to be added-----------
/Users/garrett.rowell/workspace/control-repo/metadata.json
/Users/garrett.rowell/workspace/control-repo/.gitattributes
/Users/garrett.rowell/workspace/control-repo/.pdkignore
/Users/garrett.rowell/workspace/control-repo/.puppet-lint.rc
/Users/garrett.rowell/workspace/control-repo/.rspec
/Users/garrett.rowell/workspace/control-repo/.rubocop.yml
/Users/garrett.rowell/workspace/control-repo/.vscode/extensions.json
/Users/garrett.rowell/workspace/control-repo/.yardopts
/Users/garrett.rowell/workspace/control-repo/Gemfile
/Users/garrett.rowell/workspace/control-repo/Rakefile
/Users/garrett.rowell/workspace/control-repo/spec/default_facts.yml
/Users/garrett.rowell/workspace/control-repo/spec/spec_helper.rb
/Users/garrett.rowell/workspace/control-repo/.fixtures.yml
/Users/garrett.rowell/workspace/control-repo/.sync.yml
/Users/garrett.rowell/workspace/control-repo/CHANGELOG.md

----------Files to be modified----------
/Users/garrett.rowell/workspace/control-repo/.gitignore

----------------------------------------

You can find a report of differences in convert_report.txt.

pdk (INFO): Module conversion is a potentially destructive action. Ensure that you have committed your module to a version control system or have a backup, and review the changes above before continuing.
Do you want to continue and make these changes to your module? yes
```

## Workaround this PR Eliminates
This is teadious as I typically have the feature flags set in my **.bash_profile** and need to remember to unset it anytime I run `pdk convert` or `pdk update` in a control-repo
```bash
$ git clone https://github.com/puppetlabs/control-repo
$ cd control-repo
$ pdk convert
$ PDK_FEATURE_FLAGS=controlrepo pdk validate
```