### PR TITLE
Disable the windows 2019 ruby 3.2 acceptance test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,10 @@ jobs:
         ruby_version:
           - "2.7"
           - "3.2"
+        # TEMPORARILY exclude the following until CAT-2122 is resolved
+        exclude:
+          - os: "windows-2019"
+            ruby_version: "3.2"
         include:
           - puppet_gem_version: "~> 7.0"
             ruby_version: "2.7"


### PR DESCRIPTION
## Summary

This PR disables the windows 2019, ruby 3.2 acceptance test in the nightly.yml.  The main reason for this is that it can potentially hide actual failures as the nightly is always red.  Therefore, I've created an internal ticket [CAT-2122](https://perforce.atlassian.net/browse/CAT-2122) to fix the issue and then rollback this PR.

-----

For example, [3 days ago our nightly.yml](https://github.com/puppetlabs/pdk/actions/runs/11430936125) looked like this, which was what we'd come to expect over the last lot of weeks:

![image](https://github.com/user-attachments/assets/28a0d47c-598c-4f48-84a1-f65a786e6aae)


However, [2 days ago nightly](https://github.com/puppetlabs/pdk/actions/runs/11470686046) revealed further errors (and hidden)

![image](https://github.com/user-attachments/assets/8da30a32-8227-4a35-89a0-8c043f371cf4)
