### PR TITLE
(CAT-2238) Update latest_template? check to compare version numbers

### DIFF
--- a/lib/pdk/module/update.rb
+++ b/lib/pdk/module/update.rb
@@ -81,6 +81,8 @@ module PDK
       private
 
       def latest_template?
+        return true if /^\d+\.\d+\.\d+(?:\.\d+)?$/.match?(template_uri.uri_fragment) && Gem::Version.new(template_uri.uri_fragment) > Gem::Version.new(PDK::TEMPLATE_REF)
+
         [PDK::TEMPLATE_REF, 'master', 'main'].include?(template_uri.uri_fragment)
       end
 


### PR DESCRIPTION
Previously the code would check only if the given tag matched the shipped pdk-templates version number. With this change it will now also first check if the given tag is a version number and then if it is check if it is greater than the shipped number.
As a note, this change is related to an info block that is given when running pdk update and has no effect on the actual function of the PDK.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
