### PR TITLE
(CAT-1997) Update `TEMPLATE_REF` for testing purposes

### DIFF
--- a/lib/pdk/version.rb
+++ b/lib/pdk/version.rb
@@ -1,4 +1,4 @@
 module PDK
   VERSION = '3.2.0'.freeze
-  TEMPLATE_REF = '3.2.0'.freeze
+  TEMPLATE_REF = '3.2.0.3'.freeze
 end

--- a/package-testing/spec/package/airgapped_usage_spec.rb
+++ b/package-testing/spec/package/airgapped_usage_spec.rb
@@ -27,6 +27,13 @@ describe 'Basic usage in an air-gapped environment' do
       end
     end
 
+    # If this test fails with a mismatch between the expected and actual Gemfile.lock content, check that the following
+    # steps are up to date:
+    # - Ensure that the pdk-templates main has been given an anotated (it must be annotated) tag with the version number,
+    #   if between releases add a fourth number to it, i.e. 3.2.0.3
+    # - Ensure that the pdk version.rb is pointing to this tag
+    #   https://github.com/puppetlabs/pdk/blob/main/lib/pdk/version.rb
+    # - Ensure that the pdk-vanagon template pin is up to date with the pdk-templates main commit
     context 'when validating the module' do
       context "with puppet #{PDK_VERSION[:latest][:major]}" do
         let(:ruby_version) { ruby_for_puppet(PDK_VERSION[:latest][:major]) }

--- a/package-testing/spec/package/validate_a_new_module_spec.rb
+++ b/package-testing/spec/package/validate_a_new_module_spec.rb
@@ -17,6 +17,13 @@ describe 'C100321 - Generate a module and validate it (i.e. ensure bundle instal
     end
   end
 
+  # If this test fails with a mismatch between the expected and actual Gemfile.lock content, check that the following
+  # steps are up to date:
+  # - Ensure that the pdk-templates main has been given an anotated (it must be annotated) tag with the version number,
+  #   if between releases add a fourth number to it, i.e. 3.2.0.3
+  # - Ensure that the pdk version.rb is pointing to this tag
+  #   https://github.com/puppetlabs/pdk/blob/main/lib/pdk/version.rb
+  # - Ensure that the pdk-vanagon template pin is up to date with the pdk-templates main commit
   context 'when validating the module' do
     context "with puppet #{PDK_VERSION[:latest][:major]}" do
       let(:ruby_version) { ruby_for_puppet(PDK_VERSION[:latest][:major]) }


### PR DESCRIPTION
Pre-release versions are needed within the templates for the pipelines to work correctly. Added notes to help visibility with this.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
