### PR TITLE
(CAT-1796) Fix missing locale gem

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
   spec.add_runtime_dependency 'facter', '~> 4.0'
   spec.add_runtime_dependency 'httpclient', '~> 2.8.3'
+  spec.add_runtime_dependency 'locale', '~> 2.1.0'
 
   # Used in the pdk-templates
   spec.add_runtime_dependency 'deep_merge', '~> 1.2.2'


### PR DESCRIPTION
Following some investigation, it was noted that
the pdk gem could not work correctly when analytics were enabled. This was due to the fact that the
locale gem was missing for its correct operation.

This commit adds the locale gem to the pdk.gemspec to solve the current issue.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
