### PR TITLE
(CAT-2122) Re-initialize windows-2019/ruby-3.2 nightly test run

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,10 +38,6 @@ jobs:
         ruby_version:
           - "2.7"
           - "3.2"
-        # TEMPORARILY exclude the following until CAT-2122 is resolved
-        exclude:
-          - os: "windows-2019"
-            ruby_version: "3.2"
         include:
           - puppet_gem_version: "~> 7.0"
             ruby_version: "2.7"


### PR DESCRIPTION
With the recent removal of `JSON::Pure` from the code, the dependency error that had been causing failures on this specific box, and not on local vagrant/docker/vmpooler runs with the same  windows-2019/ruby-3.2 setup has been resolved.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
