### PR TITLE
(CAT-1940) Move Windows testing onto the GCP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
-          - "windows-2019"
         ruby_version:
           - "2.7"
           - "3.2"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,6 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
-          - "windows-2019"
         ruby_version:
           - "2.7"
           - "3.2"

--- a/.github/workflows/windows-acceptance.yml
+++ b/.github/workflows/windows-acceptance.yml
@@ -1,0 +1,58 @@
+# This is a generic workflow for gem Acceptance operations.
+name: "Windows Acceptance"
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  acceptance:
+    name: "acceptance"
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+
+    env:
+      PUPPET_VERSION: puppet8-nightly
+      PUPPET_GEM_VERSION: puppet8-nightly
+
+    steps:
+
+      - name: "checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "setup ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: "Bundle environment"
+        run: |
+          echo ::group::bundler environment
+          bundle env
+          echo ::endgroup::
+
+      - name: "Provision environment"
+        run: |
+          bundle exec rake "litmus:provision[provision_service,windows-2019]"
+          # Redact password
+          FILE='spec/fixtures/litmus_inventory.yaml'
+          sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
+
+      - name: "Run acceptance tests"
+        run: |
+          bundle exec rake 'litmus:acceptance:parallel'
+
+      - name: "Remove test environment"
+        continue-on-error: true
+        run: |
+          if [[ -f spec/fixtures/litmus_inventory.yaml ]]; then
+            bundle exec rake 'litmus:tear_down'
+          fi

--- a/.github/workflows/windows-acceptance.yml
+++ b/.github/workflows/windows-acceptance.yml
@@ -50,9 +50,9 @@ jobs:
         run: |
           bundle exec rake 'litmus:acceptance:parallel'
 
-      - name: "Remove test environment"
-        continue-on-error: true
-        run: |
-          if [[ -f spec/fixtures/litmus_inventory.yaml ]]; then
-            bundle exec rake 'litmus:tear_down'
-          fi
+      # - name: "Remove test environment"
+      #   continue-on-error: true
+      #   run: |
+      #     if [[ -f spec/fixtures/litmus_inventory.yaml ]]; then
+      #       bundle exec rake 'litmus:tear_down'
+      #     fi

--- a/Gemfile
+++ b/Gemfile
@@ -35,4 +35,5 @@ end
 
 group :acceptance_ci do
   gem 'puppetlabs_spec_helper', '~> 7.0', require: false
+  gem 'puppet_litmus', '~> 1.0', require: false
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'bundler/gem_tasks'
 require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
+require 'puppetlabs_spec_helper/rake_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -6,6 +6,9 @@ require 'pdk/generate/module'
 require 'pdk/util/template_uri'
 require 'tempfile'
 require 'json'
+require 'puppet_litmus'
+
+PuppetLitmus.configure!
 
 # Sets default puppet/ruby versions to be used within the tests
 # Duplicates of this are found within spec_helper.rb and spec_helper_package.rb and should be updated simultaneously.


### PR DESCRIPTION
## Summary
Due to conflicts with the GHA windows runners causing failures on the Windows 2019 ruby 3.2 branch we are looking to move the windows tests to be run on the GCP images instead.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
