### PR TITLE
(CAT-2128) Remove `json_pure` dependency

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -47,7 +47,6 @@ Gem::Specification.new do |spec|
   # Other deps
   spec.add_runtime_dependency 'deep_merge', '~> 1.2.2'
   spec.add_runtime_dependency 'diff-lcs', '>= 1.5.0'
-  spec.add_runtime_dependency 'json_pure', '~> 2.6.3'
   spec.add_runtime_dependency 'pathspec', '~> 1.1'
   spec.add_runtime_dependency 'puppet_forge', '~> 5.0'
 


### PR DESCRIPTION
This was originally added to ensure JSON would be available in all environments but should no longer necessary as JSON has been added as a default ruby gem.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
