### PR TITLE
Revert "(CAT-2148) Update package testing to account for test machine changes"

### DIFF
--- a/package-testing/spec/package/add_gem_to_module_spec.rb
+++ b/package-testing/spec/package/add_gem_to_module_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper_package'
 describe 'C100545 - Generate a module, add a gem to it, and validate it' do
   module_name = 'c100545_module'
 
-  describe command("pdk new module #{module_name} --skip-interview --skip-interview --template-url=https://github.com/puppetlabs/pdk-templates --template-ref=main") do
+  describe command("pdk new module #{module_name} --skip-interview") do
     its(:exit_status) { is_expected.to eq(0) }
   end
 

--- a/package-testing/spec/package/airgapped_usage_spec.rb
+++ b/package-testing/spec/package/airgapped_usage_spec.rb
@@ -22,7 +22,7 @@ describe 'Basic usage in an air-gapped environment' do
         it { is_expected.to be_file }
 
         its(:content_as_json) do
-          is_expected.to include('template-url' => a_string_matching(/pdk-templates#main/))
+          is_expected.to include('template-url' => a_string_matching(/\Apdk-default#[\w.-]+\Z/))
         end
       end
     end

--- a/package-testing/spec/package/unprivileged_user_spec.rb
+++ b/package-testing/spec/package/unprivileged_user_spec.rb
@@ -28,7 +28,7 @@ describe 'Running PDK as an unprivileged user' do
       its(:stdout) { is_expected.to contain('testuser') }
     end
 
-    describe command("pdk new module #{module_name} --skip-interview --template-url=https://github.com/puppetlabs/pdk-templates --template-ref=main") do
+    describe command("pdk new module #{module_name} --skip-interview") do
       its(:exit_status) { is_expected.to eq(0) }
     end
 

--- a/package-testing/spec/package/validate_a_new_module_spec.rb
+++ b/package-testing/spec/package/validate_a_new_module_spec.rb
@@ -12,7 +12,7 @@ describe 'C100321 - Generate a module and validate it (i.e. ensure bundle instal
       it { is_expected.to be_file }
 
       its(:content_as_json) do
-        is_expected.to include('template-url' => a_string_matching(/pdk-templates#main/))
+        is_expected.to include('template-url' => a_string_matching(/\Apdk-default#[\w.-]+\Z/))
       end
     end
   end


### PR DESCRIPTION
Reverts puppetlabs/pdk#1419

Changes where put in place to allow for a release with known issue in order to resolve a serious CVE.
Changes are to be reverted as soon as the release is made.