### PR TITLE
Configure cert.pem for self-hosted git repos

### DIFF
--- a/docs/pdk_install.md
+++ b/docs/pdk_install.md
@@ -296,3 +296,7 @@ $env:http_proxy="http://user:password@proxy.domain.com:port"
 
 $env:https_proxy="http://user:password@proxy.domain.com:port"
 ```
+
+## Setting up the PDK to connect to self-hosted git repositories
+
+If after you've created a new module with the pdk, you want to download and test dependencies or "fixtures" from a self-hosted git repository, then you'll need to configure the pdk to trust this self-hosted site.  For more information, see [PDK Troubleshooting](pdk_troubleshooting.md#pdk-failing-to-pull-from-custom-git-server).

--- a/docs/pdk_known_issues.md
+++ b/docs/pdk_known_issues.md
@@ -1,5 +1,9 @@
 # PDK known issues
 
-## PDK 3.0.0
+## Upgrading the pdk over-writes the pdk's "cert.pem"
 
-For more information about upgrading your PDK installation, see [Upgrading PDK](pdk_upgrading.md).
+Upgrading the pdk from one version to another, e.g., going from `3.0.0.0` to `3.2.0.1`, will over-write the existing `/opt/puppetlabs/pdk/ssl/cert.pem` on linux or `C:\Program Files\Puppet Labs\DevelopmentKit\ssl\cert.pem` on windows.
+
+For example, if you have customized the `cert.pem` to trust a self-hosted git repository server like `git.self.hosted`, then after the PDK upgrade an error may appear during PDK usage like `fatal: unable to access 'https://git.self.hosted/companyxyz/mymodule.git/': SSL certificate problem: self signed certificate`.
+
+For more information on how to correct this known issue see the [PDK Troubleshooting](pdk_troubleshooting.md#pdk-failing-to-pull-from-custom-git-server) section.

--- a/docs/pdk_troubleshooting.md
+++ b/docs/pdk_troubleshooting.md
@@ -1,6 +1,6 @@
 # PDK troubleshooting
 
-If you are encountering trouble with PDK, check for these common issues. 
+If you are encountering trouble with PDK, check for these common issues.
 
 ## PDK not in ZShell PATH on Mac OS X
 
@@ -8,3 +8,42 @@ With ZShell on Mac OS X, PDK is not automatically added to the PATH. To fix
 this, add the PATH by adding the line `eval (/usr/libexec/path_helper -s)` to
 the ZShell resource file (`~/.zshrc`).
 
+## PDK failing to pull from custom git server
+
+If a `fatal: unable to access...SSL certificate problem: self signed certificate` error occurs during PDK usage, it indicates that the PDK is trying to download a module from a source that isn't trusted. For example, given a `.fixtures.yml` that references an untrusted self-hosted git repository server `git.self.hosted`
+
+```yaml
+# .fixtures.yml
+---
+fixtures:
+  forge_modules:
+    nginx: "puppet/nginx"
+  repositories:
+    mymodule: 'https://git.self.hosted/companyxyz/mymodule.git'
+```
+
+then running `pdk test unit` will throw an error something like:
+
+```bash
+root@seattle:~/modules/tester# pdk test unit
+pdk (INFO): Using Ruby 3.2.2
+pdk (INFO): Using Puppet 8.1.0
+[✖] Preparing to run the unit tests.
+[✔] Cleaning up after running unit tests.
+pdk (ERROR): The spec_prep rake task failed with the following error(s):
+
+Cloning into 'spec/fixtures/modules/mymodule'...
+fatal: unable to access 'https://git.self.hosted/companyxyz/mymodule.git/': SSL certificate problem: self signed certificate
+#<Thread:0x00007ffff9b2e138 /opt/puppetlabs/pdk/share/cache/ruby/3.2.0/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:471 run> terminated with exception (report_on_exception is true):
+...
+...
+```
+
+To resolve this issue, first create a backup of the existing PDK certificates file, which lives `/opt/puppetlabs/pdk/ssl/cert.pem` on linux machines and `C:\Program Files\Puppet Labs\DevelopmentKit\ssl\cert.pem` on windows.  
+
+Then do the following
+
+* Obtain the chain of trust certificates from the self-hosted server.  For example, `printf '' | openssl s_client -connect git.self.hosted:443 -showcerts` will return metadata including the trust certificates for the `git.self.hosted:443` server.
+* Append the trust certificates to the end of the `cert.pem` ensuring the pdk "trusts" the new self-hosted git server.
+
+**NOTE:** There is a known issue [Upgrading the pdk over-writes the pdk's cert.pem](pdk_known_issues.md#upgrading-the-pdk-over-writes-the-pdks-certpem).  Therefore, any custom certificates will need to be added again after upgrading the pdk.

--- a/docs/pdk_upgrading.md
+++ b/docs/pdk_upgrading.md
@@ -7,6 +7,8 @@ Upgrade PDK using the same method you used to originally install it. See the PDK
 [installation](pdk_install.md) instructions for your platform for details.
 Then, update your modules to integrate any module template changes.
 
+Note also that if you have added certificates for self-hosted git repositories to the pdk's `cert.pem` (`/opt/puppetlabs/pdk/ssl/cert.pem` on linux or `C:\Program Files\Puppet Labs\DevelopmentKit\ssl\cert.pem` on windows), then you'll need to re-append these certificates after the pdk upgrade. For more information see the known issue [Upgrading the pdk over-writes the pdk's `cert.pem`](pdk_known_issues.md#upgrading-the-pdk-over-writes-the-pdks-certpem).
+
 ## Upgrading to PDK 3.0.0
 
 ### Clear the local PDK cache


### PR DESCRIPTION
## Summary

When using `pdk test unit` one of the actions it performs is to download any module dependencies defined in the `.fixtures.yml`.  If these dependencies are held in self-hosted repositories then pdk's `cert.pem`[^1] must be configured to trust the self-hosted server.  Otherwise, an error like `fatal: unable to access...SSL certificate problem: self signed certificate` will occur when using the PDK, particularly when running `pdk test unit`.  

I've kept the guts of the explanation in the troubleshooting and then linked from related pages (install, upgrade, known issues) to the troubleshooting page.

This PR adds instruction to the docs on how to fix the above and also explains a related known issue: upgrading the PDK will overwrite any previous changes to the `cert.pem`

[^1]: `/opt/puppetlabs/pdk/ssl/cert.pem` on linux and `C:\Program Files\Puppet Labs\DevelopmentKit\ssl\cert.pem` on windows

## Checklist
- [x] Manually verified.
