### PR TITLE
(CAT-2040) pdk spinner inconsistent on windows

### DIFF
--- a/lib/pdk/cli/exec/command.rb
+++ b/lib/pdk/cli/exec/command.rb
@@ -80,7 +80,7 @@ module PDK
 
           require 'pdk/cli/util/spinner'
 
-          @spinner = TTY::Spinner.new("[:spinner] #{message}", opts.merge(PDK::CLI::Util.spinner_opts_for_platform))
+          @spinner = TTY::Spinner.new("[:spinner] #{message}")
         end
 
         def update_environment(additional_env)

--- a/lib/pdk/cli/util.rb
+++ b/lib/pdk/cli/util.rb
@@ -28,18 +28,6 @@ module PDK
       end
       module_function :ensure_in_module!
 
-      def spinner_opts_for_platform
-        windows_opts = {
-          success_mark: '*',
-          error_mark: 'X'
-        }
-
-        return windows_opts if Gem.win_platform?
-
-        {}
-      end
-      module_function :spinner_opts_for_platform
-
       def prompt_for_yes(question_text, opts = {})
         require 'tty/prompt'
 

--- a/lib/pdk/validate/external_command_validator.rb
+++ b/lib/pdk/validate/external_command_validator.rb
@@ -161,9 +161,9 @@ module PDK
               if parent_validator.nil? || parent_validator.spinner.nil? || !parent_validator.spinner.is_a?(TTY::Spinner::Multi)
                 c.add_spinner(spinner_text_for_targets(invokation_targets))
               else
-                spinner = TTY::Spinner.new("[:spinner] #{spinner_text_for_targets(invokation_targets)}", PDK::CLI::Util.spinner_opts_for_platform)
+                spinner = TTY::Spinner.new("[:spinner] #{spinner_text_for_targets(invokation_targets)}")
                 parent_validator.spinner.register(spinner)
-                c.register_spinner(spinner, PDK::CLI::Util.spinner_opts_for_platform)
+                c.register_spinner(spinner)
               end
             end
           end

--- a/lib/pdk/validate/invokable_validator.rb
+++ b/lib/pdk/validate/invokable_validator.rb
@@ -138,7 +138,7 @@ module PDK
 
         require 'pdk/cli/util/spinner'
 
-        @spinner = TTY::Spinner.new("[:spinner] #{spinner_text}", PDK::CLI::Util.spinner_opts_for_platform)
+        @spinner = TTY::Spinner.new("[:spinner] #{spinner_text}")
       end
 
       # Process any targets that were skipped by the validator and add the events to the validation report

--- a/lib/pdk/validate/validator_group.rb
+++ b/lib/pdk/validate/validator_group.rb
@@ -42,7 +42,7 @@ module PDK
 
         require 'pdk/cli/util/spinner'
 
-        @spinner = TTY::Spinner::Multi.new("[:spinner] #{spinner_text}", PDK::CLI::Util.spinner_opts_for_platform)
+        @spinner = TTY::Spinner::Multi.new("[:spinner] #{spinner_text}")
 
         # Register the child spinners
         validator_instances.each do |instance|


### PR DESCRIPTION
## Summary
Previously successful tasks on windows were marked with * . These changes will now tick on success, adding consistency across windows and *nix platforms.

Results from running pdk validate on a windows 10 pro vm:
<img width="547" alt="Screenshot 2024-09-12 at 6 02 37 PM" src="https://github.com/user-attachments/assets/0112fb6c-f9e6-4411-a080-54032c96513b">

## Additional Context
Add any additional 
context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] 🟢 Manually verified.
