### PR TITLE
(CAT-1628) Generalize version selection tests

### DIFF
--- a/package-testing/spec/package/version_selection_spec.rb
+++ b/package-testing/spec/package/version_selection_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper_package'
 
 describe 'Test puppet & ruby version selection' do
   module_name = 'version_selection'
-  # IMPORTANT: The following block should be updated with the latest version of each release supported for the
-  # test cases to pass. If you are running integration testing prior to a release and its failing due to missing Puppet
-  # gems, verify that the following versions are correct.
+  # IMPORTANT: The following block should be updated with the version of ruby that is included within the newest
+  #   Puppet release for each major version. If you are running integration testing prior to a release and its
+  #   failing, verify that the following versions are correct.
   test_cases = [
-    { envvar: 'PDK_PUPPET_VERSION', expected_puppet: '7.29.1', expected_ruby: '2.7.8' },
-    { envvar: 'PDK_PUPPET_VERSION', expected_puppet: '8.5.1', expected_ruby: '3.2.2' }
+    { envvar: 'PDK_PUPPET_VERSION', expected_puppet: '7', expected_ruby: '2.7.8' },
+    { envvar: 'PDK_PUPPET_VERSION', expected_puppet: '8', expected_ruby: '3.2.2' }
   ]
 
   before(:all) do
@@ -28,8 +28,8 @@ describe 'Test puppet & ruby version selection' do
 
       describe command('pdk bundle exec puppet --version') do
         its(:exit_status) { is_expected.to eq(0) }
-        its(:stderr) { is_expected.to match(/using puppet (#{expected_puppet})/im) }
-        its(:stdout) { is_expected.to match(/^(#{expected_puppet})*/im) }
+        its(:stderr) { is_expected.to match(/using puppet (#{expected_puppet}\.\d+\.\d+)/im) }
+        its(:stdout) { is_expected.to match(/^(#{expected_puppet}\.\d+\.\d+)*/im) }
       end
 
       describe command('pdk bundle exec ruby --version') do


### PR DESCRIPTION
Update tests to check against installing the Major versions of the PDK. This is due to the test environment only having certain versions available to install and thus necessitating that the version be updated more often than is preferred.
With this change that is no longer necessary and the test should not need to be updated again in this manner until the release of Puppet 9.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
