### PR TITLE
(CAT-2225) Update expected error message to account for changes to JSON

### DIFF
--- a/spec/unit/pdk/validate/metadata/metadata_syntax_validator_spec.rb
+++ b/spec/unit/pdk/validate/metadata/metadata_syntax_validator_spec.rb
@@ -78,7 +78,7 @@ describe PDK::Validate::Metadata::MetadataSyntaxValidator do
                                                      source: 'metadata-syntax',
                                                      state: :failure,
                                                      severity: 'error',
-                                                     message: a_string_matching(/unexpected token at/)
+                                                     message: a_string_matching(/expected ':' after object key/)
                                                    })
         expect(return_value).to eq(1)
       end


### PR DESCRIPTION
## Summary
The error message being returned has changed, as the PDK is merely a wrapper for the JSON gem in this case and the error message is still understandable, we will simply update what is expected by the tests.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
