### PR TITLE
(CAT-2162) Remove support for SLES 12

### DIFF
--- a/docs/pdk_install.md
+++ b/docs/pdk_install.md
@@ -27,7 +27,7 @@ PDK is compatible with *nix, Windows, and macOS systems. For detailed version co
 |Fedora|40|x86_64|RPM|
 |OSX|11, 12, 13|x86_64, arm64|DPKG|
 |Red Hat Enterprise Linux (RHEL)|7, 8, 9|x86_64, aarch64|RPM|
-|SUSE Linux Enterprise Server|12, 15|x86_64|N/A|
+|SUSE Linux Enterprise Server|15|x86_64|N/A|
 |Ubuntu|18.04, 20.04, 22.04|x86_64, aarch64|DEB|
 |Windows (Consumer OS)|10, 11|x86_64|MSI|
 |Windows (Server OS)|2016, 2019, 2022|x86_64|MSI|


### PR DESCRIPTION
## Summary
Due to conflicts between a newer version of GIT required to resolve a lvl9 security vulnerability and SLES 12 it looks as if we will be unable to support it, as such given that General support for it has already ended we will be dropping it from the PDK

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
