### PR TITLE
(BUGFIX) Pin bundler version

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_runtime_dependency 'bundler', '>= 2.1.0', '< 3.0.0'
+  spec.add_runtime_dependency 'bundler', '>= 2.1.0', '< 2.5.10'
   spec.add_runtime_dependency 'childprocess', '~> 4.1.0'
   spec.add_runtime_dependency 'cri', '~> 2.15.11'
   spec.add_runtime_dependency 'diff-lcs', '>= 1.5.0'

--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_runtime_dependency 'bundler', '>= 2.1.0', '< 2.5.10'
+  spec.add_runtime_dependency 'bundler', '>= 2.1.0', '< 2.5.9'
   spec.add_runtime_dependency 'childprocess', '~> 4.1.0'
   spec.add_runtime_dependency 'cri', '~> 2.15.11'
   spec.add_runtime_dependency 'diff-lcs', '>= 1.5.0'


### PR DESCRIPTION
Version seems to be causing errors on windows 2019 3.2

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
