### PR TITLE
(CAT-643) Add forge gem upload functionality

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'diff-lcs', '>= 1.5.0'
   spec.add_runtime_dependency 'json_pure', '~> 2.6.3'
   spec.add_runtime_dependency 'pathspec', '~> 1.1'
+  spec.add_runtime_dependency 'puppet_forge', '~> 5.0'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
## Summary
This PR adds the Forge module implementing its upload functionality instead of us maintaining our own method

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
