### PR TITLE
(TESTING)(CAT-2148) Add fix for template tests

### DIFF
--- a/package-testing/spec/spec_helper_package.rb
+++ b/package-testing/spec/spec_helper_package.rb
@@ -38,6 +38,9 @@ RSpec.configure do |c|
   # rubocop:disable RSpec/BeforeAfterAll
   c.before(:all) do
     RSpec.configuration.logger.log_level = :warn
+    
+    cmd = command('git config --global --add safe.directory /opt/puppetlabs/pdk/share/cache/pdk-templates.git')
+    cmd.run
   end
 
   c.after(:all) do


### PR DESCRIPTION
An on-going issue for the PDK requires the inbuilt templates to be given permissions before they can be used.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
