### PR TITLE
(BUGFIX) Exclude newest JSON version

### DIFF
--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |spec|
   # Other deps
   spec.add_runtime_dependency 'deep_merge', '~> 1.2.2'
   spec.add_runtime_dependency 'diff-lcs', '>= 1.5.0'
+  spec.add_runtime_dependency 'json', '< 2.8.0'
   spec.add_runtime_dependency 'pathspec', '~> 1.1'
   spec.add_runtime_dependency 'puppet_forge', '~> 5.0'
 


### PR DESCRIPTION
## Summary
Newest releases of the json gem have broken us, have temporarily pinned this while I reach out to the owners of the gem

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
