### PR TITLE
Support executable templates on filesystems mounted with `noexec`

### DIFF
--- a/lib/pdk/module/convert.rb
+++ b/lib/pdk/module/convert.rb
@@ -163,7 +163,7 @@ module PDK
             when :manage
               if PDK::Util::Filesystem.exist?(absolute_file_path)
                 update_manager.modify_file(absolute_file_path, file_content)
-                update_manager.make_file_executable(absolute_file_path) if file_executable && !PDK::Util::Filesystem.executable?(absolute_file_path)
+                update_manager.make_file_executable(absolute_file_path) if file_executable && !PDK::Util::Filesystem.stat(absolute_file_path).executable?
               else
                 update_manager.add_file(absolute_file_path, file_content)
                 update_manager.make_file_executable(absolute_file_path) if file_executable

--- a/lib/pdk/template/renderer/v1/renderer.rb
+++ b/lib/pdk/template/renderer/v1/renderer.rb
@@ -95,7 +95,7 @@ module PDK
                 end
               end
 
-              dest_executable = config['manage_execute_permissions'] && PDK::Util::Filesystem.executable?(File.join(template_loc, template_file))
+              dest_executable = config['manage_execute_permissions'] && PDK::Util::Filesystem.stat(File.join(template_loc, template_file)).executable?
 
               yield dest_path, dest_content, dest_status, dest_executable
             end

--- a/spec/unit/pdk/module/convert_spec.rb
+++ b/spec/unit/pdk/module/convert_spec.rb
@@ -185,6 +185,8 @@ describe PDK::Module::Convert do
       include_context 'completes a convert'
 
       before do
+        stat_double = instance_double(File::Stat, executable?: false)
+        allow(PDK::Util::Filesystem).to receive(:stat).with(module_path('/a/path/to/file')).and_return(stat_double)
         allow(PDK::Util::Filesystem).to receive(:exist?).with(module_path('/a/path/to/file')).and_return(true)
         allow(update_manager).to receive(:modify_file).with(any_args)
         allow(update_manager).to receive(:changes?).and_return(true)
@@ -227,6 +229,8 @@ describe PDK::Module::Convert do
       include_context 'completes a convert'
 
       before do
+        stat_double = instance_double(File::Stat, executable?: false)
+        allow(PDK::Util::Filesystem).to receive(:stat).with(module_path('/a/path/to/file')).and_return(stat_double)
         allow(PDK::Util::Filesystem).to receive(:exist?).with(module_path('/a/path/to/file')).and_return(true)
         allow(update_manager).to receive(:modify_file).with(any_args)
         allow(update_manager).to receive(:changes?).and_return(true)
@@ -284,7 +288,8 @@ describe PDK::Module::Convert do
           context 'when managing file execute bits' do
             context 'when file exists and has correct execute bits' do
               before do
-                allow(PDK::Util::Filesystem).to receive(:executable?).with(module_path('/a/path/to/file')).and_return(true)
+                stat_double = instance_double(File::Stat, executable?: true)
+                allow(PDK::Util::Filesystem).to receive(:stat).with(module_path('/a/path/to/file')).and_return(stat_double)
               end
 
               it 'does not stage the file for making executable' do
@@ -293,10 +298,6 @@ describe PDK::Module::Convert do
             end
 
             context 'when file exists but has incorrect execute bits' do
-              before do
-                allow(PDK::Util::Filesystem).to receive(:executable?).with(module_path('/a/path/to/file')).and_return(false)
-              end
-
               it 'stages the file for making executable' do
                 expect(update_manager).to receive(:make_file_executable).with(module_path('/a/path/to/file'))
               end


### PR DESCRIPTION
## Summary
Use File::Stat.executable? instead of File.executable? when checking if template files have the execute bit to support filesystems mounted with noexec.

## Additional Context
If the default temp directory is mounted with the `noexec` flag, `PDK::Util::Filesystem.executable?` will return `false` regardless of the execute mode bits. Using `File::Stat.executable?` instead correctly determines if the file has the execute bit set.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
