### PR TITLE
(CAT-2155) Remove metadata_syntax_validator parser swap to `JSON::Pure`

### DIFF
--- a/lib/pdk/validate/metadata/metadata_syntax_validator.rb
+++ b/lib/pdk/validate/metadata/metadata_syntax_validator.rb
@@ -22,15 +22,6 @@ module PDK
           JSON.parser = JSON::Ext::Parser if defined?(JSON::Ext::Parser)
         end
 
-        def before_validation
-          # The pure ruby JSON parser gives much nicer parse error messages than
-          # the C extension at the cost of slightly slower parsing. We require it
-          # here and restore the C extension at the end of the method (if it was
-          # being used).
-          require 'json/pure'
-          JSON.parser = JSON::Pure::Parser
-        end
-
         def validate_target(report, target)
           unless PDK::Util::Filesystem.readable?(target)
             report.add_event(
@@ -56,9 +47,7 @@ module PDK
           rescue JSON::ParserError => e
             # Because the message contains a raw segment of the file, we use
             # String#dump here to unescape any escape characters like newlines.
-            # We then strip out the surrounding quotes and the exclaimation
-            # point that json_pure likes to put in exception messages.
-            sane_message = e.message.dump[/\A"(.+?)!?"\Z/, 1]
+            sane_message = e.message.dump
 
             report.add_event(
               file: target,

--- a/pdk.gemspec
+++ b/pdk.gemspec
@@ -47,7 +47,6 @@ Gem::Specification.new do |spec|
   # Other deps
   spec.add_runtime_dependency 'deep_merge', '~> 1.2.2'
   spec.add_runtime_dependency 'diff-lcs', '>= 1.5.0'
-  spec.add_runtime_dependency 'json', '< 2.8.0'
   spec.add_runtime_dependency 'pathspec', '~> 1.1'
   spec.add_runtime_dependency 'puppet_forge', '~> 5.0'
 

--- a/spec/support/file_based_namespaces.rb
+++ b/spec/support/file_based_namespaces.rb
@@ -197,7 +197,7 @@ RSpec.shared_examples 'a json file based namespace' do
 
     context 'when there is no data stored' do
       it 'serializes to an empty JSON object' do
-        expect(serialized_data).to match(/^\{\n+\}$/)
+        expect(serialized_data).to match(/^\{\}$/)
       end
     end
 

--- a/spec/unit/pdk/validate/metadata/metadata_syntax_validator_spec.rb
+++ b/spec/unit/pdk/validate/metadata/metadata_syntax_validator_spec.rb
@@ -78,7 +78,7 @@ describe PDK::Validate::Metadata::MetadataSyntaxValidator do
                                                      source: 'metadata-syntax',
                                                      state: :failure,
                                                      severity: 'error',
-                                                     message: a_string_matching(/\Aexpected ':' in object/)
+                                                     message: a_string_matching(/unexpected token at/)
                                                    })
         expect(return_value).to eq(1)
       end


### PR DESCRIPTION
`JSON::Pure` no longer exists within the `json` gem as of `2.8.0` and as such this swap has to be removed.
![Screenshot 2024-11-08 at 11 36 11 AM](https://github.com/user-attachments/assets/288d13c0-755f-43dc-b610-3e5bc1867c62)

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
