### PR TITLE
(CAT-2093) Enable shellcheck in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       rake_task: 'spec:coverage'
       ruby_version: ${{ matrix.ruby_version }}
       puppet_gem_version: ${{ matrix.puppet_gem_version }}
+      # This line enables CI shellcheck (reviewdog) to be run on the repository
+      run_shellcheck: true
 
   acceptance:
     needs: "spec"


### PR DESCRIPTION
Following the implementation of shellcheck in the CI, we are enabling it in the repositories we consider necessary.
