### PR TITLE
(CAT-1928) Update Supported OS on new module to match what is expected

### DIFF
--- a/lib/pdk/module/metadata.rb
+++ b/lib/pdk/module/metadata.rb
@@ -9,7 +9,7 @@ module PDK
         'RedHat based Linux' => [
           {
             'operatingsystem' => 'CentOS',
-            'operatingsystemrelease' => ['7']
+            'operatingsystemrelease' => ['7', '8', '9']
           },
           {
             'operatingsystem' => 'OracleLinux',
@@ -17,30 +17,38 @@ module PDK
           },
           {
             'operatingsystem' => 'RedHat',
-            'operatingsystemrelease' => ['8']
+            'operatingsystemrelease' => ['7', '8', '9']
           },
           {
             'operatingsystem' => 'Scientific',
             'operatingsystemrelease' => ['7']
+          },
+          {
+            'operatingsystem' => 'Rocky',
+            'operatingsystemrelease' => ['8']
+          },
+          {
+            'operatingsystem' => 'AlmaLinux',
+            'operatingsystemrelease' => ['8']
           }
         ],
         'Debian based Linux' => [
           {
             'operatingsystem' => 'Debian',
-            'operatingsystemrelease' => ['10']
+            'operatingsystemrelease' => ['10', '11', '12']
           },
           {
             'operatingsystem' => 'Ubuntu',
-            'operatingsystemrelease' => ['18.04']
+            'operatingsystemrelease' => ['18.04', '20.04', '22.04']
           }
         ],
         'Fedora' => {
           'operatingsystem' => 'Fedora',
-          'operatingsystemrelease' => ['29']
+          'operatingsystemrelease' => ['40']
         },
         'OSX' => {
           'operatingsystem' => 'Darwin',
-          'operatingsystemrelease' => ['16']
+          'operatingsystemrelease' => ['21', '22', '23']
         },
         'SLES' => {
           'operatingsystem' => 'SLES',
@@ -52,11 +60,11 @@ module PDK
         },
         'Windows' => {
           'operatingsystem' => 'windows',
-          'operatingsystemrelease' => ['2019', '10']
+          'operatingsystemrelease' => ['2019', '2022', '10', '11']
         },
         'AIX' => {
           'operatingsystem' => 'AIX',
-          'operatingsystemrelease' => ['6.1', '7.1', '7.2']
+          'operatingsystemrelease' => ['7.2', '7.3']
         }
       }.freeze
 

--- a/spec/acceptance/new_module_spec.rb
+++ b/spec/acceptance/new_module_spec.rb
@@ -26,7 +26,7 @@ describe 'pdk new module' do
             'template-ref' => match(%r{(main-)|(^(tags/)?(\d+)\.(\d+)\.(\d+))}),
             'operatingsystem_support' => include(
               'operatingsystem' => 'Debian',
-              'operatingsystemrelease' => ['10']
+              'operatingsystemrelease' => ['10', '11', '12']
             )
           )
         end

--- a/spec/unit/pdk/generate/module_spec.rb
+++ b/spec/unit/pdk/generate/module_spec.rb
@@ -379,6 +379,7 @@ describe PDK::Generate::Module do
           ]
         end
 
+        # rubocop:disable RSpec/ExampleLength
         it 'populates the Metadata object based on user input' do
           expect(interview_metadata).to include(
             'name' => 'foo-bar',
@@ -392,7 +393,7 @@ describe PDK::Generate::Module do
             'operatingsystem_support' => [
               {
                 'operatingsystem' => 'CentOS',
-                'operatingsystemrelease' => ['7']
+                'operatingsystemrelease' => ['7', '8', '9']
               },
               {
                 'operatingsystem' => 'OracleLinux',
@@ -400,27 +401,36 @@ describe PDK::Generate::Module do
               },
               {
                 'operatingsystem' => 'RedHat',
-                'operatingsystemrelease' => ['8']
+                'operatingsystemrelease' => ['7', '8', '9']
               },
               {
                 'operatingsystem' => 'Scientific',
                 'operatingsystemrelease' => ['7']
               },
               {
+                'operatingsystem' => 'Rocky',
+                'operatingsystemrelease' => ['8']
+              },
+              {
+                'operatingsystem' => 'AlmaLinux',
+                'operatingsystemrelease' => ['8']
+              },
+              {
                 'operatingsystem' => 'Debian',
-                'operatingsystemrelease' => ['10']
+                'operatingsystemrelease' => ['10', '11', '12']
               },
               {
                 'operatingsystem' => 'Ubuntu',
-                'operatingsystemrelease' => ['18.04']
+                'operatingsystemrelease' => ['18.04', '20.04', '22.04']
               },
               {
                 'operatingsystem' => 'windows',
-                'operatingsystemrelease' => ['2019', '10']
+                'operatingsystemrelease' => ['2019', '2022', '10', '11']
               }
             ]
           )
         end
+        # rubocop:enable RSpec/ExampleLength
 
         it 'saves the forge username to the answer file' do
           expect(answers['forge_username']).to eq('foo')
@@ -649,9 +659,9 @@ describe PDK::Generate::Module do
         expect(interview_metadata['operatingsystem_support']).not_to be_nil
 
         [
-          { 'operatingsystem' => 'Debian', 'operatingsystemrelease' => ['10'] },
-          { 'operatingsystem' => 'Ubuntu', 'operatingsystemrelease' => ['18.04'] },
-          { 'operatingsystem' => 'windows', 'operatingsystemrelease' => ['2019', '10'] },
+          { 'operatingsystem' => 'Debian', 'operatingsystemrelease' => ['10', '11', '12'] },
+          { 'operatingsystem' => 'Ubuntu', 'operatingsystemrelease' => ['18.04', '20.04', '22.04'] },
+          { 'operatingsystem' => 'windows', 'operatingsystemrelease' => ['2019', '2022', '10', '11'] },
           { 'operatingsystem' => 'Solaris', 'operatingsystemrelease' => ['11'] }
         ].each do |expected_os|
           expect(interview_metadata['operatingsystem_support']).to include(expected_os)


### PR DESCRIPTION
Update the OS listed as supported in a default module to more accurately match what we would expect support for each OS to be.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified.
