### PR TITLE
(CAT-2121) Update tests to account for `pdk validate` changes

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -47,7 +47,6 @@ Gem::Specification.new do |spec|
   # Other deps
   spec.add_runtime_dependency 'deep_merge', '~> 1.2.2'
   spec.add_runtime_dependency 'diff-lcs', '>= 1.5.0'
-  spec.add_runtime_dependency 'json', '~> 2.6.3'
   spec.add_runtime_dependency 'json_pure', '~> 2.6.3'
   spec.add_runtime_dependency 'pathspec', '~> 1.1'
   spec.add_runtime_dependency 'puppet_forge', '~> 5.0'

--- a/spec/acceptance/report_spec.rb
+++ b/spec/acceptance/report_spec.rb
@@ -18,7 +18,7 @@ describe 'Saves report to a file' do
       include_context 'with a fake TTY'
       # Tests writing reports to a file
       describe command('pdk validate puppet manifests/init.pp --format=text:report.txt') do
-        its(:exit_status) { is_expected.to eq(1) }
+        its(:exit_status) { is_expected.to eq(1) | eq(256) }
         its(:stdout) { is_expected.to have_no_output }
         its(:stderr) { is_expected.to match(/Checking Puppet manifest syntax/i) }
         its(:stderr) { is_expected.to match(/Checking Puppet manifest style/i) }
@@ -32,7 +32,7 @@ describe 'Saves report to a file' do
 
       # Tests writing reports to stdout doesn't actually write a file named stdout
       describe command('pdk validate puppet manifests/init.pp --format=text:stdout') do
-        its(:exit_status) { is_expected.to eq(1) }
+        its(:exit_status) { is_expected.to eq(1) | eq(256) }
         its(:stderr) { is_expected.to match(/Checking Puppet manifest syntax/i) }
         its(:stderr) { is_expected.to match(/Checking Puppet manifest style/i) }
         its(:stdout) { is_expected.to match(/\(ERROR\):.*Could not parse for environment production.*\(#{Regexp.escape(init_pp)}.*\)/i) }
@@ -44,7 +44,7 @@ describe 'Saves report to a file' do
 
       # Tests writing reports to stderr doesn't actually write a file named stderr
       describe command('pdk validate puppet manifests/init.pp --format=text:stderr') do
-        its(:exit_status) { is_expected.to eq(1) }
+        its(:exit_status) { is_expected.to eq(1) | eq(256) }
         its(:stdout) { is_expected.to have_no_output }
         its(:stderr) { is_expected.to match(/Checking Puppet manifest syntax/i) }
         its(:stderr) { is_expected.to match(/Checking Puppet manifest style/i) }
@@ -63,7 +63,7 @@ describe 'Saves report to a file' do
 
     context 'when not run interactively' do
       describe command('pdk validate puppet manifests/init.pp') do
-        its(:exit_status) { is_expected.to eq(1) }
+        its(:exit_status) { is_expected.to eq(1) | eq(256) }
         its(:stderr) { is_expected.to match(/using ruby \d+\.\d+\.\d+/i) }
         its(:stderr) { is_expected.to match(/using puppet \d+\.\d+\.\d+/i) }
         its(:stdout) { is_expected.to match(/\(ERROR\):.*Could not parse for environment production.*\(#{Regexp.escape(init_pp)}.*\)/i) }

--- a/spec/acceptance/report_spec.rb
+++ b/spec/acceptance/report_spec.rb
@@ -9,7 +9,7 @@ describe 'Saves report to a file' do
     before(:all) do
       File.open(init_pp, 'w') do |f|
         f.puts <<~EOS
-          class report {}
+          class report
         EOS
       end
     end
@@ -18,24 +18,24 @@ describe 'Saves report to a file' do
       include_context 'with a fake TTY'
       # Tests writing reports to a file
       describe command('pdk validate puppet manifests/init.pp --format=text:report.txt') do
-        its(:exit_status) { is_expected.to eq(0) }
+        its(:exit_status) { is_expected.to eq(1) }
         its(:stdout) { is_expected.to have_no_output }
         its(:stderr) { is_expected.to match(/Checking Puppet manifest syntax/i) }
         its(:stderr) { is_expected.to match(/Checking Puppet manifest style/i) }
 
         describe file('report.txt') do
           it { is_expected.to exist }
-          # pdk (WARNING): puppet-lint: class not documented (manifests/init.pp:1:1)
-          its(:content) { is_expected.to match(/\(warning\):.*class not documented.*\(#{Regexp.escape(init_pp)}.*\)/i) }
+          # pdk (ERROR): puppet-syntax: Could not parse for environment production: Syntax error at end of input (manifests/init.pp)
+          its(:content) { is_expected.to match(/\(ERROR\):.*Could not parse for environment production.*\(#{Regexp.escape(init_pp)}.*\)/i) }
         end
       end
 
       # Tests writing reports to stdout doesn't actually write a file named stdout
       describe command('pdk validate puppet manifests/init.pp --format=text:stdout') do
-        its(:exit_status) { is_expected.to eq(0) }
+        its(:exit_status) { is_expected.to eq(1) }
         its(:stderr) { is_expected.to match(/Checking Puppet manifest syntax/i) }
         its(:stderr) { is_expected.to match(/Checking Puppet manifest style/i) }
-        its(:stdout) { is_expected.to match(/\(warning\):.*class not documented.*\(#{Regexp.escape(init_pp)}.*\)/i) }
+        its(:stdout) { is_expected.to match(/\(ERROR\):.*Could not parse for environment production.*\(#{Regexp.escape(init_pp)}.*\)/i) }
 
         describe file('stdout') do
           it { is_expected.not_to exist }
@@ -44,7 +44,7 @@ describe 'Saves report to a file' do
 
       # Tests writing reports to stderr doesn't actually write a file named stderr
       describe command('pdk validate puppet manifests/init.pp --format=text:stderr') do
-        its(:exit_status) { is_expected.to eq(0) }
+        its(:exit_status) { is_expected.to eq(1) }
         its(:stdout) { is_expected.to have_no_output }
         its(:stderr) { is_expected.to match(/Checking Puppet manifest syntax/i) }
         its(:stderr) { is_expected.to match(/Checking Puppet manifest style/i) }
@@ -52,7 +52,7 @@ describe 'Saves report to a file' do
         its(:stderr) do
           # Due to spinners writing at arbitrary cursor locations, we can't depend on the text
           # being at a the beginning of a line.
-          is_expected.to match(/\(warning\):.*class not documented.*\(#{Regexp.escape(init_pp)}.*\)/i)
+          is_expected.to match(/\(ERROR\):.*Could not parse for environment production.*\(#{Regexp.escape(init_pp)}.*\)/i)
         end
 
         describe file('stderr') do
@@ -63,10 +63,10 @@ describe 'Saves report to a file' do
 
     context 'when not run interactively' do
       describe command('pdk validate puppet manifests/init.pp') do
-        its(:exit_status) { is_expected.to eq(0) }
+        its(:exit_status) { is_expected.to eq(1) }
         its(:stderr) { is_expected.to match(/using ruby \d+\.\d+\.\d+/i) }
         its(:stderr) { is_expected.to match(/using puppet \d+\.\d+\.\d+/i) }
-        its(:stdout) { is_expected.to match(/\(warning\):.*class not documented.*\(#{Regexp.escape(init_pp)}.*\)/i) }
+        its(:stdout) { is_expected.to match(/\(ERROR\):.*Could not parse for environment production.*\(#{Regexp.escape(init_pp)}.*\)/i) }
       end
     end
   end

--- a/spec/acceptance/validate_all_spec.rb
+++ b/spec/acceptance/validate_all_spec.rb
@@ -107,7 +107,7 @@ describe 'pdk validate', :module_command do
       end
 
       describe command('pdk validate') do
-        its(:exit_status) { is_expected.to eq(1) }
+        its(:exit_status) { is_expected.to eq(1) | eq(256) }
         its(:stderr) { is_expected.to match(/Running all available validators/i) }
         its(:stderr) { is_expected.to match(/Checking metadata syntax/i) }
         its(:stderr) { is_expected.to match(/Checking module metadata style/i) }

--- a/spec/acceptance/validate_all_spec.rb
+++ b/spec/acceptance/validate_all_spec.rb
@@ -107,12 +107,13 @@ describe 'pdk validate', :module_command do
       end
 
       describe command('pdk validate') do
-        its(:exit_status) { is_expected.to eq(0) }
+        its(:exit_status) { is_expected.to eq(1) }
         its(:stderr) { is_expected.to match(/Running all available validators/i) }
         its(:stderr) { is_expected.to match(/Checking metadata syntax/i) }
         its(:stderr) { is_expected.to match(/Checking module metadata style/i) }
         its(:stderr) { is_expected.to match(/Checking Puppet manifest syntax/i) }
         its(:stderr) { is_expected.to match(/Checking Ruby code style/i) }
+        its(:stdout) { is_expected.to match(/\(warning\):.*indent should be 0 chars and is 2/i) }
       end
     end
   end

--- a/spec/acceptance/validate_puppet_spec.rb
+++ b/spec/acceptance/validate_puppet_spec.rb
@@ -81,7 +81,7 @@ describe 'pdk validate puppet', :module_command do
       end
 
       describe command('pdk validate puppet --format text:stdout --format junit:report.xml') do
-        its(:exit_status) { is_expected.to eq(1) }
+        its(:exit_status) { is_expected.to eq(1) | eq(256) }
         its(:stderr) { is_expected.not_to match(epp_spinner_text) }
         its(:stderr) { is_expected.to match(syntax_spinner_text) }
         its(:stderr) { is_expected.to match(lint_spinner_text) }
@@ -153,7 +153,6 @@ describe 'pdk validate puppet', :module_command do
 
       describe command('pdk validate puppet manifests\test') do
         its(:exit_status) { is_expected.to eq(0) }
-        its(:stdout) { is_expected.to match(/\(warning\):.*class not documented.*\(#{Regexp.escape(File.join('manifests', 'test', 'test.pp'))}.+\)/i) }
       end
     end
 
@@ -192,7 +191,7 @@ describe 'pdk validate puppet', :module_command do
       end
 
       describe command('pdk validate puppet --format text:stdout --format junit:report.xml') do
-        its(:exit_status) { is_expected.to eq(1) }
+        its(:exit_status) { is_expected.to eq(1) | eq(256) }
         its(:stdout) { is_expected.to match(/\(warning\):.*indent should be 0 chars and is 2.*\(#{Regexp.escape(init_pp)}.+\)/i) }
         its(:stderr) { is_expected.not_to match(epp_spinner_text) }
         its(:stderr) { is_expected.to match(syntax_spinner_text) }

--- a/spec/acceptance/validate_puppet_spec.rb
+++ b/spec/acceptance/validate_puppet_spec.rb
@@ -81,7 +81,7 @@ describe 'pdk validate puppet', :module_command do
       end
 
       describe command('pdk validate puppet --format text:stdout --format junit:report.xml') do
-        its(:exit_status) { is_expected.to eq(0) }
+        its(:exit_status) { is_expected.to eq(1) }
         its(:stderr) { is_expected.not_to match(epp_spinner_text) }
         its(:stderr) { is_expected.to match(syntax_spinner_text) }
         its(:stderr) { is_expected.to match(lint_spinner_text) }
@@ -180,7 +180,10 @@ describe 'pdk validate puppet', :module_command do
     context 'with a parsable file and some style warnings' do
       before(:all) do
         File.open(init_pp, 'w') do |f|
-          f.puts 'class foo {}'
+          f.puts <<-EOS.gsub(/^ {10}/, '')
+            # pdk_in_gemfile
+            class pdk_in_gemfile {}
+          EOS
         end
       end
 
@@ -189,8 +192,8 @@ describe 'pdk validate puppet', :module_command do
       end
 
       describe command('pdk validate puppet --format text:stdout --format junit:report.xml') do
-        its(:exit_status) { is_expected.to eq(0) }
-        its(:stdout) { is_expected.to match(/\(warning\):.*class not documented.*\(#{Regexp.escape(init_pp)}.+\)/i) }
+        its(:exit_status) { is_expected.to eq(1) }
+        its(:stdout) { is_expected.to match(/\(warning\):.*indent should be 0 chars and is 2.*\(#{Regexp.escape(init_pp)}.+\)/i) }
         its(:stderr) { is_expected.not_to match(epp_spinner_text) }
         its(:stderr) { is_expected.to match(syntax_spinner_text) }
         its(:stderr) { is_expected.to match(lint_spinner_text) }
@@ -221,7 +224,7 @@ describe 'pdk validate puppet', :module_command do
 
           its(:content) do
             is_expected.to have_junit_testcase.in_testsuite('puppet-lint').with_attributes(
-              'classname' => 'puppet-lint.documentation',
+              'classname' => 'puppet-lint.strict_indent',
               'name' => a_string_starting_with(init_pp)
             ).that_failed
           end
@@ -289,11 +292,11 @@ describe 'pdk validate puppet', :module_command do
       end
     end
 
-    context 'with a parsable file and some style errors' do
+    context 'with a parsable file and some errors' do
       before(:all) do
         File.open(example_pp, 'w') do |f|
           f.puts '# some documentation'
-          f.puts 'class foo::bar {}'
+          f.puts 'class foo::bar'
         end
       end
 
@@ -303,7 +306,7 @@ describe 'pdk validate puppet', :module_command do
 
       describe command('pdk validate puppet --format text:stdout --format junit:report.xml') do
         its(:exit_status) { is_expected.not_to eq(0) }
-        its(:stdout) { is_expected.to match(/autoload module layout.*\(#{Regexp.escape(example_pp)}.+\)/i) }
+        its(:stdout) { is_expected.to match(/Syntax error at end of input.*\(#{Regexp.escape(example_pp)}.+\)/i) }
         its(:stderr) { is_expected.not_to match(epp_spinner_text) }
         its(:stderr) { is_expected.to match(syntax_spinner_text) }
         its(:stderr) { is_expected.to match(lint_spinner_text) }
@@ -312,15 +315,15 @@ describe 'pdk validate puppet', :module_command do
           its(:content) { is_expected.to contain_valid_junit_xml }
 
           its(:content) do
-            is_expected.to have_junit_testsuite('puppet-lint').with_attributes(
+            is_expected.to have_junit_testsuite('puppet-syntax').with_attributes(
               'failures' => eq(1),
               'tests' => eq(1)
             )
           end
 
           its(:content) do
-            is_expected.to have_junit_testcase.in_testsuite('puppet-lint').with_attributes(
-              'classname' => 'puppet-lint.autoloader_layout',
+            is_expected.to have_junit_testcase.in_testsuite('puppet-syntax').with_attributes(
+              'classname' => 'puppet-syntax',
               'name' => a_string_starting_with(example_pp)
             ).that_failed
           end
@@ -388,7 +391,7 @@ describe 'pdk validate puppet', :module_command do
         before(:all) do
           FileUtils.mkdir_p(another_problem_dir)
           File.open(another_problem_pp, 'w') do |f|
-            f.puts 'class foo::bar::whoops {}'
+            f.puts 'class foo::bar::whoops'
           end
         end
 
@@ -408,15 +411,15 @@ describe 'pdk validate puppet', :module_command do
             its(:content) { is_expected.to contain_valid_junit_xml }
 
             its(:content) do
-              is_expected.to have_junit_testsuite('puppet-lint').with_attributes(
-                'failures' => eq(2),
-                'tests' => eq(2)
+              is_expected.to have_junit_testsuite('puppet-syntax').with_attributes(
+                'failures' => eq(1),
+                'tests' => eq(1)
               )
             end
 
             its(:content) do
-              is_expected.to have_junit_testcase.in_testsuite('puppet-lint').with_attributes(
-                'classname' => a_string_starting_with('puppet-lint'),
+              is_expected.to have_junit_testcase.in_testsuite('puppet-syntax').with_attributes(
+                'classname' => a_string_starting_with('puppet-syntax'),
                 'name' => a_string_starting_with(another_problem_pp)
               ).that_failed
             end

--- a/spec/acceptance/validate_puppet_spec.rb
+++ b/spec/acceptance/validate_puppet_spec.rb
@@ -306,7 +306,7 @@ describe 'pdk validate puppet', :module_command do
 
       describe command('pdk validate puppet --format text:stdout --format junit:report.xml') do
         its(:exit_status) { is_expected.not_to eq(0) }
-        its(:stdout) { is_expected.to match(/Syntax error at end of input.*\(#{Regexp.escape(example_pp)}.+\)/i) }
+        its(:stdout) { is_expected.to match(/Syntax error at end of input/i) }
         its(:stderr) { is_expected.not_to match(epp_spinner_text) }
         its(:stderr) { is_expected.to match(syntax_spinner_text) }
         its(:stderr) { is_expected.to match(lint_spinner_text) }


### PR DESCRIPTION
Updating the tests to account for puppet-lint configuration changes to the pdk-templates brought in here: https://github.com/puppetlabs/pdk-templates/pull/600

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
