### PR TITLE
(CAT-2007) Use vendored cert files and VERIFY_PEER wth NET::HTTP on Windows

### DIFF
--- a/lib/pdk/util/vendored_file.rb
+++ b/lib/pdk/util/vendored_file.rb
@@ -51,8 +51,11 @@ module PDK
         uri = URI.parse(url)
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
-        # TODO: Get rid of this
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE if Gem.win_platform?
+        if Gem.win_platform?
+          cert_path = 'C:/Program Files/Puppet Labs/DevelopmentKit\ssl\cert.pem'
+          http.cert = OpenSSL::X509::Certificate.new(cert_path)
+          http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        end
         request = Net::HTTP::Get.new(uri.request_uri)
         response = http.request(request)
 


### PR DESCRIPTION
Link to successful test chain: https://jenkins-platform.delivery.puppetlabs.net/view/PDK/view/pdk-vanagon/job/platform_pdk_pdk-van-init_main/912/

![Screenshot 2024-09-18 at 3 59 52 PM](https://github.com/user-attachments/assets/24f82e44-7a25-4979-8c09-7058a7e2cc74)


## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
