### PR TITLE
(CAT-1832) Globalize Puppet and Ruby versions within PDK testing framework

### DIFF
--- a/package-testing/spec/package/airgapped_usage_spec.rb
+++ b/package-testing/spec/package/airgapped_usage_spec.rb
@@ -28,11 +28,8 @@ describe 'Basic usage in an air-gapped environment' do
     end
 
     context 'when validating the module' do
-      context 'with puppet 8.x' do
-        puppet_version = '8.x'
-        let(:ruby_version) { ruby_for_puppet(puppet_version) }
-
-        describe command("pdk validate --puppet-version=#{puppet_version}") do
+      context "with puppet #{PDK_VERSION[:latest][:major]}" do
+        describe command("pdk validate --puppet-version=#{PDK_VERSION[:latest][:major]}") do
           let(:cwd) { module_name }
 
           its(:exit_status) { is_expected.to eq(0) }
@@ -45,7 +42,7 @@ describe 'Basic usage in an air-gapped environment' do
             subject { super().content.gsub(/^DEPENDENCIES.+?\n\n/m, '') }
 
             it 'is identical to the vendored lockfile' do
-              vendored_lockfile = File.join(install_dir, 'share', 'cache', "Gemfile-#{ruby_version}.lock")
+              vendored_lockfile = File.join(install_dir, 'share', 'cache', "Gemfile-#{PDK_VERSION[:latest][:ruby]}.lock")
 
               expect(subject).to eq(file(vendored_lockfile).content.gsub(/^DEPENDENCIES.+?\n\n/m, ''))
             end

--- a/package-testing/spec/package/validate_a_new_module_spec.rb
+++ b/package-testing/spec/package/validate_a_new_module_spec.rb
@@ -18,11 +18,8 @@ describe 'C100321 - Generate a module and validate it (i.e. ensure bundle instal
   end
 
   context 'when validating the module' do
-    context 'with puppet 8.x' do
-      puppet_version = '8.x'
-      let(:ruby_version) { ruby_for_puppet(puppet_version) }
-
-      describe command("pdk validate --puppet-version=#{puppet_version}") do
+    context "with puppet #{PDK_VERSION[:latest][:major]}" do
+      describe command("pdk validate --puppet-version=#{PDK_VERSION[:latest][:major]}") do
         let(:cwd) { module_name }
 
         its(:exit_status) { is_expected.to eq(0) }
@@ -35,7 +32,7 @@ describe 'C100321 - Generate a module and validate it (i.e. ensure bundle instal
           subject { super().content.gsub(/^DEPENDENCIES.+?\n\n/m, '') }
 
           it 'is identical to the vendored lockfile' do
-            vendored_lockfile = File.join(install_dir, 'share', 'cache', "Gemfile-#{ruby_version}.lock")
+            vendored_lockfile = File.join(install_dir, 'share', 'cache', "Gemfile-#{PDK_VERSION[:latest][:ruby]}.lock")
 
             expect(subject).to eq(file(vendored_lockfile).content.gsub(/^DEPENDENCIES.+?\n\n/m, ''))
           end

--- a/package-testing/spec/package/version_selection_spec.rb
+++ b/package-testing/spec/package/version_selection_spec.rb
@@ -2,16 +2,13 @@ require 'spec_helper_package'
 
 describe 'Test puppet & ruby version selection' do
   module_name = 'version_selection'
-  # IMPORTANT: The following block should be updated with the version of ruby that is included within the newest
-  #   Puppet release for each major version. If you are running integration testing prior to a release and its
-  #   failing, verify that the following versions are correct.
   test_cases = [
-    { envvar: 'PDK_PUPPET_VERSION', expected_puppet: '7', expected_ruby: '2.7.8' },
-    { envvar: 'PDK_PUPPET_VERSION', expected_puppet: '8', expected_ruby: '3.2.2' }
+    { envvar: 'PDK_PUPPET_VERSION', expected_puppet: PDK_VERSION[:lts][:major], expected_ruby: PDK_VERSION[:lts][:ruby] },
+    { envvar: 'PDK_PUPPET_VERSION', expected_puppet: PDK_VERSION[:latest][:major], expected_ruby: PDK_VERSION[:latest][:ruby] }
   ]
 
   before(:all) do
-    command("pdk new module #{module_name} --skip-interview").run
+    command('pdk new module version_selection --skip-interview').run
   end
 
   test_cases.each do |test_case|

--- a/package-testing/spec/spec_helper_package.rb
+++ b/package-testing/spec/spec_helper_package.rb
@@ -8,6 +8,23 @@ include SpecUtils # rubocop:disable Style/MixinUsage
 bin_path = SpecUtils.windows_node? ? 'bin$PATH' : 'bin:$PATH'
 set :path, "#{SpecUtils.install_dir}/#{bin_path}"
 
+# IMPORTANT: The following block should be updated with the version of ruby that is included within the newest
+#   Puppet release for each major version. If you are running integration testing prior to a release and its
+#   failing, verify that the following versions are correct.
+# Duplicates of this are found within spec_helper.rb and spec_helper_acceptance.rb and should be updated simultaneously.
+PDK_VERSION = {
+  latest: {
+    full: '8.6.0',
+    major: '8',
+    ruby: '3.2.3'
+  },
+  lts: {
+    full: '7.30.0',
+    major: '7',
+    ruby: '2.7.8'
+  }
+}.freeze
+
 RSpec.configure do |c|
   c.include SpecUtils
   c.extend SpecUtils

--- a/package-testing/spec/spec_helper_package.rb
+++ b/package-testing/spec/spec_helper_package.rb
@@ -16,12 +16,12 @@ PDK_VERSION = {
   latest: {
     full: '8.6.0',
     major: '8',
-    ruby: '3.2.3'
+    ruby: '3.2.*'
   },
   lts: {
     full: '7.30.0',
     major: '7',
-    ruby: '2.7.8'
+    ruby: '2.7.*'
   }
 }.freeze
 

--- a/spec/acceptance/support/in_a_new_module.rb
+++ b/spec/acceptance/support/in_a_new_module.rb
@@ -12,7 +12,7 @@ shared_context 'in a new module' do |name, options = {}|
     ]
     env = {
       'PDK_ANSWER_FILE' => File.join(Dir.pwd, "#{name}_answers.json"),
-      'PDK_PUPPET_VERSION' => ENV.fetch('PDK_PUPPET_VERSION', '7')
+      'PDK_PUPPET_VERSION' => ENV.fetch('PDK_PUPPET_VERSION', PDK_VERSION[:lts][:full])
     }
 
     output, status = Open3.capture2e(env, *argv)

--- a/spec/acceptance/version_changer_spec.rb
+++ b/spec/acceptance/version_changer_spec.rb
@@ -21,7 +21,7 @@ describe 'puppet version selection' do
       end
     end
 
-    ['7.22.0'].each do |puppet_version|
+    [PDK_VERSION[:lts][:full], PDK_VERSION[:latest][:full]].each do |puppet_version|
       context "when requesting --puppet-version #{puppet_version}" do
         describe command("pdk validate --puppet-version #{puppet_version}") do
           its(:exit_status) { is_expected.to eq(0) }

--- a/spec/acceptance/version_changer_spec.rb
+++ b/spec/acceptance/version_changer_spec.rb
@@ -21,7 +21,7 @@ describe 'puppet version selection' do
       end
     end
 
-    [PDK_VERSION[:lts][:full], PDK_VERSION[:latest][:full]].each do |puppet_version|
+    [PDK_VERSION[:lts][:full]].each do |puppet_version|
       context "when requesting --puppet-version #{puppet_version}" do
         describe command("pdk validate --puppet-version #{puppet_version}") do
           its(:exit_status) { is_expected.to eq(0) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,12 +64,12 @@ PDK_VERSION = {
   latest: {
     full: '8.6.0',
     major: '8',
-    ruby: '3.2.3'
+    ruby: '3.2.*'
   },
   lts: {
     full: '7.30.0',
     major: '7',
-    ruby: '2.7.8'
+    ruby: '2.7.*'
   }
 }.freeze
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,6 +59,7 @@ RSpec.configure do |c|
 end
 
 # Sets default puppet/ruby versions to be used within the tests
+# Duplicates of this are found within spec_helper_package.rb and spec_helper_acceptance.rb and should be updated simultaneously.
 PDK_VERSION = {
   latest: {
     full: '8.6.0',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,6 +58,20 @@ RSpec.configure do |c|
   c.root = File.dirname(__FILE__)
 end
 
+# Sets default puppet/ruby versions to be used within the tests
+PDK_VERSION = {
+  latest: {
+    full: '8.6.0',
+    major: '8',
+    ruby: '3.2.3'
+  },
+  lts: {
+    full: '7.30.0',
+    major: '7',
+    ruby: '2.7.8'
+  }
+}.freeze
+
 # Add method to StringIO needed for TTY::Prompt::Test to work on tty-prompt >=
 # 0.19 (see https://github.com/piotrmurach/tty-prompt/issues/104)
 class StringIO

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -7,6 +7,20 @@ require 'pdk/util/template_uri'
 require 'tempfile'
 require 'json'
 
+# Sets default puppet/ruby versions to be used within the tests
+PDK_VERSION = {
+  latest: {
+    full: '8.6.0',
+    major: '8',
+    ruby: '3.2.3'
+  },
+  lts: {
+    full: '7.30.0',
+    major: '7',
+    ruby: '2.7.8'
+  }
+}.freeze
+
 # automatically load any shared examples or contexts
 Dir['./spec/acceptance/support/**/*.rb'].sort.each { |f| require f }
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -8,6 +8,7 @@ require 'tempfile'
 require 'json'
 
 # Sets default puppet/ruby versions to be used within the tests
+# Duplicates of this are found within spec_helper.rb and spec_helper_package.rb and should be updated simultaneously.
 PDK_VERSION = {
   latest: {
     full: '8.6.0',

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,12 +13,12 @@ PDK_VERSION = {
   latest: {
     full: '8.6.0',
     major: '8',
-    ruby: '3.2.3'
+    ruby: '3.2.*'
   },
   lts: {
     full: '7.30.0',
     major: '7',
-    ruby: '2.7.8'
+    ruby: '2.7.*'
   }
 }.freeze
 

--- a/spec/unit/pdk/cli/test/unit_spec.rb
+++ b/spec/unit/pdk/cli/test/unit_spec.rb
@@ -4,8 +4,8 @@ require 'pdk/cli'
 describe '`pdk test unit`' do
   subject(:test_unit_cmd) { PDK::CLI.instance_variable_get(:@test_unit_cmd) }
 
-  let(:puppet_version) { '5.4.0' }
-  let(:ruby_version) { '2.4.3' }
+  let(:ruby_version) { PDK_VERSION[:latest][:ruby] }
+  let(:puppet_version) { PDK_VERSION[:latest][:full] }
 
   before do
     allow(PDK::Util::RubyVersion).to receive(:use)
@@ -204,11 +204,11 @@ describe '`pdk test unit`' do
   end
 
   context 'with --puppet-version' do
-    let(:puppet_version) { '5.3' }
+    let(:puppet_version) { PDK_VERSION[:lts][:full] }
     let(:puppet_env) do
       {
         ruby_version: ruby_version,
-        gemset: { puppet: '5.3.5' }
+        gemset: { puppet: PDK_VERSION[:latest][:full] }
       }
     end
 

--- a/spec/unit/pdk/cli/util_spec.rb
+++ b/spec/unit/pdk/cli/util_spec.rb
@@ -231,8 +231,8 @@ describe PDK::CLI::Util do
 
     context 'when puppet-version has been set' do
       let(:options) { { 'puppet-version': '8' } }
-      let(:ruby_version) { '3.2.2' }
-      let(:puppet_version) { '8' }
+      let(:ruby_version) { PDK_VERSION[:latest][:ruby] }
+      let(:puppet_version) { PDK_VERSION[:latest][:major] }
 
       before do
         allow(PDK::Util::PuppetVersion).to receive(:find_gem_for).with(anything).and_return(version_result)
@@ -243,12 +243,12 @@ describe PDK::CLI::Util do
 
     context 'when PDK_PUPPET_VERSION has been set' do
       let(:options) { {} }
-      let(:ruby_version) { '3.2.2' }
-      let(:puppet_version) { '8.1.0' }
+      let(:ruby_version) { PDK_VERSION[:latest][:ruby] }
+      let(:puppet_version) { PDK_VERSION[:latest][:full] }
 
       before do
         allow(PDK::Util::PuppetVersion).to receive(:find_gem_for).with(anything).and_return(version_result)
-        allow(PDK::Util::Env).to receive(:[]).with('PDK_PUPPET_VERSION').and_return('4.10.10')
+        allow(PDK::Util::Env).to receive(:[]).with('PDK_PUPPET_VERSION').and_return(PDK_VERSION[:latest][:full])
       end
 
       it_behaves_like 'it returns a puppet environment'
@@ -261,8 +261,8 @@ describe PDK::CLI::Util do
         let(:context) { PDK::Context::Module.new(nil, nil) }
 
         context 'and a puppet version can be found in the module metadata' do
-          let(:ruby_version) { '3.2.2' }
-          let(:puppet_version) { '8.1.0' }
+          let(:ruby_version) { PDK_VERSION[:latest][:ruby] }
+          let(:puppet_version) { PDK_VERSION[:latest][:full] }
 
           before do
             allow(PDK::Util::PuppetVersion).to receive(:from_module_metadata).and_return(version_result)
@@ -277,8 +277,8 @@ describe PDK::CLI::Util do
         end
 
         context 'and there is no puppet version in the module metadata' do
-          let(:ruby_version) { '3.2.2' }
-          let(:puppet_version) { '8.1.0' }
+          let(:ruby_version) { PDK_VERSION[:latest][:ruby] }
+          let(:puppet_version) { PDK_VERSION[:latest][:full] }
 
           before do
             allow(PDK::Util::PuppetVersion).to receive_messages(from_module_metadata: nil, latest_available: version_result)
@@ -291,8 +291,8 @@ describe PDK::CLI::Util do
       context 'in a Control Repo Context' do
         let(:context) { PDK::Context::ControlRepo.new(nil, nil) }
 
-        let(:ruby_version) { '3.2.2' }
-        let(:puppet_version) { '8.1.0' }
+        let(:ruby_version) { PDK_VERSION[:latest][:ruby] }
+        let(:puppet_version) { PDK_VERSION[:latest][:full] }
 
         before do
           expect(PDK::Util::PuppetVersion).to receive(:latest_available).and_return(version_result)
@@ -394,8 +394,8 @@ describe PDK::CLI::Util do
   describe '.validate_puppet_version_opts' do
     subject(:validate_puppet_version_opts) { described_class.validate_puppet_version_opts(options) }
 
-    let(:cli_puppet_version) { '5.3' }
-    let(:env_puppet_version) { '5.1' }
+    let(:cli_puppet_version) { PDK_VERSION[:latest][:full] }
+    let(:env_puppet_version) { PDK_VERSION[:lts][:full] }
 
     context 'when --puppet-dev is set' do
       let(:options) { { 'puppet-dev': true } }

--- a/spec/unit/pdk/cli/validate_spec.rb
+++ b/spec/unit/pdk/cli/validate_spec.rb
@@ -6,8 +6,8 @@ describe 'Running `pdk validate` in a module' do
 
   let(:pretty_validator_names) { PDK::Validate.validator_names.join(', ') }
   let(:report) { instance_double(PDK::Report).as_null_object }
-  let(:ruby_version) { '3.2.2' }
-  let(:puppet_version) { '8.0.1' }
+  let(:ruby_version) { PDK_VERSION[:latest][:ruby] }
+  let(:puppet_version) { PDK_VERSION[:latest][:full] }
   let(:module_path) { '/path/to/testmodule' }
   let(:context) { PDK::Context::Module.new(module_path, module_path) }
 
@@ -205,11 +205,11 @@ describe 'Running `pdk validate` in a module' do
   end
 
   context 'with --puppet-version' do
-    let(:puppet_version) { '5.3' }
+    let(:puppet_version) { PDK_VERSION[:lts][:ruby] }
     let(:puppet_env) do
       {
         ruby_version: ruby_version,
-        gemset: { puppet: '5.3.5' }
+        gemset: { puppet: PDK_VERSION[:latest][:full] }
       }
     end
 

--- a/spec/unit/pdk/util/ruby_version_spec.rb
+++ b/spec/unit/pdk/util/ruby_version_spec.rb
@@ -40,7 +40,7 @@ describe PDK::Util::RubyVersion do
     context 'when running from a package install' do
       include_context 'is a package install'
 
-      ['2.1.9', '2.4.4'].each do |ruby_version|
+      [PDK_VERSION[:lts][:ruby], PDK_VERSION[:latest][:ruby]].each do |ruby_version|
         context "when the active ruby version is #{ruby_version}" do
           let(:instance) { described_class.new(ruby_version) }
 
@@ -67,6 +67,7 @@ describe PDK::Util::RubyVersion do
       include_context 'is a package install'
 
       before do
+        # require 'pry'; binding.pry;
         allow(described_class).to receive_messages(versions: packaged_rubies, default_ruby_version: '2.4.4')
       end
 
@@ -143,7 +144,7 @@ describe PDK::Util::RubyVersion do
     let(:gem_home_pattern) { File.join(gem_home, 'specifications', '**', 'puppet*.gemspec') }
     let(:gem_path_results) do
       results = {}
-      [{ name: 'puppet', version: '4.10.10' }, { name: 'puppet-lint', version: '1.0.0' }].each do |spec_info|
+      [{ name: 'puppet', version: PDK_VERSION[:lts][:full] }, { name: 'puppet-lint', version: '1.0.0' }].each do |spec_info|
         spec_path = File.join(gem_home, 'specifications', "#{spec_info[:name]}-#{spec_info[:version]}.gemspec")
         spec_definition = Gem::Specification.new do |spec|
           spec.name = spec_info[:name]
@@ -155,7 +156,7 @@ describe PDK::Util::RubyVersion do
     end
     let(:gem_home_results) do
       results = {}
-      [{ name: 'puppet', version: '5.3.0' }].each do |spec_info|
+      [{ name: 'puppet', version: PDK_VERSION[:latest][:full] }].each do |spec_info|
         spec_path = File.join(gem_home, 'specifications', "#{spec_info[:name]}-#{spec_info[:version]}.gemspec")
         spec_definition = Gem::Specification.new do |spec|
           spec.name = spec_info[:name]
@@ -181,7 +182,7 @@ describe PDK::Util::RubyVersion do
     end
 
     it 'returns an ordered list of Puppet gem versions' do
-      expect(subject).to eq([Gem::Version.new('5.3.0'), Gem::Version.new('4.10.10')])
+      expect(subject).to eq([Gem::Version.new(PDK_VERSION[:latest][:full]), Gem::Version.new(PDK_VERSION[:lts][:full])])
     end
   end
 end


### PR DESCRIPTION
Set Ruby and Puppet versions used within unit, acceptance and package/integration tests to take from a hash set within their respective `spec_helper`

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
