### PR TITLE
(CAT-2130) Pin json to prevent issues

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'deep_merge', '~> 1.2.2'
   spec.add_runtime_dependency 'diff-lcs', '>= 1.5.0'
   spec.add_runtime_dependency 'json_pure', '~> 2.6.3'
+  spec.add_runtime_dependency 'json', '~> 2.6.3'
   spec.add_runtime_dependency 'pathspec', '~> 1.1'
   spec.add_runtime_dependency 'puppet_forge', '~> 5.0'
 

--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -47,8 +47,8 @@ Gem::Specification.new do |spec|
   # Other deps
   spec.add_runtime_dependency 'deep_merge', '~> 1.2.2'
   spec.add_runtime_dependency 'diff-lcs', '>= 1.5.0'
-  spec.add_runtime_dependency 'json_pure', '~> 2.6.3'
   spec.add_runtime_dependency 'json', '~> 2.6.3'
+  spec.add_runtime_dependency 'json_pure', '~> 2.6.3'
   spec.add_runtime_dependency 'pathspec', '~> 1.1'
   spec.add_runtime_dependency 'puppet_forge', '~> 5.0'
 


### PR DESCRIPTION
```
Failure/Error: require 'json'
ArgumentError:
  wrong number of arguments (given 1, expected 0)
```
As of the release of json v2.7.3 the above error has been occurring across the entirety of the PDK test environment.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
