### PR TITLE
(maint) Fix Gem::Platform.match() deprecation warning 

### DIFF
--- a/lib/pdk/util/puppet_version.rb
+++ b/lib/pdk/util/puppet_version.rb
@@ -182,7 +182,7 @@ module PDK
         @rubygems_puppet_versions ||= begin
           fetcher = Gem::SpecFetcher.fetcher
           puppet_tuples = fetcher.detect(:released) do |spec_tuple|
-            spec_tuple.name == 'puppet' && Gem::Platform.match(spec_tuple.platform)
+            spec_tuple.name == 'puppet' && Gem::Platform.match_spec?(spec_tuple)
           end
           puppet_versions = puppet_tuples.map { |name, _| name.version }.uniq
           puppet_versions.sort.reverse


### PR DESCRIPTION
## Summary
I've tested this locally on PEADM, but I'm not 100% certain this is a 1-1 swap. Based on the ruby implementation they should be calling the same function under the hood.

## Related Issues (if any)
Closes #1406 

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
