### PR TITLE
Revert "(CAT-2128) Remove `json_pure` dependency"

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |spec|
   # Other deps
   spec.add_runtime_dependency 'deep_merge', '~> 1.2.2'
   spec.add_runtime_dependency 'diff-lcs', '>= 1.5.0'
+  spec.add_runtime_dependency 'json_pure', '~> 2.6.3'
   spec.add_runtime_dependency 'pathspec', '~> 1.1'
   spec.add_runtime_dependency 'puppet_forge', '~> 5.0'
 


### PR DESCRIPTION
Reverts puppetlabs/pdk#1411

`json_pure` is explicitly used within the metadata_syntax_validator and has begun to fail tests.
Unsure of why this did not present when we raised PRs to remove it.
Setting both this and original PR to maint